### PR TITLE
feat(opencode): bundle deps with bun build for zero-dependency runtime

### DIFF
--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -459,6 +459,25 @@ bun run lint
 bun run format:check
 ```
 
+### Build modes
+
+Two build modes are available:
+
+```bash
+bun run build      # Deploy: bun build → bundled dist/ with all deps inlined (core + xxhash-wasm)
+bun run build:dev  # Dev: tsc → individual dist/*.js files (requires workspace node_modules)
+```
+
+The default `build` uses `bun build` to bundle `@cortexkit/anthropic-auth-core` and all transitive dependencies into self-contained output files. No `node_modules/` needed at runtime — the plugin works via `file://` path in OpenCode config:
+
+```json
+{
+  "plugin": ["file:///path/to/anthropic-auth/packages/opencode"]
+}
+```
+
+`@opencode-ai/plugin` remains external (peer dep provided by OpenCode).
+
 Inspect package contents:
 
 ```bash

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -27,7 +27,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && bun build src/index.ts src/cli.ts --outdir dist --target node --format esm --splitting --external @opencode-ai/plugin --minify && tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "build:dev": "rm -rf dist && tsc -p tsconfig.build.json",
     "dev": "bun ../../scripts/dev.ts",
     "dev:clean": "bun ../../scripts/dev-clean.ts",
     "extract": "bun ../../scripts/extract-system-prompt.ts",


### PR DESCRIPTION
## Summary

Changes the default `build` script in `packages/opencode` from `tsc` to `bun build`, producing self-contained output with all dependencies inlined. No `node_modules/` needed at runtime.

### Before

```bash
bun run build  # tsc → dist/*.js (requires node_modules at runtime)
```

### After

```bash
bun run build      # bun build → bundled dist/ (~85KB, all deps inlined, minified, code-split)
bun run build:dev  # tsc → individual dist/*.js (for development, requires node_modules)
```

The bundled output inlines `@cortexkit/anthropic-auth-core` and all transitive deps (like `xxhash-wasm`). Only `@opencode-ai/plugin` is kept external (peer dep provided by OpenCode at runtime).

Type declarations are still emitted via `tsc --emitDeclarationOnly`.

### Use case

This enables using the plugin via `file://` path without publishing to npm:

```json
{
  "plugin": ["file:///path/to/anthropic-auth/packages/opencode"]
}
```

## Files Changed

- `packages/opencode/package.json` — new `build` script (bun build + tsc declarations), `build:dev` for old tsc behavior
- `packages/opencode/README.md` — documents both build modes

## Testing

All 214 tests pass. Build output verified: 3 files (~85KB total).