### PR TITLE
fix(opencode): strip trailing assistant messages to prevent prefill 400

### DIFF
--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -1131,6 +1131,7 @@ describe('auth.loader', () => {
               },
             ],
           },
+          { role: 'user', content: 'follow up' },
         ],
       }),
     })

--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -770,6 +770,7 @@ describe('rewriteRequestBody', () => {
             { type: 'text', text: 'Let me check' },
           ],
         },
+        { role: 'user', content: 'Thanks' },
       ],
       system: [
         { type: 'text', text: systemPrompt },
@@ -791,6 +792,7 @@ describe('rewriteRequestBody', () => {
     // User messages are untouched
     expect(result.messages[0].content).toBe('Help me fix this bug')
     expect(result.messages[1].content[0].name).toBe('mcp_Bash')
+    expect(result.messages[2].content).toBe('Thanks')
   })
 
   test('handles body with no messages array', async () => {
@@ -995,6 +997,7 @@ describe('rewriteRequestBody', () => {
             },
           ],
         },
+        { role: 'user', content: 'follow up' },
       ],
     })
 
@@ -1096,7 +1099,6 @@ describe('rewriteRequestBody', () => {
         { role: 'user', content: 'message 0' },
         { role: 'assistant', content: 'message 1' },
         { role: 'user', content: 'message 2' },
-        { role: 'assistant', content: 'message 3' },
       ],
     })
 
@@ -1122,7 +1124,6 @@ describe('rewriteRequestBody', () => {
         cache_control: { type: 'ephemeral', ttl: '1h' },
       },
     ])
-    expect(result.messages[3].content).toBe('message 3')
   })
 
   test('hybrid mode keeps the system anchor when the latest user boundary is within lookback', async () => {
@@ -1247,6 +1248,7 @@ describe('rewriteRequestBody', () => {
             },
           ],
         },
+        { role: 'user', content: 'follow up' },
       ],
     })
 
@@ -1272,6 +1274,106 @@ describe('rewriteRequestBody', () => {
       type: 'ephemeral',
       ttl: '1h',
     })
+  })
+
+  // -----------------------------------------------------------------------
+  // Prefill stripping — trailing assistant messages
+  // -----------------------------------------------------------------------
+
+  test('strips single trailing assistant message', async () => {
+    const body = JSON.stringify({
+      system: 'sys',
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: [{ type: 'text', text: 'I will help' }] },
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    expect(result.messages.length).toBe(1)
+    expect(result.messages[0].role).toBe('user')
+  })
+
+  test('strips multiple trailing assistant messages', async () => {
+    const body = JSON.stringify({
+      system: 'sys',
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: [{ type: 'text', text: 'first' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    expect(result.messages.length).toBe(1)
+    expect(result.messages[0].role).toBe('user')
+  })
+
+  test('preserves assistant message followed by user message', async () => {
+    const body = JSON.stringify({
+      system: 'sys',
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: [{ type: 'text', text: 'response' }] },
+        { role: 'user', content: 'follow up' },
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    expect(result.messages.length).toBe(3)
+    expect(result.messages[0].role).toBe('user')
+    expect(result.messages[1].role).toBe('assistant')
+    expect(result.messages[2].role).toBe('user')
+  })
+
+  test('preserves assistant tool_use followed by user tool_result', async () => {
+    const body = JSON.stringify({
+      system: 'sys',
+      messages: [
+        { role: 'user', content: 'do something' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'tool_1', name: 'Bash', input: {} },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'tool_1', content: 'output' },
+          ],
+        },
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    expect(result.messages.length).toBe(3)
+    expect(result.messages[1].role).toBe('assistant')
+    expect(result.messages[2].role).toBe('user')
+  })
+
+  test('strips trailing assistant after tool_result + assistant', async () => {
+    const body = JSON.stringify({
+      system: 'sys',
+      messages: [
+        { role: 'user', content: 'do something' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'tool_1', name: 'Bash', input: {} },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'tool_1', content: 'output' },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'based on that output...' }],
+        },
+      ],
+    })
+    const result = JSON.parse(await rewriteRequestBody(body))
+    expect(result.messages.length).toBe(3)
+    expect(result.messages[2].role).toBe('user')
   })
 })
 

--- a/packages/opencode/src/transform.ts
+++ b/packages/opencode/src/transform.ts
@@ -595,6 +595,22 @@ function applyCache1hStrategy(
 }
 
 /**
+ * Strip trailing assistant messages. Anthropic rejects assistant-message
+ * prefill on Claude Code OAuth models with: "This model does not support
+ * assistant message prefill. The conversation must end with a user message."
+ * A resumed/compacted session can end on an assistant turn (e.g. after a
+ * failed tool round); pop those before signing.
+ */
+function stripTrailingAssistantMessages(parsed: Record<string, unknown>) {
+  if (!Array.isArray(parsed.messages)) return
+  while (parsed.messages.length) {
+    const last = parsed.messages[parsed.messages.length - 1]
+    if (!isRecord(last) || last.role !== 'assistant') break
+    parsed.messages.pop()
+  }
+}
+
+/**
  * Rewrite the full request body: sanitize system prompt and prefix tool names.
  */
 export async function rewriteRequestBody(
@@ -608,6 +624,7 @@ export async function rewriteRequestBody(
 ): Promise<string> {
   try {
     const parsed = JSON.parse(body)
+    stripTrailingAssistantMessages(parsed)
     const billingHeader =
       Array.isArray(parsed.messages) &&
       parsed.messages.some(


### PR DESCRIPTION
## Problem

`rewriteRequestBody()` never removed trailing assistant-role messages. A resumed or compacted session that ends on an assistant turn (e.g. after a failed tool round, or a session restored mid-response) reached Anthropic with assistant-message **prefill**. Claude Code OAuth models reject this:

```
This model does not support assistant message prefill.
The conversation must end with a user message.  (HTTP 400)
```

This recurs in practice on session resume/compaction and forces the user to manually send another message to recover.

## Fix

Add `stripTrailingAssistantMessages()` and call it right after `JSON.parse(body)`, so trailing assistant messages are popped before billing-header computation and signing. This mirrors the behavior of the built-in `@ai-sdk/anthropic` provider and the `packages/pi` conversion path, which already strip trailing assistant messages.

Only messages **after the last user message** are removed — the active user turn and any assistant message followed by a user message are always preserved. The alternative (no strip) is a hard 400 that returns nothing.

## Tests

Adds 5 tests:
- strips single trailing assistant message
- strips multiple trailing assistant messages
- preserves assistant message followed by user message
- preserves assistant `tool_use` followed by user `tool_result`
- strips trailing assistant after `tool_result` + assistant

Updates existing fixtures that previously ended on assistant turns to end on user messages. All opencode tests pass (264), typecheck clean, biome clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782887428&installation_id=135454708&pr_number=51&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F51&signature=aac48d8af07693671001720bbb37bdd609b38243530d23cd14a3a791b046326b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips trailing assistant messages during request rewrite so conversations end with a user message, preventing Anthropic Claude Code OAuth 400 “assistant message prefill” errors. Aligns behavior with `@ai-sdk/anthropic` and `packages/pi`.

- **Bug Fixes**
  - Added `stripTrailingAssistantMessages()` and called it in `rewriteRequestBody()` right after `JSON.parse`.
  - Only removes assistant messages after the last user message; preserves assistant→user and `tool_use`→`tool_result` flows.
  - Added 5 tests for strip/preserve scenarios and updated fixtures to end on user messages.

<sup>Written for commit ca249f99cd322d35c1af95f65d5d3a8197d2bb11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

