### PR TITLE
fix(opencode): stale fallback quota and clobbered active account in sidebar

### DIFF
--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -129,6 +129,10 @@ export type AccountManagerOptions = {
   fetchImpl?: typeof fetch
   configPath?: string
   quotaManager?: import('./quota-manager.ts').QuotaManager
+  // Invoked after a background quota pass persists at least one fallback quota
+  // change, so consumers (e.g. the OpenCode sidebar) can re-render without a
+  // request flowing through the fetch handler.
+  onFallbackQuotaFetched?: () => void
 }
 
 export type AccountRefreshError = {
@@ -978,12 +982,14 @@ export class FallbackAccountManager {
   private refreshTimer: ReturnType<typeof setInterval> | null = null
   private quotaTimer: ReturnType<typeof setInterval> | null = null
   readonly quotaManager: import('./quota-manager.ts').QuotaManager | null
+  private readonly onFallbackQuotaFetched: (() => void) | undefined
 
   constructor(options: AccountManagerOptions = {}) {
     this.now = options.now ?? Date.now
     this.fetchImpl = options.fetchImpl ?? fetch
     this.configPath = options.configPath ?? getAccountStoragePath()
     this.quotaManager = options.quotaManager ?? null
+    this.onFallbackQuotaFetched = options.onFallbackQuotaFetched
   }
 
   /**
@@ -1233,7 +1239,10 @@ export class FallbackAccountManager {
         // Quota probes are advisory; failed probes fail closed at selection time.
       }
     }
-    if (changed) await this.save(storage)
+    if (changed) {
+      await this.save(storage)
+      this.onFallbackQuotaFetched?.()
+    }
   }
 
   async refreshQuotaForAllAccounts(options: { force?: boolean } = {}) {

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -129,10 +129,11 @@ export type AccountManagerOptions = {
   fetchImpl?: typeof fetch
   configPath?: string
   quotaManager?: import('./quota-manager.ts').QuotaManager
-  // Invoked after a background quota pass persists at least one fallback quota
-  // change, so consumers (e.g. the OpenCode sidebar) can re-render without a
-  // request flowing through the fetch handler.
-  onFallbackQuotaFetched?: () => void
+  // Invoked after a background quota pass persists at least one fallback storage
+  // change (token refresh, quota update, or error recording), so consumers
+  // (e.g. the OpenCode sidebar) can re-render without a request flowing through
+  // the fetch handler.
+  onFallbackStorageChanged?: () => void
 }
 
 export type AccountRefreshError = {
@@ -982,14 +983,14 @@ export class FallbackAccountManager {
   private refreshTimer: ReturnType<typeof setInterval> | null = null
   private quotaTimer: ReturnType<typeof setInterval> | null = null
   readonly quotaManager: import('./quota-manager.ts').QuotaManager | null
-  private readonly onFallbackQuotaFetched: (() => void) | undefined
+  private readonly onFallbackStorageChanged: (() => void) | undefined
 
   constructor(options: AccountManagerOptions = {}) {
     this.now = options.now ?? Date.now
     this.fetchImpl = options.fetchImpl ?? fetch
     this.configPath = options.configPath ?? getAccountStoragePath()
     this.quotaManager = options.quotaManager ?? null
-    this.onFallbackQuotaFetched = options.onFallbackQuotaFetched
+    this.onFallbackStorageChanged = options.onFallbackStorageChanged
   }
 
   /**
@@ -1241,7 +1242,7 @@ export class FallbackAccountManager {
     }
     if (changed) {
       await this.save(storage)
-      this.onFallbackQuotaFetched?.()
+      this.onFallbackStorageChanged?.()
     }
   }
 

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -355,6 +355,13 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
   setDumpEnabled(isDumpPersistentlyEnabled(initialStorage))
   setFastModeEnabled(isFastModePersistentlyEnabled(initialStorage))
 
+  // Remembers the last explicit routing decision so quota-only sidebar refreshes
+  // (background main/fallback quota landing) do not reset the active account.
+  let lastSidebarRouting: { activeId: string | undefined; route: string } = {
+    activeId: 'main',
+    route: 'main',
+  }
+
   function writeSidebarState(
     storage: Awaited<ReturnType<typeof loadAccounts>>,
     options: {
@@ -364,6 +371,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       mainRefreshToken?: string
     },
   ) {
+    lastSidebarRouting = { activeId: options.activeId, route: options.route }
     const mainEntry = quotaManager.getMain(options.mainAccessToken)
     const lastApiError = quotaManager.getLastApiError()
     const mainRefreshError = storage?.refresh?.mainLastRefreshError
@@ -423,6 +431,30 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
         error: error instanceof Error ? error.message : String(error),
       }),
     )
+  }
+
+  // Re-write the sidebar using the LAST known routing decision, refreshing only
+  // the quota numbers. Used by async quota refreshes (main + background fallback)
+  // so they never clobber the active account back to 'main'.
+  async function refreshSidebarQuota() {
+    const storage = await loadAccounts(accountStoragePath)
+    let access: string | undefined
+    let refresh: string | undefined
+    if (latestGetAuth) {
+      try {
+        const auth = await latestGetAuth()
+        access = auth.access
+        refresh = auth.refresh
+      } catch {
+        // best-effort
+      }
+    }
+    writeSidebarState(storage, {
+      activeId: lastSidebarRouting.activeId,
+      route: lastSidebarRouting.route,
+      mainAccessToken: access,
+      mainRefreshToken: refresh,
+    })
   }
 
   let latestGetAuth:
@@ -1690,14 +1722,9 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                     // sidebar again once the new main quota lands.
                     void quotaManager
                       .refreshMain(auth.access)
-                      .then(() =>
-                        writeSidebarState(storage, {
-                          activeId: 'main',
-                          route: 'main',
-                          mainAccessToken: auth.access,
-                          mainRefreshToken: auth.refresh,
-                        }),
-                      )
+                      .then(() => {
+                        void refreshSidebarQuota()
+                      })
                       .catch(() => {})
                   }
                   // Update the sidebar every replayable request so fallback

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -306,6 +306,9 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
   })
   const fallbackManager = new FallbackAccountManager({
     quotaManager,
+    onFallbackQuotaFetched: () => {
+      void refreshSidebarQuota()
+    },
   })
   fallbackManager.startBackgroundRefresh()
   let latestRefreshMainAccessToken: (() => Promise<string>) | null = null

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -306,7 +306,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
   })
   const fallbackManager = new FallbackAccountManager({
     quotaManager,
-    onFallbackQuotaFetched: () => {
+    onFallbackStorageChanged: () => {
       void refreshSidebarQuota()
     },
   })

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -707,6 +707,49 @@ describe('FallbackAccountManager', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
+  test('refreshQuotaForDueAccounts fires onFallbackQuotaFetched when quota changes', async () => {
+    const storage = baseStorage()
+    storage.accounts.push({
+      id: 'idle-stale',
+      type: 'oauth',
+      access: 'idle-access',
+      refresh: 'idle-refresh',
+      expires: 20_000_000,
+      quota: {
+        // checkedAt far in the past → stale → will be refreshed this pass.
+        five_hour: { usedPercent: 5, remainingPercent: 95, checkedAt: 1 },
+        seven_day: { usedPercent: 5, remainingPercent: 95, checkedAt: 1 },
+      },
+    })
+    await saveAccounts(storage)
+
+    const fetchImpl = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            five_hour: { utilization: 40 },
+            seven_day: { utilization: 30 },
+          }),
+          { status: 200 },
+        ),
+      ),
+    ) as unknown as typeof fetch
+
+    let fired = 0
+    const manager = new FallbackAccountManager({
+      fetchImpl,
+      now: () => 50_000_000, // well past checkedAt → stale
+      onFallbackQuotaFetched: () => {
+        fired += 1
+      },
+    })
+
+    await manager.refreshQuotaForDueAccounts()
+
+    expect(fetchImpl).toHaveBeenCalled()
+    expect(fired).toBe(1)
+  })
+
   test('refreshes fallback token and retries quota check after stale access token 401', async () => {
     const storage = baseStorage()
     storage.accounts.push({

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -707,7 +707,7 @@ describe('FallbackAccountManager', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
-  test('refreshQuotaForDueAccounts fires onFallbackQuotaFetched when quota changes', async () => {
+  test('refreshQuotaForDueAccounts fires onFallbackStorageChanged when storage changes', async () => {
     const storage = baseStorage()
     storage.accounts.push({
       id: 'idle-stale',
@@ -739,7 +739,7 @@ describe('FallbackAccountManager', () => {
     const manager = new FallbackAccountManager({
       fetchImpl,
       now: () => 50_000_000, // well past checkedAt → stale
-      onFallbackQuotaFetched: () => {
+      onFallbackStorageChanged: () => {
         fired += 1
       },
     })

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -2774,4 +2774,70 @@ describe('auth.loader', () => {
     expect(response.status).toBe(429)
     expect(calls).toBe(1)
   })
+
+  test('background fallback refresh updates the sidebar without a request', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({
+        accounts: [
+          {
+            id: 'fallback-1',
+            type: 'oauth',
+            access: 'fallback-access',
+            refresh: 'fallback-refresh',
+            expires: Date.now() + 5 * 60 * 60 * 1000,
+            quota: {
+              // Stale (old checkedAt) → background pass will refresh it.
+              five_hour: {
+                usedPercent: 0,
+                remainingPercent: 100,
+                checkedAt: 1,
+              },
+              seven_day: {
+                usedPercent: 0,
+                remainingPercent: 100,
+                checkedAt: 1,
+              },
+            },
+          },
+        ],
+      }),
+    )
+
+    globalThis.fetch = mock((input: any) => {
+      if (extractUrl(input).includes('/api/oauth/usage')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              five_hour: { utilization: 0.42 },
+              seven_day: { utilization: 0.1 },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response('ok', { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    // Running the loader starts the background refresh (immediate first pass).
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+
+    // The background pass refreshes the stale fallback and the hook re-writes the
+    // sidebar — without any request to the messages endpoint.
+    // utilization: 0.42 → usedPercent: 0.42 (stored as-is, not multiplied by 100)
+    const state = await waitForSidebarState(
+      (candidate) =>
+        candidate.fallbacks[0]?.quota?.five_hour?.usedPercent === 0.42,
+    )
+    expect(state.fallbacks[0]?.id).toBe('fallback-1')
+  })
 })

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -9,6 +9,7 @@ import {
   resetDumpState,
   resetFastModeState,
   saveAccounts,
+  tokenFingerprint,
 } from '@cortexkit/anthropic-auth-core'
 import { AnthropicAuthPlugin } from '../index'
 import { getSidebarState } from '../sidebar-state'
@@ -2536,6 +2537,89 @@ describe('auth.loader', () => {
     } finally {
       Date.now = originalDateNow
     }
+  })
+
+  test('async main refresh does not clobber the active fallback in the sidebar', async () => {
+    const staleCheckedAt = Date.now() - 100 * 60_000 // far past → main quota is stale
+    await useTempAccountFile(
+      createFallbackStorage({
+        quota: {
+          enabled: true,
+          checkIntervalMinutes: 5,
+          minimumRemaining: { five_hour: 10, seven_day: 20 },
+          failClosedOnUnknownQuota: true,
+          // Cached, stale, and FAILING five_hour policy (used 95% → remaining 5% < 10%).
+          mainQuota: {
+            five_hour: {
+              usedPercent: 95,
+              remainingPercent: 5,
+              checkedAt: staleCheckedAt,
+            },
+            seven_day: {
+              usedPercent: 10,
+              remainingPercent: 90,
+              checkedAt: staleCheckedAt,
+            },
+          },
+          mainQuotaCheckedAt: staleCheckedAt,
+          // Bind the cached main quota to the access token the loader will use.
+          mainQuotaToken: tokenFingerprint('main-access'),
+        } as AccountStorage['quota'],
+      }),
+    )
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/api/oauth/usage')) {
+        // Delay the background main refresh so it settles AFTER the fallback
+        // write — this is the race that causes the clobber in production.
+        return Bun.sleep(40).then(
+          () =>
+            new Response(
+              JSON.stringify({
+                five_hour: { utilization: 0.95 },
+                seven_day: { utilization: 0.1 },
+              }),
+              { status: 200 },
+            ),
+        )
+      }
+      // Anthropic messages call — fallback serves 200, main would not be reached.
+      return Promise.resolve(new Response('ok', { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+
+    await result.fetch(MESSAGES_URL, {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'claude-opus-4-8',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    })
+
+    // Fallback served → active id should be the fallback.
+    const state = await waitForSidebarState(
+      (candidate) => candidate.activeId === 'fallback-1',
+    )
+    expect(state.route).toBe('fallback')
+
+    // Let the fire-and-forget refreshMain().then(...) settle.
+    await Bun.sleep(80)
+
+    // REGRESSION: pre-fix the async callback rewrites activeId to 'main'.
+    const after = await getSidebarState()
+    expect(after.activeId).toBe('fallback-1')
   })
 
   test('fetch wrapper retries with fallback when main streaming body reports rate limit', async () => {


### PR DESCRIPTION
## Summary
Two independent fixes to the OpenCode quota sidebar.

### BUG 1 — stale fallback quota
Background fallback-quota refresh updated the QuotaManager cache + disk but never triggered a sidebar write, so a fallback account's quota in the sidebar went stale until `/claude-quota` was run manually. Adds an `onFallbackQuotaFetched` callback to `FallbackAccountManager`, fired after a background quota pass persists a change, wired in the plugin to re-render the sidebar.

### BUG 2 — clobbered active account
The fire-and-forget `quotaManager.refreshMain().then(...)` callback hardcoded `activeId: 'main'` and fired asynchronously after routing was decided, clobbering the active fallback back to `main` (e.g. in fallback-first the served fallback flipped back to main). Adds a `lastSidebarRouting` memory recorded in `writeSidebarState`, and routes the async callback through a new `refreshSidebarQuota()` that reuses the last routing instead of hardcoding main.

## Changes
- `packages/core/src/accounts.ts` — `onFallbackQuotaFetched` option + invocation in `refreshQuotaForDueAccounts`.
- `packages/opencode/src/index.ts` — `lastSidebarRouting` + `refreshSidebarQuota`; async refresh no longer clobbers `activeId`.

## Tests
- 3 new regression tests (verified red without the fix): active fallback not clobbered after async main refresh; background fallback refresh updates the sidebar without a request; `onFallbackQuotaFetched` fires on background quota change.
- Full suite green (typecheck + test + build).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783145572&installation_id=135454708&pr_number=57&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F57&signature=fc16ffab7d1bf85043cac7f2e109964e2f870e8183d453ed781d3773aa55b481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two sidebar issues: stale fallback quota and the active account being reset to main after async refresh. The sidebar now stays accurate and keeps the selected account.

- **Bug Fixes**
  - Sidebar refreshes after background fallback storage changes (quota update, token refresh, or error recording) via `onFallbackStorageChanged` in `FallbackAccountManager`, hooked to `refreshSidebarQuota()` in the `AnthropicAuthPlugin`.
  - Preserves the active account during async main quota refresh by tracking `lastSidebarRouting` and reusing it in `refreshSidebarQuota()` instead of hardcoding `'main'`.

<sup>Written for commit 832e0a7d1062a465d4601e1c6f91f06827d0f9a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two independent bugs in the OpenCode quota sidebar: stale fallback quota after background refresh, and the active account being clobbered back to `main` by a fire-and-forget async callback. The PR description references `onFallbackQuotaFetched` but the landed option name is `onFallbackStorageChanged`, reflecting a rename suggested in a prior review.

- **Bug 1 (stale fallback quota):** Adds `onFallbackStorageChanged` to `FallbackAccountManager`, fired once per background pass when storage changes. The plugin wires this to a new `refreshSidebarQuota()` helper that rewrites the sidebar without a request.
- **Bug 2 (clobbered active account):** Replaces the hardcoded `activeId: 'main'` in the async `refreshMain().then(...)` callback with `refreshSidebarQuota()`, which reads `lastSidebarRouting` — a variable updated on every `writeSidebarState` call that carries the most recent routing decision.
- **Tests:** Three regression tests cover the callback firing behavior, the background-fallback-to-sidebar path, and the async main-refresh clobber race with a delayed fetch mock.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; both bug fixes are logically sound and backed by regression tests confirmed red before the fix.

The routing-memory and callback wiring are minimal and well-scoped. The one subtle concern is that `refreshSidebarQuota` calls `latestGetAuth()` unconditionally — even from the fallback background-quota path — which could on token rotation cause `quotaManager.getMain()` to destructively clear the cached main quota. The impact is transient (null main quota for one sidebar cycle, one extra `refreshMain` call on the next request) and low probability.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/accounts.ts | Adds `onFallbackStorageChanged` callback option to `FallbackAccountManager`, fired once per background quota pass when any fallback storage change is persisted. |
| packages/opencode/src/index.ts | Introduces `lastSidebarRouting` and `refreshSidebarQuota()` to fix the hardcoded `activeId: 'main'` clobber in the async main refresh callback. |
| packages/opencode/src/tests/accounts.test.ts | Adds a regression test verifying `onFallbackStorageChanged` fires exactly once when storage changes. |
| packages/opencode/src/tests/index.test.ts | Adds two integration regression tests for the clobber race and the background-fallback-to-sidebar path. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(core): rename onFallbackQuotaFe..."](https://github.com/cortexkit/anthropic-auth/commit/832e0a7d1062a465d4601e1c6f91f06827d0f9a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35555879)</sub>

<!-- /greptile_comment -->