### PR TITLE
perf: accept optional storage in getUsableFallbackAccounts to avoid redundant disk reads

### DIFF
--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -606,8 +606,9 @@ export class FallbackAccountManager {
     this.quotaTimer = null
   }
 
-  async getUsableFallbackAccounts() {
-    const storage = await this.load()
+  async getUsableFallbackAccounts(existingStorage?: AccountStorage | null) {
+    const storage =
+      existingStorage !== undefined ? existingStorage : await this.load()
     if (!storage) return []
     const usable: OAuthAccount[] = []
     let changed = false


### PR DESCRIPTION
## Summary

Adds an optional `existingStorage` parameter to `FallbackAccountManager.getUsableFallbackAccounts()`. Callers that already have storage loaded (e.g., the fetch handler which loads it at the start of every request) can pass it through to skip a redundant `readFile` + `JSON.parse`.

In the hot request path, `loadAccounts()` currently fires up to 3 times per request:
1. In the main fetch handler
2. Inside `tryFallbackAccounts()`
3. Inside `getUsableFallbackAccounts()`

This change eliminates #3 when the caller provides storage.

## API Change

```typescript
// Before
async getUsableFallbackAccounts(): Promise<OAuthAccount[]>

// After (non-breaking)
async getUsableFallbackAccounts(existingStorage?: AccountStorage | null): Promise<OAuthAccount[]>
```

Uses `!== undefined` check (not falsy) because `null` is a valid "no storage file" state.

## Testing

All existing tests pass. No behavior change — only avoids redundant disk I/O.