### PR TITLE
feat(opencode): gate OAuth cost zeroing behind opt-out config

### DIFF
--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -149,6 +149,14 @@ export type AccountStorage = {
   claudeFast?: {
     enabled?: boolean
   }
+  /**
+   * Zero out Anthropic OAuth model costs in the provider hook. Default: enabled
+   * (OAuth usage is quota-based, not per-token billed, so costs show as $0).
+   * Set `enabled: false` to opt out and display the provider's real model costs.
+   */
+  costZeroing?: {
+    enabled?: boolean
+  }
   cacheKeep?: {
     enabled?: boolean
     startHour?: number
@@ -163,6 +171,17 @@ export type AccountStorage = {
   }
   killswitch?: KillswitchConfig
   accounts: FallbackAccount[]
+}
+
+/**
+ * Whether Anthropic OAuth model costs should be zeroed in the provider hook.
+ * Defaults to enabled; only an explicit `costZeroing.enabled === false` opts out
+ * (to display the provider's real model costs).
+ */
+export function isCostZeroingEnabled(
+  storage: Pick<AccountStorage, 'costZeroing'>,
+): boolean {
+  return storage.costZeroing?.enabled !== false
 }
 
 export type AccountRuntimeEntry = Partial<
@@ -393,6 +412,7 @@ function normalizeStorage(value: unknown): AccountStorage | null {
     claudeCache: isRecord(value.claudeCache) ? value.claudeCache : undefined,
     dump: isRecord(value.dump) ? value.dump : undefined,
     claudeFast: isRecord(value.claudeFast) ? value.claudeFast : undefined,
+    costZeroing: isRecord(value.costZeroing) ? value.costZeroing : undefined,
     cacheKeep: isRecord(value.cacheKeep) ? value.cacheKeep : undefined,
     relay: isRecord(value.relay) ? value.relay : undefined,
     killswitch: isRecord(value.killswitch) ? value.killswitch : undefined,
@@ -545,6 +565,7 @@ function configFromStorage(storage: AccountStorage): Record<string, unknown> {
     claudeCache: storage.claudeCache,
     dump: storage.dump,
     claudeFast: storage.claudeFast,
+    costZeroing: storage.costZeroing,
     cacheKeep: storage.cacheKeep,
     relay: storage.relay,
     killswitch: storage.killswitch,

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -44,6 +44,7 @@ import {
   isCache1hPersistentlyEnabled,
   isCacheKeepHybridActive,
   isCacheKeepPersistentlyEnabled,
+  isCostZeroingEnabled,
   isDumpPersistentlyEnabled,
   isFastModeEnabled,
   isFastModePersistentlyEnabled,
@@ -945,7 +946,14 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
         context: { auth?: { type?: string } },
       ) {
         const models = addFableMythos5Models(provider.models)
-        if (context.auth?.type !== 'oauth') return models
+        // Zero OAuth model costs by default (quota-based, not per-token billed).
+        // Opt out via persisted config costZeroing.enabled=false to show real costs.
+        // initialStorage is nullable (no config file yet) → default to enabled.
+        if (
+          context.auth?.type !== 'oauth' ||
+          !isCostZeroingEnabled(initialStorage ?? {})
+        )
+          return models
         return zeroModelCosts(models)
       },
     },

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -10,6 +10,7 @@ import {
   FallbackAccountManager,
   getAccountStatePath,
   getCache1hPersistentMode,
+  isCostZeroingEnabled,
   isFastModePersistentlyEnabled,
   loadAccounts,
   type OAuthAccount,
@@ -62,6 +63,31 @@ afterEach(async () => {
   delete process.env.OPENCODE_ANTHROPIC_AUTH_FILE
   await rm(tempDir, { recursive: true, force: true })
   mock.restore()
+})
+
+describe('isCostZeroingEnabled', () => {
+  test('defaults to enabled when costZeroing is absent', () => {
+    expect(isCostZeroingEnabled(baseStorage())).toBe(true)
+  })
+
+  test('stays enabled when explicitly enabled', () => {
+    expect(isCostZeroingEnabled({ costZeroing: { enabled: true } })).toBe(true)
+  })
+
+  test('is disabled only when explicitly set to false', () => {
+    expect(isCostZeroingEnabled({ costZeroing: { enabled: false } })).toBe(
+      false,
+    )
+  })
+
+  test('persists across save/load round-trip', async () => {
+    const storage = baseStorage()
+    storage.costZeroing = { enabled: false }
+    await saveAccounts(storage)
+    const loaded = await loadAccounts()
+    expect(loaded!.costZeroing).toEqual({ enabled: false })
+    expect(isCostZeroingEnabled(loaded!)).toBe(false)
+  })
 })
 
 describe('account storage', () => {

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -383,6 +383,35 @@ describe('provider.models', () => {
       cache: { read: 1, write: 12.5 },
     })
   })
+
+  test('does not zero OAuth model costs when costZeroing is disabled', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({ accounts: [], costZeroing: { enabled: false } }),
+    )
+    const plugin = await getPlugin()
+    const models = {
+      'claude-opus-4-8': {
+        id: 'claude-opus-4-8',
+        name: 'Claude Opus 4.8',
+        cost: { input: 5, output: 25, cache: { read: 0.5, write: 6.25 } },
+        limit: { context: 1_000_000, output: 128_000 },
+        capabilities: { reasoning: true, attachment: true, toolcall: true },
+        release_date: '2026-01-01',
+      },
+    }
+
+    const result = await plugin.provider?.models?.(
+      { models } as never,
+      { auth: { type: 'oauth' } } as never,
+    )
+
+    // OAuth auth but opted out → real costs preserved, not zeroed.
+    expect(result?.['claude-opus-4-8']?.cost).toEqual({
+      input: 5,
+      output: 25,
+      cache: { read: 0.5, write: 6.25 },
+    })
+  })
 })
 
 describe('auth.loader', () => {


### PR DESCRIPTION
## Summary

Adds a persisted config flag to opt out of the OAuth model cost-zeroing introduced in `6f3aad1` ("Zero Anthropic OAuth model costs via provider hook").

- New `costZeroing?: { enabled?: boolean }` field on `AccountStorage` (parsed + persisted).
- New helper `isCostZeroingEnabled(storage)` → `storage.costZeroing?.enabled !== false` (**default: enabled** — behavior unchanged).
- The `provider.models` hook now zeroes OAuth model costs only when enabled; set `costZeroing.enabled = false` to display the provider's real model costs.
- No slash command — set via the persisted config (`~/.config/opencode/anthropic-auth.json`); takes effect on restart.

## Why

OAuth usage is quota-based (not per-token billed), so zeroing is the right default. But some users want real cost visibility (e.g. comparing model spend); this makes it opt-out without changing the default.

## Tests

- `isCostZeroingEnabled`: default-on, explicit-true, explicit-false, save/load round-trip.
- Integration: OAuth auth with `costZeroing.enabled=false` preserves real costs; existing default-on zeroing test still passes.
- typecheck + build + full suite green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783677959&installation_id=135454708&pr_number=59&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F59&signature=8c2b12def12529dd2cacaee87197bbd4f84c6e3781fd5f43dc180b4fb903ae4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an opt-out config to control OAuth model cost zeroing. Default stays on; set `costZeroing.enabled=false` to show real provider costs.

- **New Features**
  - Added `costZeroing?: { enabled?: boolean }` to `AccountStorage` (parsed and persisted).
  - Added `isCostZeroingEnabled(storage)` helper (enabled unless explicitly `false`).
  - Updated `provider.models` to zero OAuth costs only when enabled; opt out via `~/.config/opencode/anthropic-auth.json` and restart.

<sup>Written for commit 6f95278124c69b3efaceebce7d5b46e877f205a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

