### PR TITLE
feat(auth): add retry with exponential backoff to refreshClaudeOAuthToken

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -33,39 +33,73 @@ export async function refreshClaudeOAuthToken(input: {
   refreshToken: string
   fetchImpl?: typeof fetch
   now?: () => number
+  maxRetries?: number
+  baseDelayMs?: number
 }): Promise<ClaudeOAuthRefreshResult> {
   const fetchImpl = input.fetchImpl ?? fetch
-  const response = await fetchImpl(TOKEN_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body: JSON.stringify({
-      grant_type: 'refresh_token',
-      refresh_token: input.refreshToken,
-      client_id: CLIENT_ID,
-    }),
-  })
+  const maxRetries = input.maxRetries ?? 2
+  const baseDelayMs = input.baseDelayMs ?? 500
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => '')
-    throw new ClaudeOAuthRefreshError(response.status, body)
-  }
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      if (attempt > 0) {
+        const delay = baseDelayMs * 2 ** (attempt - 1)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
 
-  const json = (await response.json()) as {
-    access_token: string
-    refresh_token?: string
-    expires_in: number
-  }
-  const refreshedAt = input.now?.() ?? Date.now()
+      const response = await fetchImpl(TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: input.refreshToken,
+          client_id: CLIENT_ID,
+        }),
+      })
 
-  return {
-    access: json.access_token,
-    refresh: json.refresh_token ?? input.refreshToken,
-    expires: refreshedAt + json.expires_in * 1000,
-    expiresIn: json.expires_in,
+      if (!response.ok) {
+        if (response.status >= 500 && attempt < maxRetries) {
+          await response.body?.cancel()
+          continue
+        }
+        const body = await response.text().catch(() => '')
+        throw new ClaudeOAuthRefreshError(response.status, body)
+      }
+
+      const json = (await response.json()) as {
+        access_token: string
+        refresh_token?: string
+        expires_in: number
+      }
+      const refreshedAt = input.now?.() ?? Date.now()
+
+      return {
+        access: json.access_token,
+        refresh: json.refresh_token ?? input.refreshToken,
+        expires: refreshedAt + json.expires_in * 1000,
+        expiresIn: json.expires_in,
+      }
+    } catch (error) {
+      if (error instanceof ClaudeOAuthRefreshError) throw error
+      const isNetworkError =
+        error instanceof Error &&
+        (error.message.includes('fetch failed') ||
+          ('code' in error &&
+            ((error as Error & { code: string }).code === 'ECONNRESET' ||
+              (error as Error & { code: string }).code === 'ECONNREFUSED' ||
+              (error as Error & { code: string }).code === 'ETIMEDOUT' ||
+              (error as Error & { code: string }).code ===
+                'UND_ERR_CONNECT_TIMEOUT')))
+      if (attempt < maxRetries && isNetworkError) {
+        continue
+      }
+      throw error
+    }
   }
+  throw new Error('Token refresh exhausted all retries')
 }
 
 export type AuthorizationResult = {


### PR DESCRIPTION
## Summary

Adds resilient retry logic to `refreshClaudeOAuthToken`:

- **Exponential backoff**: Up to 3 attempts (configurable via `maxRetries`) with delays of 0ms, 500ms, 1000ms (configurable via `baseDelayMs`)
- **5xx retry**: Server errors automatically retry after canceling the response body
- **Network error retry**: Retries on `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `UND_ERR_CONNECT_TIMEOUT`, and generic "fetch failed"
- **4xx immediate throw**: Client errors (including `ClaudeOAuthRefreshError`) are not retried
- **Non-breaking**: New parameters are optional with sensible defaults. Existing callers get retry automatically.

## Motivation

Currently a single transient error during token refresh (e.g., a Cloudflare 502 or a momentary network blip) causes the entire session to fail. This is especially impactful for long-running sessions where a brief infrastructure hiccup shouldn't require re-authentication.

## Testing

All existing tests pass. The retry logic handles both `FallbackAccountManager.refreshAccountNow()` (which calls this function) and the main account refresh path in the OpenCode plugin.