### PR TITLE
fix(pi): empty Claude responses — parseSse cancels the tee'd clone body

### DIFF
--- a/packages/pi/src/stream.ts
+++ b/packages/pi/src/stream.ts
@@ -204,7 +204,12 @@ async function* parseSse(response: Response): AsyncGenerator<AnthropicEvent> {
       }
     }
   } finally {
-    if (!completed) await reader.cancel().catch(() => {})
+    // Do not cancel the reader on early abandon. `firstStreamingError()` peeks
+    // the first SSE event from a `response.clone()` and then abandons this
+    // generator; cancelling the cloned (tee'd) reader tears down the shared
+    // underlying body, so the real `parseSse(response)` that streams the reply
+    // reads zero events and the assistant message comes back empty. Releasing
+    // the lock is enough — the abandoned clone branch is garbage-collected.
     reader.releaseLock()
   }
 }


### PR DESCRIPTION
## Problem

Since **1.8.0**, the pi extension returns an **empty assistant message** for every Claude model, in every mode (interactive, `--mode json`, and `pi -p`). The HTTP request succeeds (200, full SSE body arrives) but pi renders no content — interactively it just spins on "Working…" forever.

## Root cause

`parseSse()` gained a `finally { if (!completed) await reader.cancel() }`. Separately, `firstStreamingError()` does `response.clone()` and reads only the **first** SSE event (to detect `rate_limit_error`), then abandons that generator:

```ts
const clone = response.clone()
for await (const event of parseSse(clone as unknown as Response)) {
  ...
  return response   // <- abandons the generator after the first event
}
```

Abandoning the generator triggers `parseSse`'s `finally`, which calls `reader.cancel()` on the **cloned, tee'd** body. Cancelling one branch of the tee tears down the shared underlying stream, so the *real* `parseSse(response)` in the main streaming loop reads **zero** events. The assistant message ends up empty (`stop`, no content blocks).

Pre-1.8.0 had no `cancel()` in `parseSse`, so abandoning the clone was harmless — which is why older versions work.

## Fix

Don't cancel in `parseSse`'s `finally`; just `releaseLock()`. The normal full-read path sets `completed = true` and never cancelled anyway, so this only affects the early-abandon (clone-peek) path — exactly where the cancel is destructive. The abandoned clone branch is garbage-collected.

## Repro / verification

```
pi --mode json --no-session --model claude-fable-5 "say PONG"
```
- before: final assistant message has `content: []`
- after: streams `message_update`s and returns `PONG`

Verified with `claude-opus-4-8` and `claude-fable-5`, in `--mode json` and `pi -p`. Bisected: 1.7.0 works, 1.8.0 and 1.9.2 are empty; pi version is irrelevant.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783740174&installation_id=135454708&pr_number=72&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F72&signature=fa520de5d0eafdcb4652a380533b4e720cbe1f073b85e32080151ed709fe78de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty assistant messages in `pi` for all Claude models by preventing `parseSse` from canceling a tee’d clone, which was shutting down the main SSE stream and yielding no events.

- **Bug Fixes**
  - In `parseSse`, remove `reader.cancel()` in the `finally` block and only call `reader.releaseLock()` to avoid tearing down the shared stream when `firstStreamingError()` peeks a `response.clone()`.

<sup>Written for commit 94e33dd682d48eaa5ca342a59577ac1e19ec4bf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression introduced in 1.8.0 where every Claude model returned an empty assistant message. The culprit was `parseSse`'s `finally` block calling `reader.cancel()` on the cloned (tee'd) body used by `firstStreamingError` for rate-limit peeking — cancelling one branch of a tee tears down the shared underlying stream, starving the real `parseSse(response)` call of all events.

- **Root cause fixed**: Replacing `reader.cancel()` with `reader.releaseLock()` in `parseSse`'s `finally` block lets the primary tee branch continue reading normally; the abandoned clone branch is garbage-collected without touching the shared source.
- **Side effect**: The `completed` variable that guarded the old `if (!completed) cancel()` call is now dead code and can be removed.
- **Scope of change**: The removal of `cancel()` is not limited to the clone path — it also affects the main stream's early-exit paths (e.g., SSE error events), reverting to pre-1.8.0 connection-cleanup behavior on those paths.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — fixes a clear correctness bug with a well-explained, minimal change that reverts to the known-good pre-1.8.0 behavior.

The one-line behavioural change is correct and the comment explains it thoroughly. The only remaining nits are the now-dead `completed` variable and the fact that the fix is slightly broader than strictly necessary (removing `cancel()` on all early-exit paths, not just the clone path). Neither affects correctness.

packages/pi/src/stream.ts — specifically the `firstStreamingError` / `parseSse` interaction; worth a glance if the team later wants to restore explicit connection cleanup for non-clone early-exit paths.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pi/src/stream.ts | Removes `reader.cancel()` from `parseSse`'s `finally` block, fixing a bug where abandoning the cloned (tee'd) reader in `firstStreamingError` destroyed the shared underlying body stream and silenced the real response. The `completed` variable is now dead code. The fix is broad — it also removes explicit cancel on the main stream's early-exit paths — which is benign but diverges from the original intent of 1.8.0's cleanup. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant FW as firstStreamingError()
    participant PC as parseSse(clone)
    participant PR as parseSse(response)
    participant Body as Shared HTTP Body (tee'd)

    FW->>Body: response.clone() → tee()
    Note over Body: Branch 1 = clone, Branch 2 = response

    FW->>PC: for await first event
    PC->>Body: reader.read() [Branch 1]
    Body-->>PC: first SSE event

    FW->>PC: return response (abandon generator)
    Note over PC: finally block runs

    rect rgb(255, 220, 220)
        Note over PC,Body: BEFORE (1.8.0): cancel() destroys shared source
        PC->>Body: reader.cancel() → tears down tee
        PR->>Body: reader.read() [Branch 2]
        Body-->>PR: empty — source destroyed
    end

    rect rgb(220, 255, 220)
        Note over PC,Body: AFTER (this PR): releaseLock() only
        PC->>Body: reader.releaseLock()
        Note over PC: clone GC'd eventually
        PR->>Body: reader.read() [Branch 2]
        Body-->>PR: SSE events stream normally
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/pi/src/stream.ts`, line 183-191 ([link](https://github.com/cortexkit/anthropic-auth/blob/94e33dd682d48eaa5ca342a59577ac1e19ec4bf9/packages/pi/src/stream.ts#L183-L191)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `completed` variable is now dead code. The only place it was ever read was the removed `if (!completed) await reader.cancel()` guard. The `break` statement that exits the `while (true)` loop when `done` is still correct, but `completed = true` is never observed by anything after this diff and can be removed to keep the function clean.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(pi): don&#39;t cancel parseSse reader on..."](https://github.com/cortexkit/anthropic-auth/commit/94e33dd682d48eaa5ca342a59577ac1e19ec4bf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36887692)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->