### PR TITLE
fix(pi): skip primary SSE preflight when no fallbacks are configured

### DIFF
--- a/packages/pi/src/stream.ts
+++ b/packages/pi/src/stream.ts
@@ -1,4 +1,5 @@
 import {
+  type AccountStorage,
   type ApiKeyAccount,
   applyClaudeCodeHeaders,
   CACHE_KEEP_EXTENDED_TTL_BETA,
@@ -294,6 +295,12 @@ export function primaryResponseAllowsApiFallback(preflight: Response | string) {
   )
 }
 
+export function shouldPreflightPrimaryForFallback(
+  storage: AccountStorage | null,
+) {
+  return Boolean(storage?.accounts.length)
+}
+
 async function firstStreamingError(
   response: Response,
 ): Promise<Response | string> {
@@ -403,6 +410,8 @@ async function executeWithFallback(options: {
     ...options,
     accessToken: options.primaryAccessToken,
   })
+  if (!shouldPreflightPrimaryForFallback(storage)) return primary
+
   const primaryPreflight = await firstStreamingError(primary)
   if (primaryPreflight instanceof Response) {
     if (!shouldFallbackStatus(primaryPreflight.status, storage))

--- a/packages/pi/src/tests/stream.test.ts
+++ b/packages/pi/src/tests/stream.test.ts
@@ -4,6 +4,7 @@ import {
   buildExplicitBaseMessagesUrl,
   configureApiRouteHeaders,
   primaryResponseAllowsApiFallback,
+  shouldPreflightPrimaryForFallback,
 } from '../stream.ts'
 
 describe('Pi API fallback routing helpers', () => {
@@ -47,6 +48,18 @@ describe('Pi API fallback routing helpers', () => {
     expect(
       primaryResponseAllowsApiFallback(new Response(null, { status: 200 })),
     ).toBe(false)
+  })
+
+  test('skips primary SSE preflight when no fallback accounts are configured', () => {
+    expect(shouldPreflightPrimaryForFallback(null)).toBe(false)
+    expect(shouldPreflightPrimaryForFallback({ accounts: [] } as any)).toBe(
+      false,
+    )
+    expect(
+      shouldPreflightPrimaryForFallback({
+        accounts: [{ id: 'fallback' }],
+      } as any),
+    ).toBe(true)
   })
 
   test('supports x-api-key auth mode for API fallback routes', () => {


### PR DESCRIPTION
## Summary
- Skip the primary Anthropic SSE preflight when there are no configured fallback accounts
- Preserve existing fallback preflight behavior when fallback accounts are present
- Add coverage for the preflight gating helper

## Why
With only the main Pi OAuth account configured, there is nothing to fall back to. The primary preflight clones and partially reads the streaming response before the normal Pi stream parser consumes it. In local testing this caused Pi to emit only the initial empty assistant message. Skipping the preflight when no fallback accounts exist restores normal streaming while keeping fallback behavior for configured fallback accounts.

## Test plan
- `bun run typecheck`
- `bun --filter @cortexkit/pi-anthropic-auth test`
- Local Pi smoke test with package installed from `packages/pi`: `pi -p --mode json --no-tools --no-session --model anthropic/claude-sonnet-4-5 "say exactly: hi"`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783716363&installation_id=135454708&pr_number=70&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F70&signature=dfe2131280fe2c5deea64cee5e9a75620cb00ba73d47d421b8c1a92754a1480c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips the primary Anthropic SSE preflight when no fallback accounts are configured, fixing truncated Pi streams. Fallback behavior is unchanged when fallbacks exist.

- **Bug Fixes**
  - Gate preflight with `shouldPreflightPrimaryForFallback(storage)`; only preflight when `storage.accounts.length > 0`.
  - Avoid cloning/reading the primary stream unless fallbacks are available.
  - Added unit tests for the gating helper.

<sup>Written for commit bffdbcc955808d5fb5d30b8607308a27ed013613. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a streaming regression where the primary Pi OAuth SSE response was being cloned and partially consumed by the preflight check even when no fallback accounts were configured — leaving the main stream parser with incomplete data. The fix gates the `firstStreamingError` preflight behind a new `shouldPreflightPrimaryForFallback` helper that returns `false` when `storage` is null or holds an empty accounts array.

- `shouldPreflightPrimaryForFallback` is exported and unit-tested against null, empty, and populated storage shapes; the early-return is placed correctly after the `fallback-first` block in `executeWithFallback`.
- The existing preflight path (for configured fallback accounts) is fully preserved; no behaviour changes for users with fallbacks enabled.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, correctly placed, and directly addresses the root cause of the streaming truncation issue.

The new guard is a one-liner that checks an already-loaded value; it cannot introduce new I/O or side-effects. All three storage states (null, empty array, populated array) are covered by the new unit test, and the existing fallback path is structurally unchanged.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pi/src/stream.ts | Adds `shouldPreflightPrimaryForFallback` helper and inserts an early-return guard in `executeWithFallback`; logic is correct for all three storage states (null, empty accounts, populated accounts). |
| packages/pi/src/tests/stream.test.ts | Adds a focused unit test for `shouldPreflightPrimaryForFallback` covering null, empty-array, and populated-array storage; all three branches of the helper are exercised. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[executeWithFallback called] --> B{fallback-first mode?}
    B -- yes --> C[tryFallbackAccounts]
    C -- fallback found --> D[return fallback response]
    C -- no fallback --> E[sendAnthropicRequest primary]
    B -- no --> E
    E --> F{shouldPreflightPrimaryForFallback?\nstorage?.accounts.length > 0}
    F -- false\nnull or empty accounts --> G[return primary directly\nno stream clone]
    F -- true\nfallbacks configured --> H[firstStreamingError preflight\nclone + partial read]
    H -- ok response --> I{shouldFallbackStatus?}
    I -- no --> J[return primary preflight]
    I -- yes --> K{allowApiFallback?}
    K -- yes --> L[tryFallbackAccounts\nincl. API routes]
    K -- no --> L2[tryFallbackAccounts\nOAuth only]
    L -- fallback found --> M[cancel primary, return fallback]
    L -- no fallback --> N[return primaryPreflight or primary]
    L2 -- fallback found --> M
    L2 -- no fallback --> N
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pi): skip primary preflight without ..."](https://github.com/cortexkit/anthropic-auth/commit/bffdbcc955808d5fb5d30b8607308a27ed013613) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36818952)</sub>

<!-- /greptile_comment -->