### PR TITLE
fix(opencode): never place cache_control on message object in hybrid mode

### DIFF
--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -1375,6 +1375,75 @@ describe('rewriteRequestBody', () => {
     expect(result.messages.length).toBe(3)
     expect(result.messages[2].role).toBe('user')
   })
+
+  test('hybrid mode never sets cache_control on the message object when the n-2 anchor has no cacheable block', async () => {
+    // Reproduces "messages.N.cache_control: Extra inputs are not permitted".
+    // The moving anchor (messages[n-2]) lands on a message whose content has no
+    // cacheable block (empty content array). cache_control must NOT be attached
+    // to the message object itself — Anthropic only allows it on content blocks.
+    const body = JSON.stringify({
+      system: 'Stable system block',
+      messages: [
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'second' },
+        { role: 'user', content: [] },
+        { role: 'assistant', content: 'last' },
+      ],
+    })
+
+    const result = JSON.parse(
+      await rewriteRequestBody(body, {
+        cache1hEnabled: true,
+        cache1hMode: 'hybrid',
+      }),
+    )
+
+    // The empty n-2 message must remain free of a message-level cache_control.
+    expect(result.messages[2].cache_control).toBeUndefined()
+    expect(result.messages[2].cacheControl).toBeUndefined()
+
+    // No message in the request may carry a message-level cache_control.
+    for (const message of result.messages) {
+      expect(message.cache_control).toBeUndefined()
+      expect(message.cacheControl).toBeUndefined()
+    }
+  })
+
+  test('hybrid mode anchors on the last non-thinking block, never the message object', async () => {
+    // messages[1] is always an anchor slot in hybrid mode. Give it mixed
+    // content ending in a thinking block: the anchor must land on the text
+    // block, never the trailing thinking block and never the message object.
+    const body = JSON.stringify({
+      system: 'Stable system block',
+      messages: [
+        { role: 'user', content: 'first' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'reasoning preface' },
+            { type: 'thinking', thinking: 'internal', signature: 'sig' },
+          ],
+        },
+        { role: 'user', content: 'last' },
+      ],
+    })
+
+    const result = JSON.parse(
+      await rewriteRequestBody(body, {
+        cache1hEnabled: true,
+        cache1hMode: 'hybrid',
+      }),
+    )
+
+    // Anchor goes on the text block, not the message and not the thinking block.
+    expect(result.messages[1].cache_control).toBeUndefined()
+    const blocks = result.messages[1].content
+    const cachedBlocks = blocks.filter(
+      (block: { cache_control?: unknown }) => block.cache_control != null,
+    )
+    expect(cachedBlocks).toHaveLength(1)
+    expect(cachedBlocks[0].type).toBe('text')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/opencode/src/transform.ts
+++ b/packages/opencode/src/transform.ts
@@ -477,14 +477,27 @@ function applyAutomaticCache1h(parsed: Record<string, unknown>) {
 function setMessageCacheAnchor(message: unknown) {
   if (!isRecord(message)) return false
 
+  // cache_control is only valid on content blocks, never on the message
+  // object itself. A message with no cacheable content block (empty content,
+  // or only thinking/redacted_thinking blocks) must be skipped entirely;
+  // attaching cache_control to the message triggers Anthropic's
+  // "messages.N.cache_control: Extra inputs are not permitted" 400.
   const content = normalizeContentToArray(message.content)
-  if (!content?.length) return setWireCacheControl(message, true)
+  if (!content?.length) return false
 
-  message.content = content
   const lastCacheableBlock = [...content]
     .reverse()
-    .find((block) => isRecord(block) && block.type !== 'thinking')
-  return setWireCacheControl(lastCacheableBlock ?? message, true)
+    .find(
+      (block) =>
+        isRecord(block) &&
+        block.type !== 'thinking' &&
+        block.type !== 'redacted_thinking',
+    )
+  if (!lastCacheableBlock) return false
+
+  // Only materialize the normalized content array once we know we will anchor.
+  message.content = content
+  return setWireCacheControl(lastCacheableBlock, true)
 }
 
 function messageContentBlockCount(message: unknown) {


### PR DESCRIPTION
## Problem

In hybrid cache mode, `setMessageCacheAnchor()` fell back to `setWireCacheControl(message, true)` when a message had empty content or only `thinking`/`redacted_thinking` blocks. That attaches `cache_control` to the **message object**, which Anthropic only permits on **content blocks**.

When resuming a session whose moving anchor (`messages[n-2]`) landed on such a message, the API rejected the request:

```
messages.N.cache_control: Extra inputs are not permitted  (HTTP 400)
```

## Fix

Never anchor on the message object. In `setMessageCacheAnchor()`:
- Return `false` when content is empty (instead of setting cache_control on the message).
- Exclude `redacted_thinking` alongside `thinking` when finding the last cacheable block.
- Return `false` when no cacheable block exists.
- Only materialize the normalized content array once an anchor target is confirmed.

## Tests

Adds 2 regression tests:
- hybrid mode never sets `cache_control` on the message object when the n-2 anchor has no cacheable block
- hybrid mode anchors on the last non-thinking block, never the message object

All opencode tests pass (261), typecheck clean, biome clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782887414&installation_id=135454708&pr_number=50&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F50&signature=16142e0f3aa42bef095823166a22bdbcb706c29ad71d003875ef80c5d7457118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents 400s in hybrid cache mode by never setting `cache_control` on message objects. Anchors only on valid content blocks to avoid “messages.N.cache_control: Extra inputs are not permitted”.

- **Bug Fixes**
  - Skip anchoring on empty content; never attach `cache_control` to the message.
  - Anchor only the last non-`thinking`/`redacted_thinking` block; skip when none exists.
  - Normalize content only after confirming an anchor; add regression tests for empty and mixed content.

<sup>Written for commit 1ba42c18bc7e5ea3f49e6c0095fd0b11e7dd1c76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

