### PR TITLE
fix(opencode): repair thinking blocks rejected by Anthropic API

### DIFF
--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -1306,3 +1306,190 @@ describe('sanitizeSystemText – realistic prompt', () => {
     expect(parsed).toMatchSnapshot()
   })
 })
+
+describe('rewriteRequestBody — thinking block repair', () => {
+  const userMsg = { role: 'user', content: 'hello world test message' }
+  const toolResult = {
+    role: 'user',
+    content: [{ type: 'tool_result', tool_use_id: 't1', content: 'out' }],
+  }
+
+  function assistant(content: unknown[]) {
+    return { role: 'assistant', content }
+  }
+
+  test('downgrades flattened interleaved thinking blocks to text', async () => {
+    const body = JSON.stringify({
+      messages: [
+        userMsg,
+        assistant([
+          { type: 'thinking', thinking: 'A', signature: 'sigA' },
+          { type: 'text', text: 'plan' },
+          { type: 'thinking', thinking: 'B', signature: 'sigB' },
+          { type: 'thinking', thinking: 'C', signature: 'sigC' },
+          { type: 'tool_use', id: 't1', name: 'bash', input: {} },
+        ]),
+        toolResult,
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    const content = result.messages[1].content
+    // All thinking blocks downgraded; no signed thinking blocks remain.
+    expect(content.some((b: any) => b.type === 'thinking')).toBe(false)
+    expect(content[0]).toEqual({ type: 'text', text: '<thinking>A</thinking>' })
+    expect(content[1]).toEqual({ type: 'text', text: 'plan' })
+    expect(content[2]).toEqual({ type: 'text', text: '<thinking>B</thinking>' })
+    expect(content[3]).toEqual({ type: 'text', text: '<thinking>C</thinking>' })
+    // tool_use preserved (and prefixed).
+    expect(content[4].type).toBe('tool_use')
+    expect(content[4].name).toBe('mcp_Bash')
+  })
+
+  test('preserves a single thinking block in the latest assistant turn', async () => {
+    const body = JSON.stringify({
+      messages: [
+        userMsg,
+        assistant([
+          { type: 'thinking', thinking: 'reasoning', signature: 'sig1' },
+          { type: 'tool_use', id: 't1', name: 'bash', input: {} },
+        ]),
+        toolResult,
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    const content = result.messages[1].content
+    expect(content[0]).toEqual({
+      type: 'thinking',
+      thinking: 'reasoning',
+      signature: 'sig1',
+    })
+  })
+
+  test('downgrades a single thinking block in a historical assistant turn', async () => {
+    const body = JSON.stringify({
+      messages: [
+        userMsg,
+        assistant([
+          { type: 'thinking', thinking: 'old', signature: 'stale' },
+          { type: 'tool_use', id: 't1', name: 'bash', input: {} },
+        ]),
+        toolResult,
+        assistant([
+          { type: 'thinking', thinking: 'current', signature: 'fresh' },
+          { type: 'tool_use', id: 't2', name: 'read', input: {} },
+        ]),
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 't2', content: 'x' }],
+        },
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    // Historical assistant (index 1): downgraded.
+    expect(result.messages[1].content[0]).toEqual({
+      type: 'text',
+      text: '<thinking>old</thinking>',
+    })
+    // Latest assistant (index 3): preserved.
+    expect(result.messages[3].content[0]).toEqual({
+      type: 'thinking',
+      thinking: 'current',
+      signature: 'fresh',
+    })
+  })
+
+  test('drops redacted_thinking among flattened blocks', async () => {
+    const body = JSON.stringify({
+      messages: [
+        userMsg,
+        assistant([
+          { type: 'thinking', thinking: 'A', signature: 'sigA' },
+          { type: 'redacted_thinking', data: 'enc' },
+          { type: 'tool_use', id: 't1', name: 'bash', input: {} },
+        ]),
+        toolResult,
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    const content = result.messages[1].content
+    expect(content.some((b: any) => b.type === 'redacted_thinking')).toBe(false)
+    expect(content[0]).toEqual({ type: 'text', text: '<thinking>A</thinking>' })
+    expect(content[1].type).toBe('tool_use')
+  })
+
+  test('downgrades a trailing thinking block (cannot be final block)', async () => {
+    const body = JSON.stringify({
+      messages: [
+        userMsg,
+        assistant([
+          { type: 'thinking', thinking: 'only reasoning', signature: 'sig1' },
+        ]),
+        { role: 'user', content: 'next' },
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    const content = result.messages[1].content
+    expect(content[content.length - 1].type).not.toBe('thinking')
+    expect(content[0]).toEqual({
+      type: 'text',
+      text: '<thinking>only reasoning</thinking>',
+    })
+  })
+
+  test('keeps single current-turn thinking when followed by tool_use', async () => {
+    const body = JSON.stringify({
+      messages: [
+        userMsg,
+        assistant([
+          { type: 'thinking', thinking: 'reasoning', signature: 'sig1' },
+          { type: 'tool_use', id: 't1', name: 'bash', input: {} },
+        ]),
+        toolResult,
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    const content = result.messages[1].content
+    // thinking preserved (not final block), tool_use is final.
+    expect(content[0].type).toBe('thinking')
+    expect(content[content.length - 1].type).toBe('tool_use')
+  })
+
+  test('drops a trailing redacted_thinking block', async () => {
+    const body = JSON.stringify({
+      messages: [
+        userMsg,
+        assistant([
+          { type: 'text', text: 'answer' },
+          { type: 'redacted_thinking', data: 'enc' },
+        ]),
+        { role: 'user', content: 'next' },
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    const content = result.messages[1].content
+    expect(content.some((b: any) => b.type === 'redacted_thinking')).toBe(false)
+    expect(content[content.length - 1]).toEqual({
+      type: 'text',
+      text: 'answer',
+    })
+  })
+
+  test('sanitizes lone surrogates when downgrading thinking', async () => {
+    const body = JSON.stringify({
+      messages: [
+        userMsg,
+        assistant([
+          { type: 'thinking', thinking: 'bad\uD800', signature: 'a' },
+          { type: 'thinking', thinking: 'b', signature: 'b' },
+          { type: 'tool_use', id: 't1', name: 'bash', input: {} },
+        ]),
+        toolResult,
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    expect(result.messages[1].content[0]).toEqual({
+      type: 'text',
+      text: '<thinking>bad\uFFFD</thinking>',
+    })
+  })
+})

--- a/packages/opencode/src/transform.ts
+++ b/packages/opencode/src/transform.ts
@@ -594,6 +594,113 @@ function applyCache1hStrategy(
   delete parsed.cacheControl
 }
 
+/** Replace lone (unpaired) UTF-16 surrogates Anthropic rejects as invalid UTF-8. */
+function sanitizeThinkingText(text: string): string {
+  return text.replace(/[\uD800-\uDFFF]/gu, '\uFFFD')
+}
+
+/** Downgrade a thinking block to a plain `<thinking>` text block (signature dropped). */
+function downgradeThinkingBlock(block: Record<string, unknown>) {
+  const thinking = typeof block.thinking === 'string' ? block.thinking : ''
+  return {
+    type: 'text',
+    text: `<thinking>${sanitizeThinkingText(thinking)}</thinking>`,
+  }
+}
+
+/**
+ * Repair `thinking`/`redacted_thinking` blocks so Anthropic accepts them.
+ *
+ * Anthropic signs each thinking block against its original position. Two things
+ * break that and trigger `... thinking blocks ... cannot be modified` 400s:
+ *
+ *   1. Interleaved thinking that opencode's AI SDK flattens — it regroups all
+ *      thinking blocks to the front of the assistant turn instead of leaving
+ *      them interleaved with the tool_use blocks they authorized. The displaced
+ *      blocks no longer match their signed positions. The original interleaving
+ *      is not recoverable from the body, so any assistant turn carrying more
+ *      than one thinking block is downgraded entirely.
+ *   2. Stale signatures on historical (non-last) assistant turns replayed in a
+ *      new request context.
+ *
+ * Strategy: keep a single thinking block only when it is the lone block in the
+ * *latest* assistant turn (the normal, still-valid current-turn case). Every
+ * other thinking block is downgraded to `<thinking>` text; redacted_thinking
+ * blocks (no readable text) are dropped.
+ */
+function sanitizeAssistantThinking(parsed: Record<string, unknown>) {
+  if (!Array.isArray(parsed.messages)) return
+
+  let lastAssistant = -1
+  for (let index = parsed.messages.length - 1; index >= 0; index--) {
+    const message = parsed.messages[index]
+    if (isRecord(message) && message.role === 'assistant') {
+      lastAssistant = index
+      break
+    }
+  }
+
+  for (let index = 0; index < parsed.messages.length; index++) {
+    const message = parsed.messages[index]
+    if (
+      !isRecord(message) ||
+      message.role !== 'assistant' ||
+      !Array.isArray(message.content)
+    ) {
+      continue
+    }
+
+    const content = message.content as Array<Record<string, unknown>>
+    const thinkingCount = content.filter(
+      (block) =>
+        isRecord(block) &&
+        (block.type === 'thinking' || block.type === 'redacted_thinking'),
+    ).length
+    if (thinkingCount === 0) continue
+
+    // A single thinking block in the current turn is still positionally valid.
+    const keepSingle = index === lastAssistant && thinkingCount === 1
+
+    const rewritten: Array<Record<string, unknown>> = []
+    for (const block of content) {
+      if (!isRecord(block)) {
+        rewritten.push(block)
+        continue
+      }
+      if (block.type === 'redacted_thinking') {
+        if (keepSingle) rewritten.push(block)
+        continue // otherwise drop — no readable text to preserve
+      }
+      if (block.type === 'thinking') {
+        rewritten.push(keepSingle ? block : downgradeThinkingBlock(block))
+        continue
+      }
+      rewritten.push(block)
+    }
+
+    // Anthropic rejects an assistant message whose final block is a thinking
+    // block ("The final block in an assistant message cannot be `thinking`").
+    // This can happen when the kept single current-turn thinking block is also
+    // the last block (a thinking-only turn). Downgrade a trailing thinking
+    // block to text; drop a trailing redacted_thinking block.
+    while (rewritten.length) {
+      const last = rewritten[rewritten.length - 1]
+      if (!isRecord(last)) break
+      if (last.type === 'thinking') {
+        rewritten[rewritten.length - 1] = downgradeThinkingBlock(last)
+        break
+      }
+      if (last.type === 'redacted_thinking') {
+        rewritten.pop()
+        continue
+      }
+      break
+    }
+
+    message.content = rewritten
+  }
+}
+
 /**
  * Rewrite the full request body: sanitize system prompt and prefix tool names.
  */
@@ -608,6 +715,9 @@ export async function rewriteRequestBody(
 ): Promise<string> {
   try {
     const parsed = JSON.parse(body)
+    // Repair thinking blocks before anything else so signature-invalid blocks
+    // (flattened interleaving / stale history) can't reach Anthropic.
+    sanitizeAssistantThinking(parsed)
     const billingHeader =
       Array.isArray(parsed.messages) &&
       parsed.messages.some(


### PR DESCRIPTION
## Problem

Anthropic signs each thinking block against its original position. Two things break signatures and trigger `thinking blocks cannot be modified` 400s:

1. **Interleaved thinking flattened by the AI SDK** — opencode's Vercel AI SDK regroups all thinking blocks to the front of the assistant turn instead of leaving them interleaved with the tool_use blocks they authorized. The displaced blocks no longer match their signed positions.

2. **Stale signatures on historical assistant turns** replayed in a new request context (after context compaction or provider failover).

3. **Final block constraint** — Anthropic also rejects an assistant message whose final block is a `thinking` block.

## Strategy

- Keep a single signed thinking block only when it is the **lone block in the latest assistant turn** (the normal, still-valid current-turn case).
- Downgrade all others to `<thinking>` text — preserves reasoning content without invalid signatures.
- Drop `redacted_thinking` blocks (no readable text to preserve).
- Guard against a trailing `thinking` block being the final block in the message.
- Sanitize lone UTF-16 surrogates in downgraded text to avoid invalid-UTF8 400s.

## Cache impact

None on the static prefix. The transform runs before cache_control anchors are applied, so anchors land on the already-normalized structure. Historical turns render deterministically once they become non-last. The only cost is the unavoidable one-time tail transition when the current turn becomes historical.

## Tests

6 new test cases covering: flattened interleaving, single-block preservation, historical downgrades, redacted_thinking drops, lone-surrogate sanitization, and trailing-thinking-block downgrade.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782672001&installation_id=135454708&pr_number=49&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F49&signature=daaee6bee201954b4da450d72e0d9c990bbb5d477c2c631387a82b501ec4086d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs Anthropic 400s by normalizing `thinking` blocks in `opencode` requests. Prevents errors from flattened interleaving, stale signatures on historical turns, and final `thinking` blocks.

- **Bug Fixes**
  - Keep a single signed `thinking` block only in the latest assistant turn; downgrade all others to `<thinking>` text.
  - Drop `redacted_thinking` blocks unless it’s the single block in the latest assistant turn; never allow it as the final block.
  - Prevent `thinking` as the final block in an assistant message.
  - Sanitize lone UTF-16 surrogates in downgraded text.

<sup>Written for commit b6971c40864b953342a3c4e694fe15be8be0f081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

