### PR TITLE
fix(pi): use safe one-event SSE preflight peek for fallback routing

### DIFF
--- a/packages/pi/src/stream.ts
+++ b/packages/pi/src/stream.ts
@@ -1,4 +1,5 @@
 import {
+  type AccountStorage,
   type ApiKeyAccount,
   applyClaudeCodeHeaders,
   CACHE_KEEP_EXTENDED_TTL_BETA,
@@ -294,6 +295,12 @@ export function primaryResponseAllowsApiFallback(preflight: Response | string) {
   )
 }
 
+export function shouldPreflightPrimaryForFallback(
+  storage: AccountStorage | null,
+) {
+  return Boolean(storage?.accounts.length)
+}
+
 async function firstStreamingError(
   response: Response,
 ): Promise<Response | string> {
@@ -403,6 +410,8 @@ async function executeWithFallback(options: {
     ...options,
     accessToken: options.primaryAccessToken,
   })
+  if (!shouldPreflightPrimaryForFallback(storage)) return primary
+
   const primaryPreflight = await firstStreamingError(primary)
   if (primaryPreflight instanceof Response) {
     if (!shouldFallbackStatus(primaryPreflight.status, storage))

--- a/packages/pi/src/stream.ts
+++ b/packages/pi/src/stream.ts
@@ -176,6 +176,27 @@ export function configureApiRouteHeaders(
   return headers
 }
 
+function extractSseEvents(buffer: string) {
+  const events: AnthropicEvent[] = []
+  let nextBuffer = buffer
+  let boundary = nextBuffer.indexOf('\n\n')
+
+  while (boundary !== -1) {
+    const frame = nextBuffer.slice(0, boundary)
+    nextBuffer = nextBuffer.slice(boundary + 2)
+    boundary = nextBuffer.indexOf('\n\n')
+
+    for (const line of frame.split('\n')) {
+      if (!line.startsWith('data:')) continue
+      const data = line.slice(5).trim()
+      if (!data || data === '[DONE]') continue
+      events.push(JSON.parse(data) as AnthropicEvent)
+    }
+  }
+
+  return { events, buffer: nextBuffer }
+}
+
 async function* parseSse(response: Response): AsyncGenerator<AnthropicEvent> {
   if (!response.body) return
   const reader = response.body.getReader()
@@ -191,18 +212,9 @@ async function* parseSse(response: Response): AsyncGenerator<AnthropicEvent> {
         break
       }
       buffer += decoder.decode(value, { stream: true })
-      let boundary = buffer.indexOf('\n\n')
-      while (boundary !== -1) {
-        const frame = buffer.slice(0, boundary)
-        buffer = buffer.slice(boundary + 2)
-        boundary = buffer.indexOf('\n\n')
-        for (const line of frame.split('\n')) {
-          if (!line.startsWith('data:')) continue
-          const data = line.slice(5).trim()
-          if (!data || data === '[DONE]') continue
-          yield JSON.parse(data) as AnthropicEvent
-        }
-      }
+      const parsed = extractSseEvents(buffer)
+      buffer = parsed.buffer
+      yield* parsed.events
     }
   } finally {
     if (!completed) await reader.cancel().catch(() => {})
@@ -314,19 +326,9 @@ async function peekFirstSseEvent(response: { body: Response['body'] }) {
       if (done) return null
 
       buffer += decoder.decode(value, { stream: true })
-      let boundary = buffer.indexOf('\n\n')
-      while (boundary !== -1) {
-        const frame = buffer.slice(0, boundary)
-        buffer = buffer.slice(boundary + 2)
-        boundary = buffer.indexOf('\n\n')
-
-        for (const line of frame.split('\n')) {
-          if (!line.startsWith('data:')) continue
-          const data = line.slice(5).trim()
-          if (!data || data === '[DONE]') continue
-          return JSON.parse(data) as AnthropicEvent
-        }
-      }
+      const parsed = extractSseEvents(buffer)
+      buffer = parsed.buffer
+      if (parsed.events.length > 0) return parsed.events[0]
     }
   } finally {
     void reader.cancel().catch(() => {})

--- a/packages/pi/src/stream.ts
+++ b/packages/pi/src/stream.ts
@@ -301,26 +301,57 @@ export function shouldPreflightPrimaryForFallback(
   return Boolean(storage?.accounts.length)
 }
 
+async function peekFirstSseEvent(response: { body: Response['body'] }) {
+  if (!response.body) return null
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) return null
+
+      buffer += decoder.decode(value, { stream: true })
+      let boundary = buffer.indexOf('\n\n')
+      while (boundary !== -1) {
+        const frame = buffer.slice(0, boundary)
+        buffer = buffer.slice(boundary + 2)
+        boundary = buffer.indexOf('\n\n')
+
+        for (const line of frame.split('\n')) {
+          if (!line.startsWith('data:')) continue
+          const data = line.slice(5).trim()
+          if (!data || data === '[DONE]') continue
+          return JSON.parse(data) as AnthropicEvent
+        }
+      }
+    }
+  } finally {
+    void reader.cancel().catch(() => {})
+    reader.releaseLock()
+  }
+}
+
 async function firstStreamingError(
   response: Response,
 ): Promise<Response | string> {
   if (!response.ok) return response
   const clone = response.clone()
   try {
-    for await (const event of parseSse(clone as unknown as Response)) {
-      if (
-        event.type === 'error' &&
-        typeof event.delta?.type === 'string' &&
-        event.delta.type === 'rate_limit_error'
-      ) {
-        return 'rate_limit_error'
-      }
-      return response
+    const event = await peekFirstSseEvent(clone)
+    if (
+      event?.type === 'error' &&
+      typeof event.delta?.type === 'string' &&
+      event.delta.type === 'rate_limit_error'
+    ) {
+      return 'rate_limit_error'
     }
+    return response
   } catch {
     return response
   }
-  return response
 }
 
 async function executeWithFallback(options: {

--- a/packages/pi/src/tests/stream.test.ts
+++ b/packages/pi/src/tests/stream.test.ts
@@ -4,6 +4,7 @@ import {
   buildExplicitBaseMessagesUrl,
   configureApiRouteHeaders,
   primaryResponseAllowsApiFallback,
+  shouldPreflightPrimaryForFallback,
 } from '../stream.ts'
 
 describe('Pi API fallback routing helpers', () => {
@@ -47,6 +48,18 @@ describe('Pi API fallback routing helpers', () => {
     expect(
       primaryResponseAllowsApiFallback(new Response(null, { status: 200 })),
     ).toBe(false)
+  })
+
+  test('skips primary SSE preflight when no fallback accounts are configured', () => {
+    expect(shouldPreflightPrimaryForFallback(null)).toBe(false)
+    expect(shouldPreflightPrimaryForFallback({ accounts: [] } as any)).toBe(
+      false,
+    )
+    expect(
+      shouldPreflightPrimaryForFallback({
+        accounts: [{ id: 'fallback' }],
+      } as any),
+    ).toBe(true)
   })
 
   test('supports x-api-key auth mode for API fallback routes', () => {


### PR DESCRIPTION
## Summary
- Replace the async-generator-based primary SSE preflight with a direct one-event peek on the cloned response body
- Keep the existing fallback-routing behavior, including main-account preflight when fallback accounts are configured
- Retain the no-fallback fast path from #70

## Why
The previous implementation used `for await ... of parseSse(response.clone())` and returned after the first event. In local Pi testing, that cleanup path left the clone in a bad state and the original stream never progressed past the initial empty assistant event.

This change keeps the intended fallback behavior but peeks the first SSE event directly from the clone reader instead of partially consuming the clone through the async generator cleanup path.

## Test plan
- `bun run typecheck`
- `bun --filter @cortexkit/pi-anthropic-auth test`
- `bun run build`
- Local Pi smoke test with a configured API fallback route and main OAuth account: `pi -p --mode json --no-tools --no-session --model anthropic/claude-sonnet-4-5 "say exactly: hi"`

## Notes
This supersedes the narrower no-fallback-only workaround in #70 by preserving the intended fallback preflight path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783717450&installation_id=135454708&pr_number=71&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F71&signature=1184082512a251beb9fff25b8fa6721cc570de764154b17c7cac262f77f29090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches primary SSE preflight to a safe one-event peek on the cloned response body to prevent stuck streams. Keeps fallback routing and skips preflight when no fallback accounts are configured.

- **Bug Fixes**
  - Peek the first SSE event via peekFirstSseEvent instead of iterating parseSse(...), avoiding clone cleanup issues that stalled the original stream.
  - Add shouldPreflightPrimaryForFallback to bypass preflight with no fallback accounts, preserving the no-fallback fast path.
  - Continue detecting primary rate_limit_error to trigger API fallback.

- **Refactors**
  - Extract shared SSE parsing into extractSseEvents and use it in both parseSse and preflight peek to keep logic consistent.

<sup>Written for commit d21821504ad620c5456a88ac1f64de8dc80309cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the async-generator-based SSE preflight (which left the cloned body in a bad state on the Pi runtime) with a direct reader-based `peekFirstSseEvent` that reads exactly the first event from the clone and then cancels. It also adds `shouldPreflightPrimaryForFallback` to short-circuit the clone/peek step when no fallback accounts are configured.

- **`extractSseEvents`** is factored out of `parseSse` and reused by both `parseSse` and `peekFirstSseEvent`, keeping the parsing logic in one place.
- **`peekFirstSseEvent`** replaces partial async-generator iteration with a direct `getReader()` loop, eliminating the generator cleanup path that stalled the original stream on Pi.
- **`shouldPreflightPrimaryForFallback`** gates the whole preflight branch, restoring the no-fallback fast path from #70 without losing fallback routing.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the clone/peek path is logically equivalent to the old generator approach and the original response body is never touched during preflight.

The change is narrowly scoped: it replaces partial async-generator iteration on a cloned body with a direct reader loop, and adds a guard to skip the whole preflight when no fallback accounts exist. The Response.clone() tee means the original body is unaffected by anything peekFirstSseEvent does to the clone. Error paths (malformed JSON, empty stream, non-ok response) all fall through to returning the original response, same as before. The shouldPreflightPrimaryForFallback guard is a straightforward boolean check with clear semantics. No data flow, auth boundary, or correctness concern is introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pi/src/stream.ts | Extracts SSE parsing into `extractSseEvents`, adds `peekFirstSseEvent` to safely peek the first event from a cloned response body, gates the primary preflight on `shouldPreflightPrimaryForFallback`, and removes the dead `return response` after the now-unreachable loop exit in `firstStreamingError`. |
| packages/pi/src/tests/stream.test.ts | Exports and tests `shouldPreflightPrimaryForFallback` covering null, empty-array, and populated-array cases; no tests for `peekFirstSseEvent` or `firstStreamingError` (already flagged in previous review thread). |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[executeWithFallback] --> B{fallback-first mode?}
    B -- yes --> C[tryFallbackAccounts]
    C -- found --> D[return fallback response]
    C -- none --> E
    B -- no --> E[sendAnthropicRequest primary]
    E --> F{shouldPreflightPrimaryForFallback?}
    F -- no accounts --> G[return primary directly]
    F -- has accounts --> H[firstStreamingError primary]
    H --> I[primary.clone]
    I --> J[peekFirstSseEvent clone]
    J --> K[extractSseEvents buffer loop]
    K -- first event --> L{rate_limit_error?}
    K -- null / non-error --> M[return original primary response]
    L -- yes --> N[return 'rate_limit_error']
    L -- no --> M
    M --> O{shouldFallbackStatus?}
    N --> P{primaryQuotaRefreshConfirmsExhausted?}
    O -- no --> Q[return primaryPreflight]
    O -- yes --> P
    P -- yes --> R[tryFallbackAccounts]
    P -- no --> S[return primaryPreflight or primary]
    R -- found --> T[cancel primary body, return fallback]
    R -- none --> S
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(pi): share SSE event extraction..."](https://github.com/cortexkit/anthropic-auth/commit/d21821504ad620c5456a88ac1f64de8dc80309cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36823713)</sub>

<!-- /greptile_comment -->