### PR TITLE
perf: pass storage to tryFallbackAccounts to skip redundant disk read

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -873,13 +873,15 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
               ReturnType<FallbackAccountManager['getUsableFallbackAccounts']>
             >,
             trace?: PerfTrace,
+            existingStorage?: Awaited<ReturnType<typeof loadAccounts>>,
           ) {
             if (!isReplayableRequest(input, init?.body)) return mainResponse
 
             const loadStart = nowMs()
-            const storage = await loadAccounts()
+            const storage = existingStorage ?? (await loadAccounts())
             trace?.mark('fallback_load_storage', {
               ms: roundMs(nowMs() - loadStart),
+              cached: !!existingStorage,
             })
             let currentResponse = mainResponse
             let shouldFallback = shouldFallbackStatus(
@@ -1022,6 +1024,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                 mainResponse,
                 preselectedFallbackAccounts,
                 trace,
+                storage,
               )
 
               trace.done('return_response', { status: response.status })


### PR DESCRIPTION
## Summary

Adds an optional `existingStorage` parameter to `tryFallbackAccounts()`. The fetch handler loads storage at the start of every request but `tryFallbackAccounts` was reloading it from disk unnecessarily.

Companion to #19 which does the same for `getUsableFallbackAccounts`.

## Testing

All 214 tests pass. No behavior change — only avoids redundant disk I/O.