### PR TITLE
feat(opencode): show quota usage toast after quota refresh

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -672,16 +672,23 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
     })
   }
 
-  function quotaBar(pct: number, width = 16): string {
-    const filled = Math.min(Math.round((pct / 100) * width), width)
+  function quotaBar(pct: number, width = 10): string {
+    const filled = Math.max(0, Math.min(Math.round((pct / 100) * width), width))
     return '█'.repeat(filled) + '░'.repeat(width - filled)
+  }
+
+  function quotaLine(label: string, pct: number): string {
+    return `${label}  ${quotaBar(pct)}  ${String(Math.round(pct)).padStart(3)}%`
   }
 
   function formatResetIn(resetsAt: string | undefined): string {
     if (!resetsAt) return ''
-    const ms = new Date(resetsAt).getTime() - Date.now()
+    const ts = new Date(resetsAt).getTime()
+    if (Number.isNaN(ts)) return ''
+    const ms = ts - Date.now()
     if (ms <= 0) return 'resets now'
     const mins = Math.floor(ms / 60_000)
+    if (mins < 1) return 'resets <1m'
     if (mins < 60) return `resets ${mins}m`
     const hrs = Math.floor(mins / 60)
     const rm = mins % 60
@@ -706,21 +713,17 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       const sd = quota.seven_day
       if (fh || sd) {
         const mainActive = activeAccountId === 'main'
-        const indicator = mainActive ? '🟢' : '  '
+        const status = mainActive ? 'active' : 'idle'
         const reset = formatResetIn(fh?.resetsAt)
         const lines: string[] = [
-          `${indicator} main${reset ? ` (${reset})` : ''}`,
+          `main · ${status}${reset ? ` (${reset})` : ''}`,
         ]
         if (fh) {
-          lines.push(
-            `5h  ${quotaBar(fh.usedPercent)}  ${Math.round(fh.usedPercent)}%`,
-          )
+          lines.push(quotaLine('5h', fh.usedPercent))
           globalMaxUsed = Math.max(globalMaxUsed, fh.usedPercent)
         }
         if (sd) {
-          lines.push(
-            `1w  ${quotaBar(sd.usedPercent)}  ${Math.round(sd.usedPercent)}%`,
-          )
+          lines.push(quotaLine('7d', sd.usedPercent))
           globalMaxUsed = Math.max(globalMaxUsed, sd.usedPercent)
         }
         sections.push(lines.join('\n'))
@@ -737,21 +740,17 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
         if (!fh && !sd) continue
         const name = fb.label || 'alt'
         const fbActive = activeAccountId === fb.id
-        const indicator = fbActive ? '🟢' : '  '
+        const status = fbActive ? 'active' : 'idle'
         const fbReset = formatResetIn(fh?.resetsAt)
         const lines: string[] = [
-          `${indicator} ${name}${fbReset ? ` (${fbReset})` : ''}`,
+          `${name} · ${status}${fbReset ? ` (${fbReset})` : ''}`,
         ]
         if (fh) {
-          lines.push(
-            `5h  ${quotaBar(fh.usedPercent)}  ${Math.round(fh.usedPercent)}%`,
-          )
+          lines.push(quotaLine('5h', fh.usedPercent))
           globalMaxUsed = Math.max(globalMaxUsed, fh.usedPercent)
         }
         if (sd) {
-          lines.push(
-            `1w  ${quotaBar(sd.usedPercent)}  ${Math.round(sd.usedPercent)}%`,
-          )
+          lines.push(quotaLine('7d', sd.usedPercent))
           globalMaxUsed = Math.max(globalMaxUsed, sd.usedPercent)
         }
         sections.push(lines.join('\n'))
@@ -1819,9 +1818,19 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
               function showQuotaToastFromCache() {
                 const mainEntry = quotaManager.getMain()
                 if (!mainEntry) return
-                const fallbacks = (storage?.accounts ?? []).filter(
-                  (a) => a.enabled !== false,
-                )
+                // Prefer the shared QuotaManager cache for fallback quota so the
+                // toast matches the sidebar and reflects background refreshes
+                // rather than the request-start storage snapshot.
+                const fallbacks = (storage?.accounts ?? [])
+                  .filter((a) => a.enabled !== false)
+                  .map((a) => ({
+                    ...a,
+                    // Token-aware read so a cached snapshot bound to a previous
+                    // access token (account re-login) is never shown.
+                    quota:
+                      quotaManager.getFallback(a.id, a.access)?.quota ??
+                      a.quota,
+                  }))
                 const mainPassesPolicy = quotaSnapshotPassesPolicy(
                   mainEntry.quota,
                   storage,
@@ -1830,7 +1839,13 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                 if (mainPassesPolicy) {
                   activeId = 'main'
                 } else {
-                  activeId = fallbacks[0]?.id
+                  // Mirror routing: the active account is the first fallback that
+                  // actually passes quota policy; if none do, routing falls
+                  // through to main, so label main — never a failing fallback.
+                  activeId =
+                    fallbacks.find((f) =>
+                      quotaSnapshotPassesPolicy(f.quota, storage),
+                    )?.id ?? 'main'
                 }
                 showQuotaToast(mainEntry.quota, fallbacks, activeId)
               }

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -42,6 +42,7 @@ import {
   loadAccounts,
   log,
   mergeAnthropicBetas,
+  type OAuthQuotaSnapshot,
   PARALLEL_TOOL_CALLS_SYSTEM_PROMPT,
   parseCache1hCommandAction,
   parseCacheKeepCommandAction,
@@ -669,6 +670,110 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       argumentsText,
       mode: getRoutingMode(storage),
     })
+  }
+
+  function quotaBar(pct: number, width = 16): string {
+    const filled = Math.min(Math.round((pct / 100) * width), width)
+    return '█'.repeat(filled) + '░'.repeat(width - filled)
+  }
+
+  function formatResetIn(resetsAt: string | undefined): string {
+    if (!resetsAt) return ''
+    const ms = new Date(resetsAt).getTime() - Date.now()
+    if (ms <= 0) return 'resets now'
+    const mins = Math.floor(ms / 60_000)
+    if (mins < 60) return `resets ${mins}m`
+    const hrs = Math.floor(mins / 60)
+    const rm = mins % 60
+    return rm > 0 ? `resets ${hrs}h${rm}m` : `resets ${hrs}h`
+  }
+
+  function showQuotaToast(
+    quota: OAuthQuotaSnapshot | null,
+    fallbacks?: Array<{
+      id: string
+      label?: string
+      quota?: OAuthQuotaSnapshot
+    }>,
+    activeAccountId?: string,
+  ) {
+    const sections: string[] = []
+    let globalMaxUsed = 0
+
+    // Main account
+    if (quota) {
+      const fh = quota.five_hour
+      const sd = quota.seven_day
+      if (fh || sd) {
+        const mainActive = activeAccountId === 'main'
+        const indicator = mainActive ? '🟢' : '  '
+        const reset = formatResetIn(fh?.resetsAt)
+        const lines: string[] = [
+          `${indicator} main${reset ? ` (${reset})` : ''}`,
+        ]
+        if (fh) {
+          lines.push(
+            `5h  ${quotaBar(fh.usedPercent)}  ${Math.round(fh.usedPercent)}%`,
+          )
+          globalMaxUsed = Math.max(globalMaxUsed, fh.usedPercent)
+        }
+        if (sd) {
+          lines.push(
+            `1w  ${quotaBar(sd.usedPercent)}  ${Math.round(sd.usedPercent)}%`,
+          )
+          globalMaxUsed = Math.max(globalMaxUsed, sd.usedPercent)
+        }
+        sections.push(lines.join('\n'))
+      }
+    }
+
+    // Fallback accounts
+    if (fallbacks?.length) {
+      for (const fb of fallbacks) {
+        const q = fb.quota
+        if (!q) continue
+        const fh = q.five_hour
+        const sd = q.seven_day
+        if (!fh && !sd) continue
+        const name = fb.label || 'alt'
+        const fbActive = activeAccountId === fb.id
+        const indicator = fbActive ? '🟢' : '  '
+        const fbReset = formatResetIn(fh?.resetsAt)
+        const lines: string[] = [
+          `${indicator} ${name}${fbReset ? ` (${fbReset})` : ''}`,
+        ]
+        if (fh) {
+          lines.push(
+            `5h  ${quotaBar(fh.usedPercent)}  ${Math.round(fh.usedPercent)}%`,
+          )
+          globalMaxUsed = Math.max(globalMaxUsed, fh.usedPercent)
+        }
+        if (sd) {
+          lines.push(
+            `1w  ${quotaBar(sd.usedPercent)}  ${Math.round(sd.usedPercent)}%`,
+          )
+          globalMaxUsed = Math.max(globalMaxUsed, sd.usedPercent)
+        }
+        sections.push(lines.join('\n'))
+      }
+    }
+
+    if (!sections.length) return
+    const message = sections.join('\n\n')
+    const variant =
+      globalMaxUsed >= 90 ? 'error' : globalMaxUsed >= 70 ? 'warning' : 'info'
+
+    // biome-ignore lint/suspicious/noExplicitAny: SDK client.tui type not exposed to server plugins
+    void (client.tui as any)
+      ?.showToast?.({
+        body: {
+          title: 'Claude Quota',
+          message,
+          variant,
+          duration: variant === 'error' ? 8000 : 5000,
+        },
+      })
+      ?.catch?.(() => {})
   }
 
   return {
@@ -1710,6 +1815,26 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                 trace.done('missing_access_error')
                 throw new Error('OAuth access token is missing after refresh')
               }
+              /** Show quota toast from current QuotaManager state */
+              function showQuotaToastFromCache() {
+                const mainEntry = quotaManager.getMain()
+                if (!mainEntry) return
+                const fallbacks = (storage?.accounts ?? []).filter(
+                  (a) => a.enabled !== false,
+                )
+                const mainPassesPolicy = quotaSnapshotPassesPolicy(
+                  mainEntry.quota,
+                  storage,
+                )
+                let activeId: string | undefined
+                if (mainPassesPolicy) {
+                  activeId = 'main'
+                } else {
+                  activeId = fallbacks[0]?.id
+                }
+                showQuotaToast(mainEntry.quota, fallbacks, activeId)
+              }
+
               if (replayableRequest && mainQuotaRoutingEnabled(storage)) {
                 try {
                   const quotaStart = nowMs()
@@ -1719,14 +1844,16 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                   let routingQuota = quotaManager.getMain(auth.access)?.quota
                   if (!routingQuota) {
                     routingQuota = await quotaManager.refreshMain(auth.access)
+                    showQuotaToastFromCache()
                   } else if (quotaManager.needsRefresh(sessionRequestCount)) {
                     // Stale OR every-N request boundary — background refresh,
                     // return current snapshot to avoid blocking. Refresh the
-                    // sidebar again once the new main quota lands.
+                    // sidebar and show the toast once the new main quota lands.
                     void quotaManager
                       .refreshMain(auth.access)
                       .then(() => {
                         void refreshSidebarQuota()
+                        showQuotaToastFromCache()
                       })
                       .catch(() => {})
                   }


### PR DESCRIPTION
> Rebased onto `upstream/main` (v1.5.0) now that #34 (QuotaManager) is merged — this branch no longer depends on `feat/quota-manager`.

Displays quota-usage bar notifications via `client.tui.showToast` after quota data is refreshed.

- Shows main and enabled fallback account usage with visual bars (`█░`).
- Padded percentage and reset time per account; `formatResetIn` handles sub-1-minute (`<1m`), "now", and invalid-date inputs.
- Toast variant reflects severity: info (<70%), warning (≥70%), error (≥90%).
- Clamped bar rendering prevents `RangeError` on >100% utilization.
- Reads main/fallback quota from the shared, **token-aware** QuotaManager cache (not the request-start snapshot).
- The "active" account label mirrors actual routing: the first fallback that passes quota policy, otherwise **main** — never a failing fallback.
- Fires on a synchronous cold-start cache miss and on the resolved `.then()` of each periodic background refresh; never blocks the request.

Single file change: `packages/opencode/src/index.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a quota usage toast after quota refresh, matching the TUI sidebar. Keeps the sidebar correct during async refreshes by preserving the active account and re-rendering when background fallback storage changes via `@cortexkit/anthropic-auth-core`.

- **New Features**
  - Quota toast via `client.tui.showToast` after cold-start `refreshMain` and background refresh; shows main + enabled fallbacks with shared-width `█░` bars, padded %, 5h/7d, “resets <1m/now”, and active/idle status; clamps >100%; severity by max usage; reads token-aware data from the shared `QuotaManager` cache and marks the first account that passes policy.

- **Bug Fixes**
  - Preserve the active fallback in the sidebar after async main refresh by remembering the last routing and only refreshing numbers.
  - Auto-refresh the sidebar when background fallback storage changes (token refresh, quota update, error) by wiring `onFallbackStorageChanged` in `FallbackAccountManager`.

<sup>Written for commit 4b7a88c3a3352c3244e5646b797fffcb32852990. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a quota-usage toast notification after main quota refreshes (both cold-start and periodic background) and fixes the bug where async background refreshes would clobber the active fallback account back to `main` in the sidebar. It also wires `onFallbackStorageChanged` in `FallbackAccountManager` so the sidebar updates automatically when background fallback quota refreshes persist storage changes.

- Introduces `showQuotaToast` / `showQuotaToastFromCache` with `quotaBar`, `quotaLine`, and `formatResetIn` helpers; toast variant (info/warning/error) reflects the highest `usedPercent` across all shown accounts.
- Adds `lastSidebarRouting` state and `refreshSidebarQuota()` to preserve the actual active-account label across quota-only sidebar refreshes, specifically targeting the async background-refresh clobber race.
- Adds `onFallbackStorageChanged` callback to `FallbackAccountManager` (fired from `refreshQuotaForDueAccounts` when storage changes) and wires it to `refreshSidebarQuota()`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core logic is correct and well-tested, with one minor interaction between the new lastSidebarRouting mechanism and the pre-existing /claude-quota command handler.

The async-clobber fix is solid and covered by integration tests. The one notable rough edge is that the pre-existing /claude-quota command handler still calls writeSidebarState with a hardcoded activeId:'main', which now also resets lastSidebarRouting — so a background refresh landing after a quota command continues showing 'main' as active even when a fallback is serving, until the next real request corrects it. It doesn't affect routing correctness, only display accuracy.

packages/opencode/src/index.ts around the CLAUDE_QUOTAS_COMMAND_NAME handler (lines 847–863)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/opencode/src/index.ts | Adds showQuotaToast, formatResetIn, quotaBar/quotaLine helpers; wires toast after cold-start and background main quota refresh; adds lastSidebarRouting + refreshSidebarQuota to prevent the async-refresh clobber bug. Pre-existing /claude-quota command handler still hard-codes activeId:'main' which now also resets lastSidebarRouting. |
| packages/core/src/accounts.ts | Adds onFallbackStorageChanged callback to AccountManagerOptions and FallbackAccountManager; fires it after refreshQuotaForDueAccounts persists changes. Minimal, well-scoped change. |
| packages/opencode/src/tests/accounts.test.ts | New test verifying onFallbackStorageChanged fires exactly once when refreshQuotaForDueAccounts changes storage. Well-structured. |
| packages/opencode/src/tests/index.test.ts | Two new integration tests: one for the async-main-refresh-clobber regression, one for sidebar updating on background fallback quota changes. Both cover the key scenarios introduced by this PR. |

</details>

</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;fix/sidebar-fallback-quota..."](https://github.com/cortexkit/anthropic-auth/commit/e21de9f0418041a9078ccbcc94a30a67d8e6744a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35109353)</sub>

<!-- /greptile_comment -->