### PR TITLE
perf(opencode): memoise system-prompt sanitation

### DIFF
--- a/packages/opencode/src/sanitize-memo.ts
+++ b/packages/opencode/src/sanitize-memo.ts
@@ -1,0 +1,74 @@
+export type SanitizeMemoStats = {
+  hits: number
+  misses: number
+  evictions: number
+  entries: number
+  cacheBytes: number
+  computeMsTotal: number
+}
+
+/**
+ * Generic byte-bounded LRU memo for a pure `(key: string) => string` function.
+ * - Hit: move-to-end (true LRU recency).
+ * - Miss: compute (timed), insert, then evict oldest until total bytes <= budget.
+ * - Oversize (single entry > budget): compute but do not cache (no thrash).
+ * - Disabled: bypass the cache; still record misses/computeMs (measurable baseline).
+ * Byte size is approximated by UTF-16 length (key.length + value.length).
+ */
+export function makeByteBoundedMemo(
+  fn: (key: string) => string,
+  opts: { maxBytes: number; enabled: () => boolean },
+): { call: (key: string) => string; stats: () => SanitizeMemoStats } {
+  const cache = new Map<string, string>()
+  let cacheBytes = 0
+  let hits = 0
+  let misses = 0
+  let evictions = 0
+  let computeMsTotal = 0
+
+  const compute = (key: string): string => {
+    const start = performance.now()
+    const value = fn(key)
+    computeMsTotal += performance.now() - start
+    misses++
+    return value
+  }
+
+  const call = (key: string): string => {
+    if (!opts.enabled()) return compute(key)
+
+    const cached = cache.get(key)
+    if (cached !== undefined) {
+      hits++
+      cache.delete(key)
+      cache.set(key, cached) // move-to-end: LRU recency
+      return cached
+    }
+
+    const value = compute(key)
+    const entryBytes = key.length + value.length
+    if (entryBytes > opts.maxBytes) return value // oversize: do not cache
+
+    cache.set(key, value)
+    cacheBytes += entryBytes
+    while (cacheBytes > opts.maxBytes && cache.size > 1) {
+      const oldestKey = cache.keys().next().value as string
+      const oldestValue = cache.get(oldestKey) ?? ''
+      cache.delete(oldestKey)
+      cacheBytes -= oldestKey.length + oldestValue.length
+      evictions++
+    }
+    return value
+  }
+
+  const stats = (): SanitizeMemoStats => ({
+    hits,
+    misses,
+    evictions,
+    entries: cache.size,
+    cacheBytes,
+    computeMsTotal,
+  })
+
+  return { call, stats }
+}

--- a/packages/opencode/src/tests/sanitize-memo.test.ts
+++ b/packages/opencode/src/tests/sanitize-memo.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test'
+import { makeByteBoundedMemo } from '../sanitize-memo'
+
+describe('makeByteBoundedMemo', () => {
+  test('computes on miss and returns cached value on hit (fn runs once)', () => {
+    let calls = 0
+    const memo = makeByteBoundedMemo(
+      (k) => {
+        calls++
+        return `<${k}>`
+      },
+      { maxBytes: 1024, enabled: () => true },
+    )
+    expect(memo.call('a')).toBe('<a>')
+    expect(memo.call('a')).toBe('<a>')
+    expect(calls).toBe(1)
+    const s = memo.stats()
+    expect(s.hits).toBe(1)
+    expect(s.misses).toBe(1)
+    expect(s.entries).toBe(1)
+  })
+
+  test('evicts oldest until under the byte budget (LRU recency on hit)', () => {
+    // entryBytes = key.length + value.length = 1 + 10 = 11; budget ~= 2 entries
+    const memo = makeByteBoundedMemo((k) => k.repeat(10), {
+      maxBytes: 24,
+      enabled: () => true,
+    })
+    memo.call('a')
+    memo.call('b')
+    memo.call('a') // hit -> 'a' becomes most-recently-used
+    memo.call('c') // insert -> evicts least-recently-used ('b')
+    const s = memo.stats()
+    expect(s.cacheBytes).toBeLessThanOrEqual(24)
+    expect(s.entries).toBeLessThanOrEqual(2)
+    expect(s.evictions).toBeGreaterThanOrEqual(1)
+    expect(s.hits).toBe(1)
+  })
+
+  test('does not cache an entry larger than the budget (oversize guard)', () => {
+    let calls = 0
+    const memo = makeByteBoundedMemo(
+      (k) => {
+        calls++
+        return k.repeat(100) // huge value
+      },
+      { maxBytes: 16, enabled: () => true },
+    )
+    expect(memo.call('x')).toBe('x'.repeat(100))
+    expect(memo.call('x')).toBe('x'.repeat(100))
+    expect(calls).toBe(2) // never cached -> recomputed each time
+    expect(memo.stats().entries).toBe(0)
+  })
+
+  test('disabled: bypasses cache but still records misses/computeMs', () => {
+    let calls = 0
+    const memo = makeByteBoundedMemo(
+      (k) => {
+        calls++
+        return k.toUpperCase()
+      },
+      { maxBytes: 1024, enabled: () => false },
+    )
+    expect(memo.call('a')).toBe('A')
+    expect(memo.call('a')).toBe('A')
+    expect(calls).toBe(2)
+    const s = memo.stats()
+    expect(s.hits).toBe(0)
+    expect(s.misses).toBe(2)
+    expect(s.entries).toBe(0)
+  })
+})

--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -9,6 +9,7 @@ import dedent from 'dedent'
 import {
   addFastModeBetaHeader,
   createStrippedStream,
+  getSanitizeMemoStats,
   isInsecure,
   mergeBetaHeaders,
   mergeHeaders,
@@ -640,6 +641,37 @@ describe('sanitizeSystemText', () => {
       Normal content.
     `)
     expect(onError).not.toHaveBeenCalled()
+  })
+
+  test('memoised output equals a fresh sanitation and is stable on repeat', () => {
+    const text = dedent`
+      You are OpenCode, an AI assistant.
+
+      Keep this paragraph intact.
+    `
+    const first = sanitizeSystemText(text)
+    const second = sanitizeSystemText(text)
+    expect(second).toBe(first)
+    // identity-bearing paragraph is still stripped (behaviour unchanged)
+    expect(first).not.toContain(OPENCODE_IDENTITY_PREFIX)
+  })
+
+  test('getSanitizeMemoStats records a hit on identical repeat input', () => {
+    // Force the memo on regardless of the ambient OPENCODE_ANTHROPIC_AUTH_MEMO
+    // env (baseline test runs may export =0, which would disable caching).
+    const prev = process.env.OPENCODE_ANTHROPIC_AUTH_MEMO
+    process.env.OPENCODE_ANTHROPIC_AUTH_MEMO = '1'
+    try {
+      const before = getSanitizeMemoStats()
+      const text = `unique-memo-probe-${Date.now()}`
+      sanitizeSystemText(text)
+      sanitizeSystemText(text)
+      const after = getSanitizeMemoStats()
+      expect(after.hits - before.hits).toBeGreaterThanOrEqual(1)
+    } finally {
+      if (prev === undefined) delete process.env.OPENCODE_ANTHROPIC_AUTH_MEMO
+      else process.env.OPENCODE_ANTHROPIC_AUTH_MEMO = prev
+    }
   })
 })
 

--- a/packages/opencode/src/transform.ts
+++ b/packages/opencode/src/transform.ts
@@ -18,6 +18,7 @@ import {
   TEXT_REPLACEMENTS,
   TOOL_PREFIX,
 } from '@cortexkit/anthropic-auth-core'
+import { makeByteBoundedMemo } from './sanitize-memo'
 
 /**
  * Prefix a tool name with TOOL_PREFIX and uppercase the first character.
@@ -333,7 +334,7 @@ export function rewriteUrl(
  * prompt — as long as the anchor strings (URLs, etc.) still appear
  * somewhere in the paragraph, the removal works.
  */
-export function sanitizeSystemText(text: string): string {
+function _sanitizeSystemText(text: string): string {
   // Split into paragraphs (separated by one or more blank lines)
   const paragraphs = text.split(/\n\n+/)
 
@@ -359,6 +360,30 @@ export function sanitizeSystemText(text: string): string {
   }
 
   return result.trim()
+}
+
+const SANITIZE_MEMO_MAX_BYTES = 8 * 1024 * 1024
+
+/** Memo on by default; OPENCODE_ANTHROPIC_AUTH_MEMO=0 disables (baseline). */
+function sanitizeMemoEnabled(): boolean {
+  return process.env.OPENCODE_ANTHROPIC_AUTH_MEMO !== '0'
+}
+
+const sanitizeSystemMemo = makeByteBoundedMemo(_sanitizeSystemText, {
+  maxBytes: SANITIZE_MEMO_MAX_BYTES,
+  enabled: sanitizeMemoEnabled,
+})
+
+/**
+ * Sanitize a system-prompt block. Memoised: the prompt is stable within a
+ * session, so the paragraph-filter + regex pass is skipped on cache hits.
+ */
+export function sanitizeSystemText(text: string): string {
+  return sanitizeSystemMemo.call(text)
+}
+
+export function getSanitizeMemoStats() {
+  return sanitizeSystemMemo.stats()
 }
 
 type SystemBlock = { type: string; text: string; [k: string]: unknown }


### PR DESCRIPTION
## Summary

Adds a bounded LRU memo around the system-prompt sanitation pass (`sanitizeSystemText`).

- New `packages/opencode/src/sanitize-memo.ts`: `makeByteBoundedMemo(fn, { maxBytes, enabled })` — a generic, byte-budget-bounded LRU (move-to-end on hit, evict-oldest when over budget, oversize entries computed-but-not-cached).
- `sanitizeSystemText` is wrapped by an 8 MB memo; `_sanitizeSystemText` holds the original pure logic. Exposes `getSanitizeMemoStats()`.
- Toggle via `OPENCODE_ANTHROPIC_AUTH_MEMO=0` (default on).

## Why

`sanitizeSystemText` runs the paragraph-removal filter + `TEXT_REPLACEMENTS` regex pass over the **full system prompt on every request**, even though the prompt is stable within a session. The replacement rules are static module constants, so the function is pure and safe to memoise — the cache returns byte-identical output and skips the redundant recompute on repeat prompts. Memory is hard-capped by the byte budget regardless of prompt size.

This is a redundant-work elimination (micro-optimization); it is orthogonal to the request/stream perf instrumentation added in v1.8.0.

## Tests

- Memo unit tests: hit avoids recompute, byte-budget eviction (LRU recency), oversize guard, disabled-bypass still records misses.
- `sanitizeSystemText` output unchanged (existing behavior tests pass); memo hit recorded on identical repeat input.
- typecheck + build + full suite green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783677973&installation_id=135454708&pr_number=60&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F60&signature=76571ad382d5e008173813ccfb998316148c4215c1eaf2cdedb236479e0899b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized system-prompt sanitation with a byte-bounded LRU to skip redundant recomputes and cap memory. `sanitizeSystemText` now uses an 8 MB cache with stats and an env toggle.

- **Refactors**
  - Added `makeByteBoundedMemo(fn, { maxBytes, enabled })` in `packages/opencode/src/sanitize-memo.ts` (string→string, true LRU, UTF‑16 byte budget, oversize guard).
  - Wrapped `_sanitizeSystemText` with an 8 MB memo; `sanitizeSystemText` now calls it and exposes `getSanitizeMemoStats()`.
  - Toggle via `OPENCODE_ANTHROPIC_AUTH_MEMO=0` (default on).
  - Tests cover hits, LRU eviction, oversize bypass, disabled path; sanitation output unchanged.

<sup>Written for commit c783840ceb8e8dff4083fa92e5d7c12f9bbc2901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

