### PR TITLE
feat(opencode): collapsible TUI sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ The sidebar polls plugin state and refreshes on OpenCode session and message eve
 - **Cache** — the 1-hour cache keepalive window and the number of tracked sessions, shown when cache keepalive is configured.
 - **Health** — quota-API and token-refresh backoff countdowns. This section is hidden unless a backoff is active, and a `LIMITED` badge appears in the header.
 
+Click the `CLAUDE` header to collapse or expand the sidebar. Collapsed, it shows the active account's 5-hour quota usage and a fast-mode row when fast mode is on; the header shows the plugin version (or a `LIMITED` badge when degraded). Collapse state is per-session and resets when OpenCode restarts.
+
 ## Claude prompt cache control
 
 Both OpenCode and Pi packages add a slash command for Anthropic's 1-hour ephemeral prompt-cache TTL:

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -129,6 +129,10 @@ export type AccountManagerOptions = {
   fetchImpl?: typeof fetch
   configPath?: string
   quotaManager?: import('./quota-manager.ts').QuotaManager
+  // Invoked after a background quota pass persists at least one fallback quota
+  // change, so consumers (e.g. the OpenCode sidebar) can re-render without a
+  // request flowing through the fetch handler.
+  onFallbackQuotaFetched?: () => void
 }
 
 export type AccountRefreshError = {
@@ -978,12 +982,14 @@ export class FallbackAccountManager {
   private refreshTimer: ReturnType<typeof setInterval> | null = null
   private quotaTimer: ReturnType<typeof setInterval> | null = null
   readonly quotaManager: import('./quota-manager.ts').QuotaManager | null
+  private readonly onFallbackQuotaFetched: (() => void) | undefined
 
   constructor(options: AccountManagerOptions = {}) {
     this.now = options.now ?? Date.now
     this.fetchImpl = options.fetchImpl ?? fetch
     this.configPath = options.configPath ?? getAccountStoragePath()
     this.quotaManager = options.quotaManager ?? null
+    this.onFallbackQuotaFetched = options.onFallbackQuotaFetched
   }
 
   /**
@@ -1233,7 +1239,10 @@ export class FallbackAccountManager {
         // Quota probes are advisory; failed probes fail closed at selection time.
       }
     }
-    if (changed) await this.save(storage)
+    if (changed) {
+      await this.save(storage)
+      this.onFallbackQuotaFetched?.()
+    }
   }
 
   async refreshQuotaForAllAccounts(options: { force?: boolean } = {}) {

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -129,10 +129,11 @@ export type AccountManagerOptions = {
   fetchImpl?: typeof fetch
   configPath?: string
   quotaManager?: import('./quota-manager.ts').QuotaManager
-  // Invoked after a background quota pass persists at least one fallback quota
-  // change, so consumers (e.g. the OpenCode sidebar) can re-render without a
-  // request flowing through the fetch handler.
-  onFallbackQuotaFetched?: () => void
+  // Invoked after a background quota pass persists at least one fallback storage
+  // change (token refresh, quota update, or error recording), so consumers
+  // (e.g. the OpenCode sidebar) can re-render without a request flowing through
+  // the fetch handler.
+  onFallbackStorageChanged?: () => void
 }
 
 export type AccountRefreshError = {
@@ -982,14 +983,14 @@ export class FallbackAccountManager {
   private refreshTimer: ReturnType<typeof setInterval> | null = null
   private quotaTimer: ReturnType<typeof setInterval> | null = null
   readonly quotaManager: import('./quota-manager.ts').QuotaManager | null
-  private readonly onFallbackQuotaFetched: (() => void) | undefined
+  private readonly onFallbackStorageChanged: (() => void) | undefined
 
   constructor(options: AccountManagerOptions = {}) {
     this.now = options.now ?? Date.now
     this.fetchImpl = options.fetchImpl ?? fetch
     this.configPath = options.configPath ?? getAccountStoragePath()
     this.quotaManager = options.quotaManager ?? null
-    this.onFallbackQuotaFetched = options.onFallbackQuotaFetched
+    this.onFallbackStorageChanged = options.onFallbackStorageChanged
   }
 
   /**
@@ -1241,7 +1242,7 @@ export class FallbackAccountManager {
     }
     if (changed) {
       await this.save(storage)
-      this.onFallbackQuotaFetched?.()
+      this.onFallbackStorageChanged?.()
     }
   }
 

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -355,6 +355,13 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
   setDumpEnabled(isDumpPersistentlyEnabled(initialStorage))
   setFastModeEnabled(isFastModePersistentlyEnabled(initialStorage))
 
+  // Remembers the last explicit routing decision so quota-only sidebar refreshes
+  // (background main/fallback quota landing) do not reset the active account.
+  let lastSidebarRouting: { activeId: string | undefined; route: string } = {
+    activeId: 'main',
+    route: 'main',
+  }
+
   function writeSidebarState(
     storage: Awaited<ReturnType<typeof loadAccounts>>,
     options: {
@@ -364,6 +371,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       mainRefreshToken?: string
     },
   ) {
+    lastSidebarRouting = { activeId: options.activeId, route: options.route }
     const mainEntry = quotaManager.getMain(options.mainAccessToken)
     const lastApiError = quotaManager.getLastApiError()
     const mainRefreshError = storage?.refresh?.mainLastRefreshError
@@ -423,6 +431,30 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
         error: error instanceof Error ? error.message : String(error),
       }),
     )
+  }
+
+  // Re-write the sidebar using the LAST known routing decision, refreshing only
+  // the quota numbers. Used by async quota refreshes (main + background fallback)
+  // so they never clobber the active account back to 'main'.
+  async function refreshSidebarQuota() {
+    const storage = await loadAccounts(accountStoragePath)
+    let access: string | undefined
+    let refresh: string | undefined
+    if (latestGetAuth) {
+      try {
+        const auth = await latestGetAuth()
+        access = auth.access
+        refresh = auth.refresh
+      } catch {
+        // best-effort
+      }
+    }
+    writeSidebarState(storage, {
+      activeId: lastSidebarRouting.activeId,
+      route: lastSidebarRouting.route,
+      mainAccessToken: access,
+      mainRefreshToken: refresh,
+    })
   }
 
   let latestGetAuth:
@@ -1690,14 +1722,9 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                     // sidebar again once the new main quota lands.
                     void quotaManager
                       .refreshMain(auth.access)
-                      .then(() =>
-                        writeSidebarState(storage, {
-                          activeId: 'main',
-                          route: 'main',
-                          mainAccessToken: auth.access,
-                          mainRefreshToken: auth.refresh,
-                        }),
-                      )
+                      .then(() => {
+                        void refreshSidebarQuota()
+                      })
                       .catch(() => {})
                   }
                   // Update the sidebar every replayable request so fallback

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -306,6 +306,9 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
   })
   const fallbackManager = new FallbackAccountManager({
     quotaManager,
+    onFallbackQuotaFetched: () => {
+      void refreshSidebarQuota()
+    },
   })
   fallbackManager.startBackgroundRefresh()
   let latestRefreshMainAccessToken: (() => Promise<string>) | null = null

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -306,7 +306,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
   })
   const fallbackManager = new FallbackAccountManager({
     quotaManager,
-    onFallbackQuotaFetched: () => {
+    onFallbackStorageChanged: () => {
       void refreshSidebarQuota()
     },
   })

--- a/packages/opencode/src/sidebar-state.ts
+++ b/packages/opencode/src/sidebar-state.ts
@@ -88,6 +88,10 @@ export function resolveActiveAccount(state: SidebarState): {
 } {
   const activeId = state.activeId
   if (activeId && activeId !== 'main') {
+    // `account.enabled` is defensive: writeSidebarState already filters disabled
+    // accounts out of state.fallbacks, so in normal operation every entry is
+    // enabled. Kept so this pure helper stays correct for any caller and is
+    // exercised directly by the unit tests.
     const fallback = state.fallbacks.find(
       (account) => account.enabled && account.id === activeId,
     )

--- a/packages/opencode/src/sidebar-state.ts
+++ b/packages/opencode/src/sidebar-state.ts
@@ -77,3 +77,27 @@ export async function setSidebarState(state: SidebarState): Promise<void> {
     // Best-effort — sidebar is non-critical
   }
 }
+
+// Resolve the currently-active account from activeId for the collapsed sidebar
+// view. activeId === 'main' (or undefined/unmatched/disabled) → the main
+// account; otherwise the enabled fallback whose id matches.
+export function resolveActiveAccount(state: SidebarState): {
+  id: string
+  name: string
+  quota: AccountQuota | null
+} {
+  const activeId = state.activeId
+  if (activeId && activeId !== 'main') {
+    const fallback = state.fallbacks.find(
+      (account) => account.enabled && account.id === activeId,
+    )
+    if (fallback) {
+      return {
+        id: fallback.id,
+        name: fallback.label ?? fallback.id,
+        quota: fallback.quota,
+      }
+    }
+  }
+  return { id: 'main', name: 'main', quota: state.main.quota }
+}

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -707,6 +707,49 @@ describe('FallbackAccountManager', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
+  test('refreshQuotaForDueAccounts fires onFallbackQuotaFetched when quota changes', async () => {
+    const storage = baseStorage()
+    storage.accounts.push({
+      id: 'idle-stale',
+      type: 'oauth',
+      access: 'idle-access',
+      refresh: 'idle-refresh',
+      expires: 20_000_000,
+      quota: {
+        // checkedAt far in the past → stale → will be refreshed this pass.
+        five_hour: { usedPercent: 5, remainingPercent: 95, checkedAt: 1 },
+        seven_day: { usedPercent: 5, remainingPercent: 95, checkedAt: 1 },
+      },
+    })
+    await saveAccounts(storage)
+
+    const fetchImpl = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            five_hour: { utilization: 40 },
+            seven_day: { utilization: 30 },
+          }),
+          { status: 200 },
+        ),
+      ),
+    ) as unknown as typeof fetch
+
+    let fired = 0
+    const manager = new FallbackAccountManager({
+      fetchImpl,
+      now: () => 50_000_000, // well past checkedAt → stale
+      onFallbackQuotaFetched: () => {
+        fired += 1
+      },
+    })
+
+    await manager.refreshQuotaForDueAccounts()
+
+    expect(fetchImpl).toHaveBeenCalled()
+    expect(fired).toBe(1)
+  })
+
   test('refreshes fallback token and retries quota check after stale access token 401', async () => {
     const storage = baseStorage()
     storage.accounts.push({

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -707,7 +707,7 @@ describe('FallbackAccountManager', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
-  test('refreshQuotaForDueAccounts fires onFallbackQuotaFetched when quota changes', async () => {
+  test('refreshQuotaForDueAccounts fires onFallbackStorageChanged when storage changes', async () => {
     const storage = baseStorage()
     storage.accounts.push({
       id: 'idle-stale',
@@ -739,7 +739,7 @@ describe('FallbackAccountManager', () => {
     const manager = new FallbackAccountManager({
       fetchImpl,
       now: () => 50_000_000, // well past checkedAt → stale
-      onFallbackQuotaFetched: () => {
+      onFallbackStorageChanged: () => {
         fired += 1
       },
     })

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -2774,4 +2774,70 @@ describe('auth.loader', () => {
     expect(response.status).toBe(429)
     expect(calls).toBe(1)
   })
+
+  test('background fallback refresh updates the sidebar without a request', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({
+        accounts: [
+          {
+            id: 'fallback-1',
+            type: 'oauth',
+            access: 'fallback-access',
+            refresh: 'fallback-refresh',
+            expires: Date.now() + 5 * 60 * 60 * 1000,
+            quota: {
+              // Stale (old checkedAt) → background pass will refresh it.
+              five_hour: {
+                usedPercent: 0,
+                remainingPercent: 100,
+                checkedAt: 1,
+              },
+              seven_day: {
+                usedPercent: 0,
+                remainingPercent: 100,
+                checkedAt: 1,
+              },
+            },
+          },
+        ],
+      }),
+    )
+
+    globalThis.fetch = mock((input: any) => {
+      if (extractUrl(input).includes('/api/oauth/usage')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              five_hour: { utilization: 0.42 },
+              seven_day: { utilization: 0.1 },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response('ok', { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    // Running the loader starts the background refresh (immediate first pass).
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+
+    // The background pass refreshes the stale fallback and the hook re-writes the
+    // sidebar — without any request to the messages endpoint.
+    // utilization: 0.42 → usedPercent: 0.42 (stored as-is, not multiplied by 100)
+    const state = await waitForSidebarState(
+      (candidate) =>
+        candidate.fallbacks[0]?.quota?.five_hour?.usedPercent === 0.42,
+    )
+    expect(state.fallbacks[0]?.id).toBe('fallback-1')
+  })
 })

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -9,6 +9,7 @@ import {
   resetDumpState,
   resetFastModeState,
   saveAccounts,
+  tokenFingerprint,
 } from '@cortexkit/anthropic-auth-core'
 import { AnthropicAuthPlugin } from '../index'
 import { getSidebarState } from '../sidebar-state'
@@ -2536,6 +2537,89 @@ describe('auth.loader', () => {
     } finally {
       Date.now = originalDateNow
     }
+  })
+
+  test('async main refresh does not clobber the active fallback in the sidebar', async () => {
+    const staleCheckedAt = Date.now() - 100 * 60_000 // far past → main quota is stale
+    await useTempAccountFile(
+      createFallbackStorage({
+        quota: {
+          enabled: true,
+          checkIntervalMinutes: 5,
+          minimumRemaining: { five_hour: 10, seven_day: 20 },
+          failClosedOnUnknownQuota: true,
+          // Cached, stale, and FAILING five_hour policy (used 95% → remaining 5% < 10%).
+          mainQuota: {
+            five_hour: {
+              usedPercent: 95,
+              remainingPercent: 5,
+              checkedAt: staleCheckedAt,
+            },
+            seven_day: {
+              usedPercent: 10,
+              remainingPercent: 90,
+              checkedAt: staleCheckedAt,
+            },
+          },
+          mainQuotaCheckedAt: staleCheckedAt,
+          // Bind the cached main quota to the access token the loader will use.
+          mainQuotaToken: tokenFingerprint('main-access'),
+        } as AccountStorage['quota'],
+      }),
+    )
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/api/oauth/usage')) {
+        // Delay the background main refresh so it settles AFTER the fallback
+        // write — this is the race that causes the clobber in production.
+        return Bun.sleep(40).then(
+          () =>
+            new Response(
+              JSON.stringify({
+                five_hour: { utilization: 0.95 },
+                seven_day: { utilization: 0.1 },
+              }),
+              { status: 200 },
+            ),
+        )
+      }
+      // Anthropic messages call — fallback serves 200, main would not be reached.
+      return Promise.resolve(new Response('ok', { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+
+    await result.fetch(MESSAGES_URL, {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'claude-opus-4-8',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    })
+
+    // Fallback served → active id should be the fallback.
+    const state = await waitForSidebarState(
+      (candidate) => candidate.activeId === 'fallback-1',
+    )
+    expect(state.route).toBe('fallback')
+
+    // Let the fire-and-forget refreshMain().then(...) settle.
+    await Bun.sleep(80)
+
+    // REGRESSION: pre-fix the async callback rewrites activeId to 'main'.
+    const after = await getSidebarState()
+    expect(after.activeId).toBe('fallback-1')
   })
 
   test('fetch wrapper retries with fallback when main streaming body reports rate limit', async () => {

--- a/packages/opencode/src/tests/sidebar-state.test.ts
+++ b/packages/opencode/src/tests/sidebar-state.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  type AccountQuota,
+  DEFAULT_SIDEBAR_STATE,
+  resolveActiveAccount,
+  type SidebarState,
+} from '../sidebar-state'
+
+const quota = (used: number): AccountQuota => ({
+  five_hour: { usedPercent: used, remainingPercent: 100 - used },
+  seven_day: { usedPercent: used, remainingPercent: 100 - used },
+})
+
+function make(overrides: Partial<SidebarState>): SidebarState {
+  return { ...DEFAULT_SIDEBAR_STATE, ...overrides }
+}
+
+describe('resolveActiveAccount', () => {
+  test('activeId "main" resolves to the main account', () => {
+    const state = make({ activeId: 'main', main: { quota: quota(20) } })
+    const active = resolveActiveAccount(state)
+    expect(active.id).toBe('main')
+    expect(active.name).toBe('main')
+    expect(active.quota?.five_hour?.usedPercent).toBe(20)
+  })
+
+  test('activeId matching an enabled fallback resolves to that fallback (label name)', () => {
+    const state = make({
+      activeId: 'fb1',
+      fallbacks: [
+        { id: 'fb1', label: 'work', quota: quota(40), enabled: true },
+      ],
+    })
+    const active = resolveActiveAccount(state)
+    expect(active.id).toBe('fb1')
+    expect(active.name).toBe('work')
+    expect(active.quota?.five_hour?.usedPercent).toBe(40)
+  })
+
+  test('fallback without a label uses its id as the name', () => {
+    const state = make({
+      activeId: 'fb1',
+      fallbacks: [
+        { id: 'fb1', label: undefined, quota: quota(5), enabled: true },
+      ],
+    })
+    expect(resolveActiveAccount(state).name).toBe('fb1')
+  })
+
+  test('activeId matching a DISABLED fallback falls back to main', () => {
+    const state = make({
+      activeId: 'fb1',
+      main: { quota: quota(12) },
+      fallbacks: [
+        { id: 'fb1', label: 'work', quota: quota(40), enabled: false },
+      ],
+    })
+    const active = resolveActiveAccount(state)
+    expect(active.id).toBe('main')
+    expect(active.quota?.five_hour?.usedPercent).toBe(12)
+  })
+
+  test('undefined activeId resolves to main', () => {
+    const state = make({ activeId: undefined, main: { quota: quota(7) } })
+    expect(resolveActiveAccount(state).id).toBe('main')
+  })
+
+  test('unmatched activeId resolves to main', () => {
+    const state = make({
+      activeId: 'ghost',
+      main: { quota: null },
+      fallbacks: [
+        { id: 'fb1', label: 'work', quota: quota(40), enabled: true },
+      ],
+    })
+    const active = resolveActiveAccount(state)
+    expect(active.id).toBe('main')
+    expect(active.quota).toBeNull()
+  })
+})

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -339,93 +339,134 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
         </Show>
       </box>
 
-      <Show
-        when={hasData()}
-        fallback={
-          <box marginTop={1} width='100%'>
-            <text fg={theme().textMuted}>{'Waiting for quota\u2026'}</text>
-          </box>
-        }
-      >
-        {/* Quota */}
-        <SectionHeader theme={theme()} title='Quota' />
-        <AccountBlock
-          theme={theme()}
-          name='main'
-          quota={state().main.quota}
-          active={state().activeId === 'main'}
-        />
-        <For each={enabledFallbacks()}>
-          {(fb) => (
-            <AccountBlock
-              theme={theme()}
-              name={fb.label ?? fb.id}
-              quota={fb.quota}
-              active={state().activeId === fb.id}
-              marginTop={1}
-            />
-          )}
-        </For>
+      {/* Collapsed: active account 5h quota + dot, plus fast-mode when on */}
+      <Show when={collapsed() && hasData()}>
+        <CollapsedRow theme={theme()} label={activeAccount().name}>
+          <Show
+            when={activeFiveHourPct() != null}
+            fallback={<text fg={theme().textMuted}>{'\u2014'}</text>}
+          >
+            <box flexDirection='row'>
+              <text
+                fg={toneColor(
+                  theme(),
+                  usageTone(activeFiveHourPct() as number),
+                )}
+              >
+                <b>
+                  {`${String(Math.round(activeFiveHourPct() as number)).padStart(3)}%`}
+                </b>
+              </text>
+              <text
+                fg={toneColor(
+                  theme(),
+                  usageTone(activeFiveHourPct() as number),
+                )}
+              >
+                {' \u25cf'}
+              </text>
+            </box>
+          </Show>
+        </CollapsedRow>
+        <Show when={state().fastMode}>
+          <CollapsedRow theme={theme()} label='Mode'>
+            <text fg={toneColor(theme(), 'accent')}>
+              <b>{'fast'}</b>
+            </text>
+          </CollapsedRow>
+        </Show>
       </Show>
 
-      {/* Routing */}
-      <SectionHeader theme={theme()} title='Routing' />
-      <StatRow
-        theme={theme()}
-        label='Route'
-        value={state().route}
-        tone='accent'
-      />
-      <StatRow
-        theme={theme()}
-        label='Mode'
-        value={state().fastMode ? 'fast' : 'std'}
-        tone={state().fastMode ? 'accent' : 'muted'}
-      />
-      <StatRow
-        theme={theme()}
-        label='Relay'
-        value={relayValue()}
-        tone={state().relay?.enabled ? 'ok' : 'muted'}
-      />
+      {/* Expanded: full sections, hidden when collapsed */}
+      <Show when={!collapsed()}>
+        <Show
+          when={hasData()}
+          fallback={
+            <box marginTop={1} width='100%'>
+              <text fg={theme().textMuted}>{'Waiting for quota\u2026'}</text>
+            </box>
+          }
+        >
+          {/* Quota */}
+          <SectionHeader theme={theme()} title='Quota' />
+          <AccountBlock
+            theme={theme()}
+            name='main'
+            quota={state().main.quota}
+            active={state().activeId === 'main'}
+          />
+          <For each={enabledFallbacks()}>
+            {(fb) => (
+              <AccountBlock
+                theme={theme()}
+                name={fb.label ?? fb.id}
+                quota={fb.quota}
+                active={state().activeId === fb.id}
+                marginTop={1}
+              />
+            )}
+          </For>
+        </Show>
 
-      {/* Cache */}
-      <Show when={showCache()}>
-        <SectionHeader theme={theme()} title='Cache' />
+        {/* Routing */}
+        <SectionHeader theme={theme()} title='Routing' />
         <StatRow
           theme={theme()}
-          label='1h cache'
-          value={`${cacheKeep()?.window} \u00b7 ${cacheKeep()?.enabled ? 'on' : 'off'}`}
-          tone={cacheKeep()?.enabled ? 'ok' : 'muted'}
+          label='Route'
+          value={state().route}
+          tone='accent'
         />
-        <Show when={(cacheKeep()?.trackedSessions ?? 0) > 0}>
-          <StatRow
-            theme={theme()}
-            label='Tracked'
-            value={String(cacheKeep()?.trackedSessions)}
-            tone='text'
-          />
-        </Show>
-      </Show>
+        <StatRow
+          theme={theme()}
+          label='Mode'
+          value={state().fastMode ? 'fast' : 'std'}
+          tone={state().fastMode ? 'accent' : 'muted'}
+        />
+        <StatRow
+          theme={theme()}
+          label='Relay'
+          value={relayValue()}
+          tone={state().relay?.enabled ? 'ok' : 'muted'}
+        />
 
-      {/* Health — only when something is wrong */}
-      <Show when={degraded()}>
-        <SectionHeader theme={theme()} title='Health' />
-        <Show when={quotaBackedOff()}>
+        {/* Cache */}
+        <Show when={showCache()}>
+          <SectionHeader theme={theme()} title='Cache' />
           <StatRow
             theme={theme()}
-            label='Quota API'
-            value={`backoff ${formatUntil(state().main.quotaBackoffUntil)}`}
-            tone='warn'
+            label='1h cache'
+            value={`${cacheKeep()?.window} \u00b7 ${cacheKeep()?.enabled ? 'on' : 'off'}`}
+            tone={cacheKeep()?.enabled ? 'ok' : 'muted'}
           />
+          <Show when={(cacheKeep()?.trackedSessions ?? 0) > 0}>
+            <StatRow
+              theme={theme()}
+              label='Tracked'
+              value={String(cacheKeep()?.trackedSessions)}
+              tone='text'
+            />
+          </Show>
         </Show>
-        <Show when={refreshBackedOff()}>
-          <StatRow
-            theme={theme()}
-            label='Token refresh'
-            value={`backoff ${formatUntil(state().main.refreshBackoffUntil)}`}
-            tone='warn'
-          />
+
+        {/* Health — only when something is wrong */}
+        <Show when={degraded()}>
+          <SectionHeader theme={theme()} title='Health' />
+          <Show when={quotaBackedOff()}>
+            <StatRow
+              theme={theme()}
+              label='Quota API'
+              value={`backoff ${formatUntil(state().main.quotaBackoffUntil)}`}
+              tone='warn'
+            />
+          </Show>
+          <Show when={refreshBackedOff()}>
+            <StatRow
+              theme={theme()}
+              label='Token refresh'
+              value={`backoff ${formatUntil(state().main.refreshBackoffUntil)}`}
+              tone='warn'
+            />
+          </Show>
         </Show>
       </Show>
     </box>

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -305,6 +305,7 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
       paddingRight={1}
     >
       {/* Header: ▼/▶ CLAUDE badge (click to collapse) + version, or LIMITED badge */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: opentui renders to a terminal, not the DOM — ARIA roles do not apply */}
       <box
         width='100%'
         flexDirection='row'

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -377,8 +377,9 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
         </Show>
       </Show>
 
-      {/* Expanded: full sections, hidden when collapsed */}
-      <Show when={!collapsed()}>
+      {/* Expanded: full sections. Also render when there's no data so the
+          sidebar can never go blank if data clears while collapsed. */}
+      <Show when={!collapsed() || !hasData()}>
         <Show
           when={hasData()}
           fallback={

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -1,17 +1,21 @@
 /** @jsxImportSource @opentui/solid */
 
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import type {
   TuiPlugin,
   TuiPluginApi,
   TuiPluginModule,
 } from '@opencode-ai/plugin/tui'
-import { For, Show, createSignal, onCleanup } from 'solid-js'
+import { For, type JSX, Show, createSignal, onCleanup } from 'solid-js'
 
 import {
   type AccountQuota,
   DEFAULT_SIDEBAR_STATE,
   type SidebarState,
   getSidebarState,
+  resolveActiveAccount,
 } from './sidebar-state.js'
 
 const POLL_MS = 1500
@@ -21,6 +25,20 @@ const ID = 'cortexkit.anthropic-auth'
 const BAR_WIDTH = 10
 const BAR_FILLED = '\u2588'
 const BAR_EMPTY = '\u2591'
+
+// Plugin version for the header (mirrors the Magic Context / AFT convention).
+// Read at runtime from package.json relative to this module — NOT a TS JSON
+// import, which would break the declaration build (package.json is outside
+// rootDir). Empty string on any failure → header shows the badge with no version.
+const PLUGIN_VERSION: string = (() => {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const raw = readFileSync(join(here, '..', 'package.json'), 'utf8')
+    return (JSON.parse(raw) as { version?: string }).version ?? ''
+  } catch {
+    return ''
+  }
+})()
 
 // biome-ignore lint/suspicious/noExplicitAny: opentui border prop not typed in plugin tui surface
 const SINGLE_BORDER = { type: 'single' } as any
@@ -116,6 +134,21 @@ function StatRow(props: {
   )
 }
 
+// Compact row for the collapsed view: muted label left, caller-provided value
+// right. Mirrors StatRow's layout so columns line up.
+function CollapsedRow(props: {
+  theme: ThemeCurrent
+  label: string
+  children: JSX.Element
+}) {
+  return (
+    <box width='100%' flexDirection='row' justifyContent='space-between'>
+      <text fg={props.theme.textMuted}>{props.label}</text>
+      {props.children}
+    </box>
+  )
+}
+
 // Quota window row: muted label left, tone-colored bar + percentage right,
 // with an optional muted reset suffix.
 function QuotaRow(props: {
@@ -203,6 +236,7 @@ async function readStateFromFile(): Promise<SidebarState> {
 
 function QuotaSidebar(props: { api: TuiPluginApi }) {
   const [state, setState] = createSignal<SidebarState>(DEFAULT_SIDEBAR_STATE)
+  const [collapsed, setCollapsed] = createSignal(false)
   let lastUpdated = 0
   let debounce: ReturnType<typeof setTimeout> | null = null
 
@@ -241,6 +275,12 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
   const hasData = () =>
     state().main.quota != null || enabledFallbacks().length > 0
 
+  const headerLabel = () =>
+    !hasData() ? 'CLAUDE' : collapsed() ? '\u25b6 CLAUDE' : '\u25bc CLAUDE'
+  const activeAccount = () => resolveActiveAccount(state())
+  const activeFiveHourPct = () =>
+    activeAccount().quota?.five_hour?.usedPercent ?? null
+
   const quotaBackedOff = () => state().main.quotaBackedOff === true
   const refreshBackedOff = () => state().main.refreshBackedOff === true
   const degraded = () => quotaBackedOff() || refreshBackedOff()
@@ -264,19 +304,29 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
       paddingLeft={1}
       paddingRight={1}
     >
-      {/* Header: CLAUDE badge + optional LIMITED degraded badge */}
+      {/* Header: ▼/▶ CLAUDE badge (click to collapse) + version, or LIMITED badge */}
       <box
         width='100%'
         flexDirection='row'
         justifyContent='space-between'
         alignItems='center'
+        onMouseDown={() => {
+          if (hasData()) setCollapsed((value) => !value)
+        }}
       >
         <box paddingLeft={1} paddingRight={1} backgroundColor={theme().accent}>
           <text fg={theme().background}>
-            <b>{'CLAUDE'}</b>
+            <b>{headerLabel()}</b>
           </text>
         </box>
-        <Show when={degraded()}>
+        <Show
+          when={degraded()}
+          fallback={
+            <Show when={PLUGIN_VERSION !== ''}>
+              <text fg={theme().textMuted}>{`v${PLUGIN_VERSION}`}</text>
+            </Show>
+          }
+        >
           <box
             paddingLeft={1}
             paddingRight={1}

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -29,7 +29,10 @@ const BAR_EMPTY = '\u2591'
 // Plugin version for the header (mirrors the Magic Context / AFT convention).
 // Read at runtime from package.json relative to this module — NOT a TS JSON
 // import, which would break the declaration build (package.json is outside
-// rootDir). Empty string on any failure → header shows the badge with no version.
+// rootDir). tui.tsx ships as source (package.json exports["./tui"] →
+// "./src/tui.tsx") and is never compiled into a deeper dist tree, so `..` from
+// src/ is always the package root. Empty string on any failure → header shows
+// the badge with no version.
 const PLUGIN_VERSION: string = (() => {
   try {
     const here = dirname(fileURLToPath(import.meta.url))


### PR DESCRIPTION
## Summary
Adds a click-to-collapse toggle to the OpenCode quota sidebar, mirroring cortexkit's `aft` plugin.

- Local, non-persisted collapse state; `onMouseDown` on the header toggles it (resets to expanded on restart).
- Header: `▼`/`▶ CLAUDE` glyph + plugin version (or the `LIMITED` badge when degraded).
- Collapsed view: the active account's name + 5h usage `% ●` (usage-toned), plus a `Mode  fast` row when fast mode is on. Em dash when no 5h window.
- Expanded view unchanged, gated on `!collapsed() || !hasData()` so it never goes blank.
- `resolveActiveAccount` pure helper (unit-tested) resolves the active account from `activeId`.

## Changes
- `packages/opencode/src/sidebar-state.ts` — `resolveActiveAccount` helper.
- `packages/opencode/src/tui.tsx` — collapse signal, header (glyph + version), collapsed render.
- `README.md` — sidebar docs.

## Tests
- 6 unit tests for `resolveActiveAccount`. Full suite green (typecheck + test + build).

## Dependency
Stacked on #57 (stale fallback quota / clobbered active account). The collapsed view shows the **active** account, which relies on the BUG 2 `activeId` fix in #57. **Merge #57 first** — until then this PR's diff includes #57's commits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783145586&installation_id=135454708&pr_number=58&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F58&signature=455793b7db5ece83450240c25e50d6f323f77fd7861319438f3f1d690484fbeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a click-to-collapse toggle to the OpenCode quota sidebar with a compact view and versioned header. Preserves the active fallback during async quota refreshes and live-updates after background fallback storage changes.

- New Features
  - Click the `CLAUDE` header to collapse/expand; shows `▼/▶` and `v{version}` (read from `package.json`) or `LIMITED` when degraded.
  - Collapsed view: active account name, 5h usage percent with tone dot, plus a `Mode fast` row when enabled. Collapse state is per session.
  - `resolveActiveAccount` selects the active account for the collapsed view (with a defensive enabled guard).
  - Sidebar stays visible when data clears while collapsed.

- Bug Fixes
  - Prevent async main quota refresh from clobbering the active fallback by reusing the last routing via `refreshSidebarQuota`.
  - Refresh sidebar quota after background fallback storage changes via `onFallbackStorageChanged`, without a request.
  - Suppress a false-positive a11y lint warning on the interactive header box.

<sup>Written for commit 5959f4583b57df0c9b0a3a0bc477ef220a9d915c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a click-to-collapse toggle to the OpenCode quota sidebar and fixes a bug where async background quota refreshes would clobber the active fallback account in the sidebar state. The collapse state is session-local, the header gains a `▼/▶` glyph plus plugin version (or `LIMITED` badge when degraded), and the collapsed view shows the active account's 5h usage.

- **Collapse toggle** (`tui.tsx`): A `collapsed` Solid signal toggles on `onMouseDown` only when `hasData()` is true; collapsed and expanded views are gated with complementary `Show` predicates so the sidebar never goes blank when data clears while collapsed.
- **Clobber fix** (`index.ts`): `lastSidebarRouting` captures the last explicit routing decision; `refreshSidebarQuota()` replays it during async quota refreshes instead of unconditionally resetting `activeId` to `'main'`.
- **`resolveActiveAccount`** (`sidebar-state.ts`): New pure helper with 6 unit tests mapping `activeId` → `{id, name, quota}` for the collapsed view; `onFallbackStorageChanged` callback in `accounts.ts` triggers a sidebar re-render after background storage saves.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are confined to TUI rendering and sidebar state plumbing, with no load-bearing auth or quota logic altered.

All new code paths are guarded (null checks on latestGetAuth, hasData() gate on collapse toggle, defensive enabled check in resolveActiveAccount), the clobber fix is straightforward and well-tested with a timing-sensitive integration test, and the reactive patterns in tui.tsx are idiomatic Solid.js. No data-loss or auth boundary concerns introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/opencode/src/tui.tsx | Adds collapsed signal, CollapsedRow component, header glyph + version display, and conditional collapsed/expanded rendering; reactive patterns are correct for Solid.js. |
| packages/opencode/src/index.ts | Introduces lastSidebarRouting and refreshSidebarQuota to prevent async quota refreshes from clobbering the active fallback account in the sidebar; logic and guards are sound. |
| packages/opencode/src/sidebar-state.ts | Adds resolveActiveAccount pure helper; correctly handles main/undefined/unmatched/disabled-fallback cases with a well-placed defensive guard. |
| packages/core/src/accounts.ts | Threads onFallbackStorageChanged callback through FallbackAccountManager; callback fires once after save() when storage changes, sequencing is correct. |
| packages/opencode/src/tests/index.test.ts | Adds two integration tests covering the async-clobber regression and background-fallback-refresh-updates-sidebar scenarios; timing approach with Bun.sleep is reasonable. |
| packages/opencode/src/tests/sidebar-state.test.ts | New unit test file covering all resolveActiveAccount branches including main, enabled/disabled fallback, undefined, and unmatched activeId. |
| packages/opencode/src/tests/accounts.test.ts | Adds test verifying onFallbackStorageChanged fires exactly once when refreshQuotaForDueAccounts saves a changed storage; correctly validates the new callback contract. |
| README.md | Single-sentence doc addition for the collapse toggle; accurate and concise. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(opencode): clarify version path lay..."](https://github.com/cortexkit/anthropic-auth/commit/5959f4583b57df0c9b0a3a0bc477ef220a9d915c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35556628)</sub>

<!-- /greptile_comment -->