### PR TITLE
feat(opencode): quota pacing — burn-rate projection on the TUI sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,84 @@ The sidebar polls plugin state and refreshes on OpenCode session and message eve
 
 Click the `CLAUDE` header to collapse or expand the sidebar. Collapsed, it shows the active account's 5-hour quota usage and a fast-mode row when fast mode is on; the header shows the plugin version (or a `LIMITED` badge when degraded). Collapse state is per-session and resets when OpenCode restarts.
 
+## TUI preferences
+
+The TUI sidebar reads `tui-preferences.jsonc` from the opencode config
+directory (`$OPENCODE_CONFIG_DIR`, else `$XDG_CONFIG_HOME/opencode`, else
+`~/.config/opencode`). The file is optional — defaults apply without it — and
+safe to hand-edit: the plugin updates single keys in place, preserving
+comments, and picks up edits live while the TUI runs.
+
+The file is shared: any opencode TUI plugin can claim one top-level key
+(short plugin name). This plugin uses `anthropic-auth`:
+
+```jsonc
+{
+  "anthropic-auth": {
+    // Layout — applied at TUI startup; restart to change
+    "forceToTop": false,        // jump to the first sidebar slot
+    "order": 160,               // slot order when not forced (-10000..10000)
+
+    // Behavior
+    "startCollapsed": false,    // initial state when nothing persisted
+    "rememberCollapsed": true,  // persist header clicks across restarts
+    "collapsed": false,         // written by the plugin on header click
+    "pollMs": 1500,             // state poll interval (500..30000)
+    "refreshDebounceMs": 200,   // event debounce (50..5000)
+
+    // Header
+    "header": {
+      "label": "CLAUDE",        // badge text (1..20 chars)
+      "showVersion": true
+    },
+
+    // Sections
+    "sections": {
+      "quota": true,
+      "fallbackAccounts": true,
+      "routing": true,
+      "cache": true,
+      "health": true
+    },
+
+    // Appearance
+    "appearance": {
+      "barWidth": 10,           // quota bar width (4..40)
+      "barFilledChar": "█",
+      "barEmptyChar": "░",
+      "warnThreshold": 50,      // used% where bars turn warn-colored
+      "errorThreshold": 80      // used% where bars turn error-colored
+    }
+  }
+}
+```
+
+Out-of-range numbers are clamped, wrong types fall back to defaults per key,
+and a malformed file is ignored entirely — the sidebar never crashes on bad
+preferences. The LIMITED badge always renders when an account is degraded,
+regardless of preferences.
+
+### forceToTop convention
+
+Sidebar slots render in ascending `order` (opencode built-ins use 100-500).
+Plugins adopting this convention compute their order as
+`-100000 + indexOfKeyInFile` when their `forceToTop` is `true`, so all forced
+plugins float above everything else, ordered by their key's position in the
+file. Reorder keys to reprioritize. Manual `order` values clamp to
+-10000..10000 and can never beat a forced plugin.
+
+Other plugins can reuse the helpers:
+
+```ts
+import {
+  computeEffectiveOrder,
+  readTuiPreferencesFile,
+} from '@cortexkit/opencode-anthropic-auth/tui-prefs'
+
+const root = await readTuiPreferencesFile()
+const order = computeEffectiveOrder(root, 'my-plugin', 200)
+```
+
 ## Claude prompt cache control
 
 Both OpenCode and Pi packages add a slash command for Anthropic's 1-hour ephemeral prompt-cache TTL:

--- a/README.md
+++ b/README.md
@@ -314,14 +314,15 @@ The sidebar polls plugin state and refreshes on OpenCode session and message eve
 - **Cache** — the 1-hour cache keepalive window and the number of tracked sessions, shown when cache keepalive is configured.
 - **Health** — quota-API and token-refresh backoff countdowns. This section is hidden unless a backoff is active, and a `LIMITED` badge appears in the header.
 
-Click the `CLAUDE` header to collapse or expand the sidebar. Collapsed, it shows the active account's 5-hour quota usage and a fast-mode row when fast mode is on; the header shows the plugin version (or a `LIMITED` badge when degraded). Collapse state is per-session and resets when OpenCode restarts.
+Click the `CLAUDE` header to collapse or expand the sidebar. Collapsed, it shows the active account's 5-hour quota usage and a fast-mode row when fast mode is on; the header shows the plugin version (or a `LIMITED` badge when degraded). Collapse state persists across restarts by default via `tui-preferences.jsonc` (`rememberCollapsed`); set `"rememberCollapsed": false` for the old per-session behavior.
 
 ## TUI preferences
 
 The TUI sidebar reads `tui-preferences.jsonc` from the opencode config
-directory (`$OPENCODE_CONFIG_DIR`, else `$XDG_CONFIG_HOME/opencode`, else
-`~/.config/opencode`). The file is optional — defaults apply without it — and
-safe to hand-edit: the plugin updates single keys in place, preserving
+directory, resolved in this order: `OPENCODE_TUI_PREFERENCES_FILE` (full file
+path override), else `$OPENCODE_CONFIG_DIR`, else `$XDG_CONFIG_HOME/opencode`,
+else `~/.config/opencode`. The file is optional — defaults apply without it —
+and safe to hand-edit: the plugin updates single keys in place, preserving
 comments, and picks up edits live while the TUI runs.
 
 The file is shared: any opencode TUI plugin can claim one top-level key

--- a/README.md
+++ b/README.md
@@ -354,7 +354,8 @@ The file is shared: any opencode TUI plugin can claim one top-level key
       "fallbackAccounts": true,
       "routing": true,
       "cache": true,
-      "health": true
+      "health": true,
+      "pacing": true
     },
 
     // Appearance
@@ -373,6 +374,13 @@ Out-of-range numbers are clamped, wrong types fall back to defaults per key,
 and a malformed file is ignored entirely — the sidebar never crashes on bad
 preferences. The LIMITED badge always renders when an account is degraded,
 regardless of preferences.
+
+With `sections.pacing` on (default), quota bars show an even-burn pace
+segment — `▒` headroom when under pace, `▓` overshoot when over — and
+off-pace windows add a subline with the reserve/deficit percentage and, when
+the current burn rate would exhaust the window before it resets, the
+projected `out in …` time. The collapsed summary turns red when the active
+account is over pace in any window.
 
 ### forceToTop convention
 

--- a/README.md
+++ b/README.md
@@ -379,8 +379,10 @@ With `sections.pacing` on (default), quota bars show an even-burn pace
 segment — `▒` headroom when under pace, `▓` overshoot when over — and
 off-pace windows add a subline with the reserve/deficit percentage and, when
 the current burn rate would exhaust the window before it resets, the
-projected `out in …` time. The collapsed summary turns red when the active
-account is over pace in any window.
+projected `out in …` time. The collapsed summary turns the warning color
+(amber) when the active account is over pace in any window — this is a
+pacing projection, not quota exhaustion, and never paints the row red
+unless real usage already warrants it.
 
 ### forceToTop convention
 

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "@cortexkit/anthropic-auth-core": "1.9.2",
         "@opentui/core": ">=0.4.0",
         "@opentui/solid": ">=0.4.0",
+        "jsonc-parser": "^3.3.1",
         "solid-js": "^1.9.10",
       },
       "peerDependencies": {
@@ -540,6 +541,8 @@
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -17,6 +17,10 @@
     "./tui": {
       "types": "./dist/tui.d.ts",
       "import": "./src/tui.tsx"
+    },
+    "./tui-prefs": {
+      "types": "./dist/tui-preferences.d.ts",
+      "import": "./dist/tui-preferences.js"
     }
   },
   "oc-plugin": [
@@ -33,11 +37,12 @@
     "dist",
     "src/tui.tsx",
     "src/sidebar-state.ts",
+    "src/tui-preferences.ts",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/cli.ts src/sidebar-state.ts --outdir dist --target node --format esm --splitting --external @opencode-ai/plugin --minify && tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "build": "rm -rf dist && bun build src/index.ts src/cli.ts src/sidebar-state.ts src/tui-preferences.ts --outdir dist --target node --format esm --splitting --external @opencode-ai/plugin --minify && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:dev": "rm -rf dist && tsc -p tsconfig.build.json",
     "dev": "bun ../../scripts/dev.ts",
     "dev:clean": "bun ../../scripts/dev-clean.ts",
@@ -54,6 +59,7 @@
     "@cortexkit/anthropic-auth-core": "1.9.2",
     "@opentui/core": ">=0.4.0",
     "@opentui/solid": ">=0.4.0",
+    "jsonc-parser": "^3.3.1",
     "solid-js": "^1.9.10"
   }
 }

--- a/packages/opencode/src/sidebar-state.ts
+++ b/packages/opencode/src/sidebar-state.ts
@@ -123,3 +123,57 @@ export function getCollapsedQuotaSummary(quota: AccountQuota | null): {
     text: `5h: ${fiveHourUsedPercent == null ? '—' : `${Math.round(fiveHourUsedPercent)}%`} 7d: ${sevenDayUsedPercent == null ? '—' : `${Math.round(sevenDayUsedPercent)}%`}`,
   }
 }
+
+export const FIVE_HOUR_MS = 5 * 60 * 60 * 1000
+export const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000
+
+const PACING_MIN_ELAPSED_MS = 5 * 60 * 1000
+const PACING_MIN_ELAPSED_FRACTION = 0.01
+const ON_PACE_DELTA = 1
+
+export interface QuotaPacing {
+  pacePercent: number
+  deltaPercent: number
+  state: 'deficit' | 'reserve' | 'on-pace'
+  runsOutAt: string | null
+}
+
+// Even-burn pacing for a quota window. The window start is inferred from the
+// reset timestamp minus the window length. Two metrics: deltaPercent compares
+// usage against a uniform burn-down (positive = deficit), and runsOutAt
+// projects the current average burn rate forward — null means the window
+// lasts until reset at that rate. Returns null when there is no reset
+// timestamp or the elapsed time is too small to give a meaningful rate.
+export function computeQuotaPacing(
+  window: QuotaWindow,
+  windowMs: number,
+  now: number,
+): QuotaPacing | null {
+  if (!window.resetsAt) return null
+  const resetsAt = new Date(window.resetsAt).getTime()
+  if (!Number.isFinite(resetsAt)) return null
+  const start = resetsAt - windowMs
+  const elapsed = now - start
+  if (elapsed < PACING_MIN_ELAPSED_MS) return null
+  if (elapsed < windowMs * PACING_MIN_ELAPSED_FRACTION) return null
+  if (elapsed >= windowMs) return null
+
+  const used = window.usedPercent
+  const pacePercent = Math.min(Math.max((elapsed / windowMs) * 100, 0), 100)
+  const deltaPercent = used - pacePercent
+  const state =
+    Math.abs(deltaPercent) < ON_PACE_DELTA
+      ? 'on-pace'
+      : deltaPercent > 0
+        ? 'deficit'
+        : 'reserve'
+
+  let runsOutAt: string | null = null
+  if (used > 0) {
+    const msToFull = (elapsed * 100) / used
+    const runOut = start + msToFull
+    if (runOut < resetsAt) runsOutAt = new Date(runOut).toISOString()
+  }
+
+  return { pacePercent, deltaPercent, state, runsOutAt }
+}

--- a/packages/opencode/src/tests/sidebar-state.test.ts
+++ b/packages/opencode/src/tests/sidebar-state.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import {
   type AccountQuota,
+  computeQuotaPacing,
   DEFAULT_SIDEBAR_STATE,
+  FIVE_HOUR_MS,
   getCollapsedQuotaSummary,
   resolveActiveAccount,
+  SEVEN_DAY_MS,
   type SidebarState,
 } from '../sidebar-state'
 
@@ -105,5 +108,120 @@ describe('getCollapsedQuotaSummary', () => {
   test('returns no collapsed quota text when no windows are available', () => {
     expect(getCollapsedQuotaSummary(null).text).toBeNull()
     expect(getCollapsedQuotaSummary({}).text).toBeNull()
+  })
+})
+
+describe('computeQuotaPacing', () => {
+  const now = Date.UTC(2026, 5, 12, 12, 0, 0)
+
+  function fiveHourWindow(elapsedMs: number, usedPercent: number) {
+    return {
+      window: {
+        usedPercent,
+        remainingPercent: 100 - usedPercent,
+        resetsAt: new Date(now + FIVE_HOUR_MS - elapsedMs).toISOString(),
+      },
+      elapsedMs,
+    }
+  }
+
+  test('reserve: under even-burn pace, lasts until reset', () => {
+    const { window } = fiveHourWindow(FIVE_HOUR_MS / 4, 5)
+    const pacing = computeQuotaPacing(window, FIVE_HOUR_MS, now)
+    expect(pacing).not.toBeNull()
+    expect(pacing?.pacePercent).toBeCloseTo(25, 5)
+    expect(pacing?.deltaPercent).toBeCloseTo(-20, 5)
+    expect(pacing?.state).toBe('reserve')
+    expect(pacing?.runsOutAt).toBeNull()
+  })
+
+  test('deficit: over pace, projects runout before reset', () => {
+    const elapsed = FIVE_HOUR_MS / 4
+    const { window } = fiveHourWindow(elapsed, 50)
+    const pacing = computeQuotaPacing(window, FIVE_HOUR_MS, now)
+    expect(pacing?.pacePercent).toBeCloseTo(25, 5)
+    expect(pacing?.deltaPercent).toBeCloseTo(25, 5)
+    expect(pacing?.state).toBe('deficit')
+    const start = now - elapsed
+    expect(pacing?.runsOutAt).toBe(new Date(start + elapsed * 2).toISOString())
+  })
+
+  test('screenshot case: 7d window, 12h elapsed, 17% used', () => {
+    const elapsed = 12 * 60 * 60 * 1000
+    const window = {
+      usedPercent: 17,
+      remainingPercent: 83,
+      resetsAt: new Date(now + SEVEN_DAY_MS - elapsed).toISOString(),
+    }
+    const pacing = computeQuotaPacing(window, SEVEN_DAY_MS, now)
+    expect(pacing?.deltaPercent).toBeCloseTo(17 - (12 / 168) * 100, 5)
+    expect(pacing?.state).toBe('deficit')
+    expect(pacing?.runsOutAt).not.toBeNull()
+    const runsOutMs = new Date(pacing?.runsOutAt as string).getTime() - now
+    const expectedMs = (elapsed * 100) / 17 - elapsed
+    expect(runsOutMs).toBeCloseTo(expectedMs, -4)
+  })
+
+  test('on-pace when |delta| < 1', () => {
+    const { window } = fiveHourWindow(FIVE_HOUR_MS / 4, 25.5)
+    const pacing = computeQuotaPacing(window, FIVE_HOUR_MS, now)
+    expect(pacing?.state).toBe('on-pace')
+  })
+
+  test('zero usage is reserve and lasts', () => {
+    const { window } = fiveHourWindow(FIVE_HOUR_MS / 2, 0)
+    const pacing = computeQuotaPacing(window, FIVE_HOUR_MS, now)
+    expect(pacing?.state).toBe('reserve')
+    expect(pacing?.deltaPercent).toBeCloseTo(-50, 5)
+    expect(pacing?.runsOutAt).toBeNull()
+  })
+
+  test('projection landing exactly at reset means lasts', () => {
+    const elapsed = FIVE_HOUR_MS / 2
+    const { window } = fiveHourWindow(elapsed, 50)
+    const pacing = computeQuotaPacing(window, FIVE_HOUR_MS, now)
+    expect(pacing?.state).toBe('on-pace')
+    expect(pacing?.runsOutAt).toBeNull()
+  })
+
+  test('null when resetsAt missing or invalid', () => {
+    expect(
+      computeQuotaPacing(
+        { usedPercent: 10, remainingPercent: 90 },
+        FIVE_HOUR_MS,
+        now,
+      ),
+    ).toBeNull()
+    expect(
+      computeQuotaPacing(
+        { usedPercent: 10, remainingPercent: 90, resetsAt: 'garbage' },
+        FIVE_HOUR_MS,
+        now,
+      ),
+    ).toBeNull()
+  })
+
+  test('null in the early-window noise guard', () => {
+    const fourMinutes = 4 * 60 * 1000
+    const { window } = fiveHourWindow(fourMinutes, 3)
+    expect(computeQuotaPacing(window, FIVE_HOUR_MS, now)).toBeNull()
+    const oneHour = 60 * 60 * 1000
+    const sevenDay = {
+      usedPercent: 3,
+      remainingPercent: 97,
+      resetsAt: new Date(now + SEVEN_DAY_MS - oneHour).toISOString(),
+    }
+    expect(computeQuotaPacing(sevenDay, SEVEN_DAY_MS, now)).toBeNull()
+  })
+
+  test('null when elapsed reaches or exceeds the window', () => {
+    const { window } = fiveHourWindow(FIVE_HOUR_MS, 80)
+    expect(computeQuotaPacing(window, FIVE_HOUR_MS, now)).toBeNull()
+    const past = {
+      usedPercent: 80,
+      remainingPercent: 20,
+      resetsAt: new Date(now - 1000).toISOString(),
+    }
+    expect(computeQuotaPacing(past, FIVE_HOUR_MS, now)).toBeNull()
   })
 })

--- a/packages/opencode/src/tests/tui-preferences.test.ts
+++ b/packages/opencode/src/tests/tui-preferences.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   computeEffectiveOrder,
   DEFAULT_PREFS,
   getTuiPreferencesFile,
+  PLUGIN_KEY,
+  queueTuiPreferenceUpdate,
   readTuiPreferencesFile,
   resolveAnthropicAuthPrefs,
   TUI_PREFS_FILE_ENV,
@@ -249,5 +251,64 @@ describe('computeEffectiveOrder', () => {
         160,
       ),
     ).toBe(160)
+  })
+})
+
+describe('queueTuiPreferenceUpdate', () => {
+  test('creates file with template on first write', async () => {
+    await queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], true)
+    const text = await readFile(file, 'utf8')
+    expect(text).toContain('Shared preferences for opencode TUI plugins')
+    const root = await readTuiPreferencesFile()
+    expect(root).toEqual({ 'anthropic-auth': { collapsed: true } })
+  })
+
+  test('preserves comments and unrelated keys on update', async () => {
+    const original = `// my notes
+{
+  // keep me
+  "other-plugin": { "forceToTop": true },
+  "anthropic-auth": {
+    "pollMs": 2000, // tuned
+    "collapsed": false
+  }
+}
+`
+    await writeFile(file, original, 'utf8')
+    await queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], true)
+    const text = await readFile(file, 'utf8')
+    expect(text).toContain('// my notes')
+    expect(text).toContain('// keep me')
+    expect(text).toContain('// tuned')
+    expect(text).toContain('"pollMs": 2000')
+    const root = await readTuiPreferencesFile()
+    expect(root['other-plugin']).toEqual({ forceToTop: true })
+    expect((root['anthropic-auth'] as Record<string, unknown>).collapsed).toBe(
+      true,
+    )
+  })
+
+  test('writes nested paths', async () => {
+    await queueTuiPreferenceUpdate(PLUGIN_KEY, ['header', 'label'], 'Q')
+    const root = await readTuiPreferencesFile()
+    expect(root).toEqual({ 'anthropic-auth': { header: { label: 'Q' } } })
+  })
+
+  test('rapid sequential updates land the final value', async () => {
+    const writes = [true, false, true, false].map((value) =>
+      queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], value),
+    )
+    await Promise.all(writes)
+    const root = await readTuiPreferencesFile()
+    expect((root['anthropic-auth'] as Record<string, unknown>).collapsed).toBe(
+      false,
+    )
+  })
+
+  test('no temp files are left behind', async () => {
+    await queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], true)
+    const { readdir } = await import('node:fs/promises')
+    const entries = await readdir(dir)
+    expect(entries).toEqual(['tui-preferences.jsonc'])
   })
 })

--- a/packages/opencode/src/tests/tui-preferences.test.ts
+++ b/packages/opencode/src/tests/tui-preferences.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  computeEffectiveOrder,
   DEFAULT_PREFS,
   getTuiPreferencesFile,
   readTuiPreferencesFile,
@@ -194,5 +195,59 @@ describe('resolveAnthropicAuthPrefs', () => {
     expect(resolveAnthropicAuthPrefs({ 'anthropic-auth': 42 })).toEqual(
       DEFAULT_PREFS,
     )
+  })
+})
+
+describe('computeEffectiveOrder', () => {
+  test('missing key returns default order', () => {
+    expect(computeEffectiveOrder({}, 'anthropic-auth', 160)).toBe(160)
+  })
+
+  test('explicit order knob is used and clamped', () => {
+    expect(
+      computeEffectiveOrder(
+        { 'anthropic-auth': { order: 42 } },
+        'anthropic-auth',
+        160,
+      ),
+    ).toBe(42)
+    expect(
+      computeEffectiveOrder(
+        { 'anthropic-auth': { order: -99999999 } },
+        'anthropic-auth',
+        160,
+      ),
+    ).toBe(-10000)
+  })
+
+  test('forceToTop beats any explicit order', () => {
+    expect(
+      computeEffectiveOrder(
+        { 'anthropic-auth': { forceToTop: true, order: -10000 } },
+        'anthropic-auth',
+        160,
+      ),
+    ).toBe(-100000)
+  })
+
+  test('multiple forced plugins order by key position in file', () => {
+    const root = {
+      'plugin-a': { forceToTop: true },
+      'plugin-b': { order: 5 },
+      'plugin-c': { forceToTop: true },
+    }
+    expect(computeEffectiveOrder(root, 'plugin-a', 0)).toBe(-100000)
+    expect(computeEffectiveOrder(root, 'plugin-c', 0)).toBe(-99998)
+    expect(computeEffectiveOrder(root, 'plugin-b', 0)).toBe(5)
+  })
+
+  test('non-boolean forceToTop is ignored', () => {
+    expect(
+      computeEffectiveOrder(
+        { 'anthropic-auth': { forceToTop: 'yes' } },
+        'anthropic-auth',
+        160,
+      ),
+    ).toBe(160)
   })
 })

--- a/packages/opencode/src/tests/tui-preferences.test.ts
+++ b/packages/opencode/src/tests/tui-preferences.test.ts
@@ -133,6 +133,7 @@ describe('resolveAnthropicAuthPrefs', () => {
       routing: false,
       cache: false,
       health: true,
+      pacing: true,
     })
     expect(prefs.appearance.barWidth).toBe(20)
     expect(prefs.appearance.warnThreshold).toBe(60)
@@ -222,6 +223,20 @@ describe('resolveAnthropicAuthPrefs', () => {
     expect(resolveAnthropicAuthPrefs({ 'anthropic-auth': 42 })).toEqual(
       DEFAULT_PREFS,
     )
+  })
+
+  test('sections.pacing defaults true, accepts false, rejects wrong type', () => {
+    expect(resolveAnthropicAuthPrefs({}).sections.pacing).toBe(true)
+    expect(
+      resolveAnthropicAuthPrefs({
+        'anthropic-auth': { sections: { pacing: false } },
+      }).sections.pacing,
+    ).toBe(false)
+    expect(
+      resolveAnthropicAuthPrefs({
+        'anthropic-auth': { sections: { pacing: 'off' } },
+      }).sections.pacing,
+    ).toBe(true)
   })
 })
 

--- a/packages/opencode/src/tests/tui-preferences.test.ts
+++ b/packages/opencode/src/tests/tui-preferences.test.ts
@@ -3,8 +3,10 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  DEFAULT_PREFS,
   getTuiPreferencesFile,
   readTuiPreferencesFile,
+  resolveAnthropicAuthPrefs,
   TUI_PREFS_FILE_ENV,
 } from '../tui-preferences'
 
@@ -73,5 +75,124 @@ describe('readTuiPreferencesFile', () => {
   test('non-object root returns empty object', async () => {
     await writeFile(file, '[1, 2, 3]', 'utf8')
     expect(await readTuiPreferencesFile()).toEqual({})
+  })
+})
+
+describe('resolveAnthropicAuthPrefs', () => {
+  test('empty root yields defaults', () => {
+    const prefs = resolveAnthropicAuthPrefs({})
+    expect(prefs).toEqual(DEFAULT_PREFS)
+    expect(prefs.order).toBe(160)
+    expect(prefs.collapsed).toBeNull()
+  })
+
+  test('valid values pass through', () => {
+    const prefs = resolveAnthropicAuthPrefs({
+      'anthropic-auth': {
+        forceToTop: true,
+        order: -500,
+        startCollapsed: true,
+        rememberCollapsed: false,
+        collapsed: true,
+        pollMs: 5000,
+        refreshDebounceMs: 100,
+        header: { label: 'QUOTA', showVersion: false },
+        sections: { routing: false, cache: false },
+        appearance: { barWidth: 20, warnThreshold: 60, errorThreshold: 90 },
+      },
+    })
+    expect(prefs.forceToTop).toBe(true)
+    expect(prefs.order).toBe(-500)
+    expect(prefs.startCollapsed).toBe(true)
+    expect(prefs.rememberCollapsed).toBe(false)
+    expect(prefs.collapsed).toBe(true)
+    expect(prefs.pollMs).toBe(5000)
+    expect(prefs.refreshDebounceMs).toBe(100)
+    expect(prefs.header).toEqual({ label: 'QUOTA', showVersion: false })
+    expect(prefs.sections).toEqual({
+      quota: true,
+      fallbackAccounts: true,
+      routing: false,
+      cache: false,
+      health: true,
+    })
+    expect(prefs.appearance.barWidth).toBe(20)
+    expect(prefs.appearance.warnThreshold).toBe(60)
+    expect(prefs.appearance.errorThreshold).toBe(90)
+  })
+
+  test('numbers are clamped to their ranges', () => {
+    const prefs = resolveAnthropicAuthPrefs({
+      'anthropic-auth': {
+        order: 99999999,
+        pollMs: 1,
+        refreshDebounceMs: 999999,
+        appearance: { barWidth: 1000, warnThreshold: -5, errorThreshold: 400 },
+      },
+    })
+    expect(prefs.order).toBe(10000)
+    expect(prefs.pollMs).toBe(500)
+    expect(prefs.refreshDebounceMs).toBe(5000)
+    expect(prefs.appearance.barWidth).toBe(40)
+    expect(prefs.appearance.warnThreshold).toBe(0)
+    expect(prefs.appearance.errorThreshold).toBe(100)
+  })
+
+  test('errorThreshold is forced above warnThreshold', () => {
+    const prefs = resolveAnthropicAuthPrefs({
+      'anthropic-auth': {
+        appearance: { warnThreshold: 80, errorThreshold: 30 },
+      },
+    })
+    expect(prefs.appearance.warnThreshold).toBe(80)
+    expect(prefs.appearance.errorThreshold).toBe(81)
+  })
+
+  test('label is truncated to 20 chars and empty label falls back', () => {
+    const long = resolveAnthropicAuthPrefs({
+      'anthropic-auth': { header: { label: 'X'.repeat(50) } },
+    })
+    expect(long.header.label).toBe('X'.repeat(20))
+    const empty = resolveAnthropicAuthPrefs({
+      'anthropic-auth': { header: { label: '' } },
+    })
+    expect(empty.header.label).toBe('CLAUDE')
+  })
+
+  test('bar chars reduce to first code point', () => {
+    const prefs = resolveAnthropicAuthPrefs({
+      'anthropic-auth': {
+        appearance: { barFilledChar: 'abc', barEmptyChar: '🟦🟦' },
+      },
+    })
+    expect(prefs.appearance.barFilledChar).toBe('a')
+    expect(prefs.appearance.barEmptyChar).toBe('🟦')
+  })
+
+  test('wrong types fall back per key, unknown keys ignored', () => {
+    const prefs = resolveAnthropicAuthPrefs({
+      'anthropic-auth': {
+        forceToTop: 'yes',
+        order: 'high',
+        pollMs: null,
+        header: 'big',
+        sections: { quota: 1, bogus: true },
+        appearance: { barWidth: '12' },
+        somethingElse: { nested: true },
+      },
+    })
+    expect(prefs.forceToTop).toBe(false)
+    expect(prefs.order).toBe(160)
+    expect(prefs.pollMs).toBe(1500)
+    expect(prefs.header).toEqual(DEFAULT_PREFS.header)
+    expect(prefs.sections.quota).toBe(true)
+    expect(prefs.appearance.barWidth).toBe(10)
+    expect('bogus' in prefs.sections).toBe(false)
+  })
+
+  test('non-object plugin entry yields defaults', () => {
+    expect(resolveAnthropicAuthPrefs({ 'anthropic-auth': 42 })).toEqual(
+      DEFAULT_PREFS,
+    )
   })
 })

--- a/packages/opencode/src/tests/tui-preferences.test.ts
+++ b/packages/opencode/src/tests/tui-preferences.test.ts
@@ -416,4 +416,20 @@ describe('watchTuiPreferences', () => {
       dispose()
     }
   })
+
+  test('does not fire when the file is rewritten with identical content', async () => {
+    await writeFile(file, '{}', 'utf8')
+    let fired = 0
+    const dispose = watchTuiPreferences(() => {
+      fired += 1
+    })
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      await writeFile(file, '{}', 'utf8')
+      await new Promise((resolve) => setTimeout(resolve, 400))
+      expect(fired).toBe(0)
+    } finally {
+      dispose()
+    }
+  })
 })

--- a/packages/opencode/src/tests/tui-preferences.test.ts
+++ b/packages/opencode/src/tests/tui-preferences.test.ts
@@ -11,6 +11,7 @@ import {
   readTuiPreferencesFile,
   resolveAnthropicAuthPrefs,
   TUI_PREFS_FILE_ENV,
+  watchTuiPreferences,
 } from '../tui-preferences'
 
 let dir: string
@@ -310,5 +311,62 @@ describe('queueTuiPreferenceUpdate', () => {
     const { readdir } = await import('node:fs/promises')
     const entries = await readdir(dir)
     expect(entries).toEqual(['tui-preferences.jsonc'])
+  })
+})
+
+describe('watchTuiPreferences', () => {
+  test('fires after the file changes', async () => {
+    await writeFile(file, '{}', 'utf8')
+    let fired = 0
+    const dispose = watchTuiPreferences(() => {
+      fired += 1
+    })
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      await queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], true)
+      await new Promise((resolve) => setTimeout(resolve, 400))
+      expect(fired).toBeGreaterThanOrEqual(1)
+    } finally {
+      dispose()
+    }
+  })
+
+  test('debounces bursts into few callbacks', async () => {
+    await writeFile(file, '{}', 'utf8')
+    let fired = 0
+    const dispose = watchTuiPreferences(() => {
+      fired += 1
+    })
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      for (let i = 0; i < 5; i++) {
+        await queueTuiPreferenceUpdate(PLUGIN_KEY, ['pollMs'], 1000 + i)
+      }
+      await new Promise((resolve) => setTimeout(resolve, 400))
+      expect(fired).toBeGreaterThanOrEqual(1)
+      expect(fired).toBeLessThan(5)
+    } finally {
+      dispose()
+    }
+  })
+
+  test('missing directory returns a no-op disposer', () => {
+    process.env[TUI_PREFS_FILE_ENV] = join(dir, 'nope', 'missing.jsonc')
+    const dispose = watchTuiPreferences(() => {})
+    expect(typeof dispose).toBe('function')
+    dispose()
+  })
+
+  test('dispose stops callbacks', async () => {
+    await writeFile(file, '{}', 'utf8')
+    let fired = 0
+    const dispose = watchTuiPreferences(() => {
+      fired += 1
+    })
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    dispose()
+    await queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], true)
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(fired).toBe(0)
   })
 })

--- a/packages/opencode/src/tests/tui-preferences.test.ts
+++ b/packages/opencode/src/tests/tui-preferences.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getTuiPreferencesFile,
+  readTuiPreferencesFile,
+  TUI_PREFS_FILE_ENV,
+} from '../tui-preferences'
+
+let dir: string
+let file: string
+const savedEnv: Record<string, string | undefined> = {}
+const ENV_KEYS = [TUI_PREFS_FILE_ENV, 'OPENCODE_CONFIG_DIR', 'XDG_CONFIG_HOME']
+
+beforeEach(async () => {
+  for (const key of ENV_KEYS) savedEnv[key] = process.env[key]
+  dir = await mkdtemp(join(tmpdir(), 'tui-prefs-test-'))
+  file = join(dir, 'tui-preferences.jsonc')
+  process.env[TUI_PREFS_FILE_ENV] = file
+})
+
+afterEach(async () => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key]
+    else process.env[key] = savedEnv[key]
+  }
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('getTuiPreferencesFile', () => {
+  test('env override wins', () => {
+    expect(getTuiPreferencesFile()).toBe(file)
+  })
+
+  test('OPENCODE_CONFIG_DIR beats XDG_CONFIG_HOME', () => {
+    delete process.env[TUI_PREFS_FILE_ENV]
+    process.env.OPENCODE_CONFIG_DIR = '/cfg/opencode-dir'
+    process.env.XDG_CONFIG_HOME = '/xdg'
+    expect(getTuiPreferencesFile()).toBe(
+      '/cfg/opencode-dir/tui-preferences.jsonc',
+    )
+  })
+
+  test('XDG_CONFIG_HOME fallback appends opencode/', () => {
+    delete process.env[TUI_PREFS_FILE_ENV]
+    delete process.env.OPENCODE_CONFIG_DIR
+    process.env.XDG_CONFIG_HOME = '/xdg'
+    expect(getTuiPreferencesFile()).toBe('/xdg/opencode/tui-preferences.jsonc')
+  })
+})
+
+describe('readTuiPreferencesFile', () => {
+  test('missing file returns empty object', async () => {
+    expect(await readTuiPreferencesFile()).toEqual({})
+  })
+
+  test('parses JSONC with comments and trailing commas', async () => {
+    await writeFile(
+      file,
+      `// header comment\n{\n  // plugin\n  "anthropic-auth": { "order": 5, },\n}\n`,
+      'utf8',
+    )
+    const root = await readTuiPreferencesFile()
+    expect(root).toEqual({ 'anthropic-auth': { order: 5 } })
+  })
+
+  test('malformed file returns empty object', async () => {
+    await writeFile(file, '{{{{ not json', 'utf8')
+    expect(await readTuiPreferencesFile()).toEqual({})
+  })
+
+  test('non-object root returns empty object', async () => {
+    await writeFile(file, '[1, 2, 3]', 'utf8')
+    expect(await readTuiPreferencesFile()).toEqual({})
+  })
+})

--- a/packages/opencode/src/tests/tui-preferences.test.ts
+++ b/packages/opencode/src/tests/tui-preferences.test.ts
@@ -76,6 +76,20 @@ describe('readTuiPreferencesFile', () => {
     expect(await readTuiPreferencesFile()).toEqual({})
   })
 
+  test('unterminated object returns empty object', async () => {
+    await writeFile(file, '{"anthropic-auth": {"order": 5}', 'utf8')
+    expect(await readTuiPreferencesFile()).toEqual({})
+  })
+
+  test('trailing garbage after object returns empty object', async () => {
+    await writeFile(
+      file,
+      '{"anthropic-auth":{"order":5}} trailing garbage',
+      'utf8',
+    )
+    expect(await readTuiPreferencesFile()).toEqual({})
+  })
+
   test('non-object root returns empty object', async () => {
     await writeFile(file, '[1, 2, 3]', 'utf8')
     expect(await readTuiPreferencesFile()).toEqual({})
@@ -150,6 +164,16 @@ describe('resolveAnthropicAuthPrefs', () => {
     })
     expect(prefs.appearance.warnThreshold).toBe(80)
     expect(prefs.appearance.errorThreshold).toBe(81)
+  })
+
+  test('warnThreshold is clamped to 0..99 so error can stay strictly above it', () => {
+    const prefs = resolveAnthropicAuthPrefs({
+      'anthropic-auth': {
+        appearance: { warnThreshold: 100, errorThreshold: 30 },
+      },
+    })
+    expect(prefs.appearance.warnThreshold).toBe(99)
+    expect(prefs.appearance.errorThreshold).toBe(100)
   })
 
   test('label is truncated to 20 chars and empty label falls back', () => {
@@ -368,5 +392,28 @@ describe('watchTuiPreferences', () => {
     await queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], true)
     await new Promise((resolve) => setTimeout(resolve, 300))
     expect(fired).toBe(0)
+  })
+
+  test('ignores sibling files that share the preferences name as a prefix', async () => {
+    await writeFile(file, '{}', 'utf8')
+    let fired = 0
+    const dispose = watchTuiPreferences(() => {
+      fired += 1
+    })
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      await writeFile(
+        join(dir, 'tui-preferences.jsonc.backup'),
+        'noise',
+        'utf8',
+      )
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      expect(fired).toBe(0)
+      await queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], true)
+      await new Promise((resolve) => setTimeout(resolve, 400))
+      expect(fired).toBeGreaterThanOrEqual(1)
+    } finally {
+      dispose()
+    }
   })
 })

--- a/packages/opencode/src/tui-preferences.ts
+++ b/packages/opencode/src/tui-preferences.ts
@@ -1,7 +1,7 @@
-import { readFile } from 'node:fs/promises'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
-import { parse } from 'jsonc-parser'
+import { dirname, join } from 'node:path'
+import { applyEdits, modify, parse } from 'jsonc-parser'
 
 export const TUI_PREFS_FILE_ENV = 'OPENCODE_TUI_PREFERENCES_FILE'
 const FILE_NAME = 'tui-preferences.jsonc'
@@ -201,4 +201,53 @@ export function computeEffectiveOrder(
     return FORCE_TOP_BASE + Object.keys(root).indexOf(pluginKey)
   }
   return int(entry.order, defaultOrder, -10000, 10000)
+}
+
+const TEMPLATE = `// Shared preferences for opencode TUI plugins.
+// One top-level key per plugin (short name). See each plugin's README for
+// its supported settings. This file is safe to hand-edit; plugins update
+// individual keys in place and preserve comments.
+{}
+`
+
+type JsonValue = string | number | boolean | null
+
+async function writePreference(
+  pluginKey: string,
+  path: string[],
+  value: JsonValue,
+): Promise<void> {
+  const file = getTuiPreferencesFile()
+  await mkdir(dirname(file), { recursive: true })
+  let text: string
+  try {
+    text = await readFile(file, 'utf8')
+  } catch {
+    text = ''
+  }
+  if (text.trim() === '') text = TEMPLATE
+  const edits = modify(text, [pluginKey, ...path], value, {
+    formattingOptions: { insertSpaces: true, tabSize: 2 },
+  })
+  const next = applyEdits(text, edits)
+  const tmp = `${file}.${process.pid}.tmp`
+  await writeFile(tmp, next, 'utf8')
+  await rename(tmp, file)
+}
+
+let writeChain: Promise<void> = Promise.resolve()
+
+// Writes are serialized on a promise chain: each update re-reads the file,
+// applies a minimal comment-preserving edit to one property, and replaces the
+// file atomically (temp + rename in the same directory). Best-effort by
+// design — preferences are never worth crashing the TUI over.
+export function queueTuiPreferenceUpdate(
+  pluginKey: string,
+  path: string[],
+  value: JsonValue,
+): Promise<void> {
+  writeChain = writeChain
+    .then(() => writePreference(pluginKey, path, value))
+    .catch(() => {})
+  return writeChain
 }

--- a/packages/opencode/src/tui-preferences.ts
+++ b/packages/opencode/src/tui-preferences.ts
@@ -36,3 +36,148 @@ export async function readTuiPreferencesFile(): Promise<
     return {}
   }
 }
+
+export const PLUGIN_KEY = 'anthropic-auth'
+export const DEFAULT_SLOT_ORDER = 160
+
+export interface AnthropicAuthTuiPrefs {
+  forceToTop: boolean
+  order: number
+  startCollapsed: boolean
+  rememberCollapsed: boolean
+  // null = never persisted; seed the UI from startCollapsed instead.
+  collapsed: boolean | null
+  pollMs: number
+  refreshDebounceMs: number
+  header: {
+    label: string
+    showVersion: boolean
+  }
+  sections: {
+    quota: boolean
+    fallbackAccounts: boolean
+    routing: boolean
+    cache: boolean
+    health: boolean
+  }
+  appearance: {
+    barWidth: number
+    barFilledChar: string
+    barEmptyChar: string
+    warnThreshold: number
+    errorThreshold: number
+  }
+}
+
+export type AppearancePrefs = AnthropicAuthTuiPrefs['appearance']
+
+export const DEFAULT_PREFS: AnthropicAuthTuiPrefs = {
+  forceToTop: false,
+  order: DEFAULT_SLOT_ORDER,
+  startCollapsed: false,
+  rememberCollapsed: true,
+  collapsed: null,
+  pollMs: 1500,
+  refreshDebounceMs: 200,
+  header: { label: 'CLAUDE', showVersion: true },
+  sections: {
+    quota: true,
+    fallbackAccounts: true,
+    routing: true,
+    cache: true,
+    health: true,
+  },
+  appearance: {
+    barWidth: 10,
+    barFilledChar: '\u2588',
+    barEmptyChar: '\u2591',
+    warnThreshold: 50,
+    errorThreshold: 80,
+  },
+}
+
+function bool(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function int(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.min(Math.max(Math.round(value), min), max)
+}
+
+function label(value: unknown, fallback: string, maxLength: number): string {
+  if (typeof value !== 'string' || value.length === 0) return fallback
+  return value.slice(0, maxLength)
+}
+
+function char(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback
+  const first = [...value][0]
+  return first ?? fallback
+}
+
+// Per-key validation: every value is independently clamped/defaulted so one
+// bad entry never poisons the rest. Never throws.
+export function resolveAnthropicAuthPrefs(
+  root: Record<string, unknown>,
+): AnthropicAuthTuiPrefs {
+  const entry = root[PLUGIN_KEY]
+  if (!isRecord(entry)) return structuredClone(DEFAULT_PREFS)
+
+  const d = DEFAULT_PREFS
+  const header = isRecord(entry.header) ? entry.header : {}
+  const sections = isRecord(entry.sections) ? entry.sections : {}
+  const appearance = isRecord(entry.appearance) ? entry.appearance : {}
+
+  const warnThreshold = int(
+    appearance.warnThreshold,
+    d.appearance.warnThreshold,
+    0,
+    100,
+  )
+  const errorThreshold = Math.max(
+    int(appearance.errorThreshold, d.appearance.errorThreshold, 0, 100),
+    Math.min(warnThreshold + 1, 100),
+  )
+
+  return {
+    forceToTop: bool(entry.forceToTop, d.forceToTop),
+    order: int(entry.order, d.order, -10000, 10000),
+    startCollapsed: bool(entry.startCollapsed, d.startCollapsed),
+    rememberCollapsed: bool(entry.rememberCollapsed, d.rememberCollapsed),
+    collapsed: typeof entry.collapsed === 'boolean' ? entry.collapsed : null,
+    pollMs: int(entry.pollMs, d.pollMs, 500, 30000),
+    refreshDebounceMs: int(
+      entry.refreshDebounceMs,
+      d.refreshDebounceMs,
+      50,
+      5000,
+    ),
+    header: {
+      label: label(header.label, d.header.label, 20),
+      showVersion: bool(header.showVersion, d.header.showVersion),
+    },
+    sections: {
+      quota: bool(sections.quota, d.sections.quota),
+      fallbackAccounts: bool(
+        sections.fallbackAccounts,
+        d.sections.fallbackAccounts,
+      ),
+      routing: bool(sections.routing, d.sections.routing),
+      cache: bool(sections.cache, d.sections.cache),
+      health: bool(sections.health, d.sections.health),
+    },
+    appearance: {
+      barWidth: int(appearance.barWidth, d.appearance.barWidth, 4, 40),
+      barFilledChar: char(appearance.barFilledChar, d.appearance.barFilledChar),
+      barEmptyChar: char(appearance.barEmptyChar, d.appearance.barEmptyChar),
+      warnThreshold,
+      errorThreshold,
+    },
+  }
+}

--- a/packages/opencode/src/tui-preferences.ts
+++ b/packages/opencode/src/tui-preferences.ts
@@ -2,7 +2,7 @@ import { watch } from 'node:fs'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
-import { applyEdits, modify, parse } from 'jsonc-parser'
+import { applyEdits, modify, type ParseError, parse } from 'jsonc-parser'
 
 export const TUI_PREFS_FILE_ENV = 'OPENCODE_TUI_PREFERENCES_FILE'
 const FILE_NAME = 'tui-preferences.jsonc'
@@ -25,13 +25,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 // Tolerant read: missing file, parse errors, or a non-object root all resolve
 // to {} so the sidebar never crashes on user-edited content. jsonc-parser's
-// fault-tolerant parse handles comments and trailing commas.
+// fault-tolerant parse can still hand back a partial object for an
+// unterminated/bracketed file or trailing garbage, so we collect errors and
+// treat any reported fault as malformed.
 export async function readTuiPreferencesFile(): Promise<
   Record<string, unknown>
 > {
   try {
     const raw = await readFile(getTuiPreferencesFile(), 'utf8')
-    const root: unknown = parse(raw)
+    const errors: ParseError[] = []
+    const root: unknown = parse(raw, errors, { allowTrailingComma: true })
+    if (errors.length > 0) return {}
     return isRecord(root) ? root : {}
   } catch {
     return {}
@@ -139,7 +143,7 @@ export function resolveAnthropicAuthPrefs(
     appearance.warnThreshold,
     d.appearance.warnThreshold,
     0,
-    100,
+    99,
   )
   const errorThreshold = Math.max(
     int(appearance.errorThreshold, d.appearance.errorThreshold, 0, 100),
@@ -191,6 +195,13 @@ const FORCE_TOP_BASE = -100000
 // to -10000..10000, strictly above the forced band, so a manual order can
 // never beat forceToTop. Host slots render ascending by order; opencode's
 // built-ins occupy 100-500.
+//
+// Key-naming requirement: plugin keys must be non-integer-like short names
+// (e.g. "anthropic-auth"). JavaScript object key iteration order hoists
+// integer-like keys ("0", "1", "42") ahead of any string keys, which would
+// skew the indexOf-based ordering of forced plugins. The shared
+// `tui-preferences.jsonc` convention requires non-numeric names, so this
+// implementation does not paper over the JS quirk.
 export function computeEffectiveOrder(
   root: Record<string, unknown>,
   pluginKey: string,
@@ -257,15 +268,26 @@ const WATCH_DEBOUNCE_MS = 150
 
 // Watches the directory rather than the file: editors and our own atomic
 // writes replace the file via rename, which kills file-level watchers. Events
-// are filtered to the preferences file name (temp-file events share the
-// prefix) and debounced. Returns a disposer; never throws.
+// are filtered to the preferences file name and our atomic-write temp files
+// (sibling files like `tui-preferences.jsonc.backup` share the name as a
+// prefix but don't match either pattern, so they don't fire spuriously) and
+// debounced. Returns a disposer; never throws.
 export function watchTuiPreferences(onChange: () => void): () => void {
   const file = getTuiPreferencesFile()
   const name = basename(file)
   let timer: ReturnType<typeof setTimeout> | null = null
   try {
     const watcher = watch(dirname(file), (_event, filename) => {
-      if (filename != null && !filename.startsWith(name)) return
+      // Exact match against the preferences file name, plus the temp file
+      // we use for atomic writes (carrying our pid + `.tmp`). Sibling files
+      // like `tui-preferences.jsonc.backup` share the name as a prefix but
+      // don't match either pattern, so they no longer fire spurious
+      // callbacks. Direct edits to the file (e.g. an editor save) emit
+      // `change` events with the final filename, which still match.
+      const isOurs =
+        filename === name ||
+        (filename?.startsWith(`${name}.`) && filename.endsWith('.tmp'))
+      if (filename != null && !isOurs) return
       if (timer) clearTimeout(timer)
       timer = setTimeout(() => {
         timer = null

--- a/packages/opencode/src/tui-preferences.ts
+++ b/packages/opencode/src/tui-preferences.ts
@@ -267,23 +267,40 @@ export function queueTuiPreferenceUpdate(
 const WATCH_DEBOUNCE_MS = 150
 
 // Watches the directory rather than the file: editors and our own atomic
-// writes replace the file via rename, which kills file-level watchers. Events
-// are filtered to the preferences file name and our atomic-write temp files
-// (sibling files like `tui-preferences.jsonc.backup` share the name as a
-// prefix but don't match either pattern, so they don't fire spuriously) and
-// debounced. Returns a disposer; never throws.
+// writes replace the file via rename, which kills file-level watchers.
+//
+// Filtering is two-stage:
+//   1. Filename pre-filter: only debounce events for the preferences file
+//      name, or our atomic-write temp file. This is a cheap first pass that
+//      drops the common case (unrelated sibling files).
+//   2. Content check inside the debounce: after the timer fires, re-read
+//      the file and compare it against the last seen content. Only fire
+//      `onChange` when the content actually changed. This is the authority.
+//      Some platforms (notably macOS FSEvents and a few inotify backends)
+//      can misattribute a rename of an unrelated sibling file to the
+//      real preferences filename in addition to emitting the sibling's
+//      own event, so a name-only filter still produces a stray callback.
+//      A content comparison is robust against that, against coalesced
+//      events, and against mtime granularity.
+//
+// Returns a disposer; never throws.
 export function watchTuiPreferences(onChange: () => void): () => void {
   const file = getTuiPreferencesFile()
   const name = basename(file)
   let timer: ReturnType<typeof setTimeout> | null = null
+  let lastSeen: string | null = null
+  // Seed asynchronously; a real change that fires before the seed resolves
+  // still wins because the debounce re-reads the file fresh and compares
+  // against `lastSeen` (which will be `null` → does not match → fires).
+  void readFile(file, 'utf8')
+    .then((text) => {
+      if (lastSeen === null) lastSeen = text
+    })
+    .catch(() => {})
   try {
     const watcher = watch(dirname(file), (_event, filename) => {
       // Exact match against the preferences file name, plus the temp file
-      // we use for atomic writes (carrying our pid + `.tmp`). Sibling files
-      // like `tui-preferences.jsonc.backup` share the name as a prefix but
-      // don't match either pattern, so they no longer fire spurious
-      // callbacks. Direct edits to the file (e.g. an editor save) emit
-      // `change` events with the final filename, which still match.
+      // we use for atomic writes (carrying our pid + `.tmp`).
       const isOurs =
         filename === name ||
         (filename?.startsWith(`${name}.`) && filename.endsWith('.tmp'))
@@ -291,7 +308,14 @@ export function watchTuiPreferences(onChange: () => void): () => void {
       if (timer) clearTimeout(timer)
       timer = setTimeout(() => {
         timer = null
-        onChange()
+        void readFile(file, 'utf8')
+          .catch(() => null)
+          .then((text) => {
+            if (text === null) return
+            if (text === lastSeen) return
+            lastSeen = text
+            onChange()
+          })
       }, WATCH_DEBOUNCE_MS)
     })
     return () => {

--- a/packages/opencode/src/tui-preferences.ts
+++ b/packages/opencode/src/tui-preferences.ts
@@ -1,6 +1,7 @@
+import { watch } from 'node:fs'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { applyEdits, modify, parse } from 'jsonc-parser'
 
 export const TUI_PREFS_FILE_ENV = 'OPENCODE_TUI_PREFERENCES_FILE'
@@ -250,4 +251,32 @@ export function queueTuiPreferenceUpdate(
     .then(() => writePreference(pluginKey, path, value))
     .catch(() => {})
   return writeChain
+}
+
+const WATCH_DEBOUNCE_MS = 150
+
+// Watches the directory rather than the file: editors and our own atomic
+// writes replace the file via rename, which kills file-level watchers. Events
+// are filtered to the preferences file name (temp-file events share the
+// prefix) and debounced. Returns a disposer; never throws.
+export function watchTuiPreferences(onChange: () => void): () => void {
+  const file = getTuiPreferencesFile()
+  const name = basename(file)
+  let timer: ReturnType<typeof setTimeout> | null = null
+  try {
+    const watcher = watch(dirname(file), (_event, filename) => {
+      if (filename != null && !filename.startsWith(name)) return
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        timer = null
+        onChange()
+      }, WATCH_DEBOUNCE_MS)
+    })
+    return () => {
+      if (timer) clearTimeout(timer)
+      watcher.close()
+    }
+  } catch {
+    return () => {}
+  }
 }

--- a/packages/opencode/src/tui-preferences.ts
+++ b/packages/opencode/src/tui-preferences.ts
@@ -64,6 +64,7 @@ export interface AnthropicAuthTuiPrefs {
     routing: boolean
     cache: boolean
     health: boolean
+    pacing: boolean
   }
   appearance: {
     barWidth: number
@@ -91,6 +92,7 @@ export const DEFAULT_PREFS: AnthropicAuthTuiPrefs = {
     routing: true,
     cache: true,
     health: true,
+    pacing: true,
   },
   appearance: {
     barWidth: 10,
@@ -176,6 +178,7 @@ export function resolveAnthropicAuthPrefs(
       routing: bool(sections.routing, d.sections.routing),
       cache: bool(sections.cache, d.sections.cache),
       health: bool(sections.health, d.sections.health),
+      pacing: bool(sections.pacing, d.sections.pacing),
     },
     appearance: {
       barWidth: int(appearance.barWidth, d.appearance.barWidth, 4, 40),

--- a/packages/opencode/src/tui-preferences.ts
+++ b/packages/opencode/src/tui-preferences.ts
@@ -181,3 +181,24 @@ export function resolveAnthropicAuthPrefs(
     },
   }
 }
+
+const FORCE_TOP_BASE = -100000
+
+// Shared forceToTop convention: forced plugins sort below FORCE_TOP_BASE,
+// ordered among themselves by their top-level key's position in the file, so
+// users reprioritize by reordering keys. The user-facing `order` knob clamps
+// to -10000..10000, strictly above the forced band, so a manual order can
+// never beat forceToTop. Host slots render ascending by order; opencode's
+// built-ins occupy 100-500.
+export function computeEffectiveOrder(
+  root: Record<string, unknown>,
+  pluginKey: string,
+  defaultOrder: number,
+): number {
+  const entry = root[pluginKey]
+  if (!isRecord(entry)) return defaultOrder
+  if (entry.forceToTop === true) {
+    return FORCE_TOP_BASE + Object.keys(root).indexOf(pluginKey)
+  }
+  return int(entry.order, defaultOrder, -10000, 10000)
+}

--- a/packages/opencode/src/tui-preferences.ts
+++ b/packages/opencode/src/tui-preferences.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { parse } from 'jsonc-parser'
+
+export const TUI_PREFS_FILE_ENV = 'OPENCODE_TUI_PREFERENCES_FILE'
+const FILE_NAME = 'tui-preferences.jsonc'
+
+// Shared preferences file for opencode TUI plugins. One top-level key per
+// plugin (short name, e.g. "anthropic-auth"). The file is optional: every
+// reader must fall back to defaults when it is missing or malformed.
+export function getTuiPreferencesFile(): string {
+  const override = process.env[TUI_PREFS_FILE_ENV]
+  if (override) return override
+  const configDir =
+    process.env.OPENCODE_CONFIG_DIR ||
+    join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'opencode')
+  return join(configDir, FILE_NAME)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// Tolerant read: missing file, parse errors, or a non-object root all resolve
+// to {} so the sidebar never crashes on user-edited content. jsonc-parser's
+// fault-tolerant parse handles comments and trailing commas.
+export async function readTuiPreferencesFile(): Promise<
+  Record<string, unknown>
+> {
+  try {
+    const raw = await readFile(getTuiPreferencesFile(), 'utf8')
+    const root: unknown = parse(raw)
+    return isRecord(root) ? root : {}
+  } catch {
+    return {}
+  }
+}

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -262,20 +262,77 @@ async function readStateFromFile(): Promise<SidebarState> {
   return getSidebarState()
 }
 
+interface SidebarController {
+  prefs: () => AnthropicAuthTuiPrefs
+  collapsed: () => boolean
+  toggleCollapsed: () => void
+}
+
+// The TUI may unmount and remount sidebar_content when the user switches
+// views (e.g. main -> subagent -> main). A remount re-runs the component
+// body, so any signal created inside the component would reset to its
+// seed. The controller lives in the plugin closure (process lifetime)
+// and owns the durable prefs/collapse signals plus the single shared
+// watcher subscription, so collapse and live pref reloads survive the
+// remount. No effects or memos here — those need a Solid owner, so the
+// poll-interval createEffect stays inside the component.
+function createSidebarController(
+  initialPrefs: AnthropicAuthTuiPrefs,
+): SidebarController {
+  const [prefs, setPrefs] = createSignal<AnthropicAuthTuiPrefs>(initialPrefs)
+  const seedCollapsed =
+    initialPrefs.rememberCollapsed && initialPrefs.collapsed != null
+      ? initialPrefs.collapsed
+      : initialPrefs.startCollapsed
+  const [collapsed, setCollapsed] = createSignal(seedCollapsed)
+  let lastPersistedCollapsed: boolean | null = initialPrefs.collapsed
+  let lastApplied = JSON.stringify(initialPrefs)
+
+  // The watcher lives for the plugin/process lifetime — it is intentionally
+  // never disposed. Collapse guard mirrors the race-fix in toggleCollapsed:
+  // lastPersistedCollapsed is advanced only once our own write lands, so
+  // watcher echoes of the previous persisted value are rejected by the
+  // `!==` check and cannot revert a user click.
+  watchTuiPreferences(() => {
+    void (async () => {
+      const next = resolveAnthropicAuthPrefs(await readTuiPreferencesFile())
+      const serialized = JSON.stringify(next)
+      if (serialized === lastApplied) return
+      lastApplied = serialized
+      setPrefs(next)
+      if (
+        next.rememberCollapsed &&
+        next.collapsed != null &&
+        next.collapsed !== lastPersistedCollapsed
+      ) {
+        lastPersistedCollapsed = next.collapsed
+        setCollapsed(next.collapsed)
+      }
+    })()
+  })
+
+  function toggleCollapsed() {
+    const next = !collapsed()
+    setCollapsed(next)
+    if (prefs().rememberCollapsed) {
+      void queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], next).then(
+        () => {
+          lastPersistedCollapsed = next
+        },
+      )
+    }
+  }
+
+  return { prefs, collapsed, toggleCollapsed }
+}
+
 function QuotaSidebar(props: {
   api: TuiPluginApi
-  initialPrefs: AnthropicAuthTuiPrefs
+  controller: SidebarController
 }) {
+  const prefs = props.controller.prefs
+  const collapsed = props.controller.collapsed
   const [state, setState] = createSignal<SidebarState>(DEFAULT_SIDEBAR_STATE)
-  const [prefs, setPrefs] = createSignal<AnthropicAuthTuiPrefs>(
-    props.initialPrefs,
-  )
-  const seedCollapsed =
-    props.initialPrefs.rememberCollapsed && props.initialPrefs.collapsed != null
-      ? props.initialPrefs.collapsed
-      : props.initialPrefs.startCollapsed
-  const [collapsed, setCollapsed] = createSignal(seedCollapsed)
-  let lastPersistedCollapsed: boolean | null = props.initialPrefs.collapsed
   let lastUpdated = 0
   let debounce: ReturnType<typeof setTimeout> | null = null
 
@@ -308,52 +365,10 @@ function QuotaSidebar(props: {
   ]
   setTimeout(refresh, 300)
 
-  // Live preference reload. Skip no-op updates so our own collapse writes
-  // (which echo back through the watcher) don't churn the UI, and only sync
-  // the collapsed signal when the persisted value actually changed — a local
-  // click must not be clobbered by an unrelated file edit.
-  //
-  // `lastPersistedCollapsed` is advanced in the `.then()` of the write (see
-  // `toggleCollapsed`), not optimistically. While our write is in flight the
-  // marker still holds the previous persisted value, so any watcher event
-  // echoing that stale value is correctly rejected by the `!==` guard.
-  let lastApplied = JSON.stringify(props.initialPrefs)
-  const unwatch = watchTuiPreferences(() => {
-    void (async () => {
-      const next = resolveAnthropicAuthPrefs(await readTuiPreferencesFile())
-      const serialized = JSON.stringify(next)
-      if (serialized === lastApplied) return
-      lastApplied = serialized
-      setPrefs(next)
-      if (
-        next.rememberCollapsed &&
-        next.collapsed != null &&
-        next.collapsed !== lastPersistedCollapsed
-      ) {
-        lastPersistedCollapsed = next.collapsed
-        setCollapsed(next.collapsed)
-      }
-    })()
-  })
-
   onCleanup(() => {
     if (debounce) clearTimeout(debounce)
     for (const u of unsubs) u()
-    unwatch()
   })
-
-  function toggleCollapsed() {
-    if (!hasData()) return
-    const next = !collapsed()
-    setCollapsed(next)
-    if (prefs().rememberCollapsed) {
-      void queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], next).then(
-        () => {
-          lastPersistedCollapsed = next
-        },
-      )
-    }
-  }
 
   const theme = () => props.api.theme.current
   const enabledFallbacks = () => state().fallbacks.filter((f) => f.enabled)
@@ -409,7 +424,9 @@ function QuotaSidebar(props: {
         flexDirection='row'
         justifyContent='space-between'
         alignItems='center'
-        onMouseDown={toggleCollapsed}
+        onMouseDown={() => {
+          if (hasData()) props.controller.toggleCollapsed()
+        }}
       >
         <box paddingLeft={1} paddingRight={1} backgroundColor={theme().accent}>
           <text fg={theme().background}>
@@ -564,12 +581,12 @@ function QuotaSidebar(props: {
 
 const tui: TuiPlugin = async (api) => {
   const root = await readTuiPreferencesFile()
-  const initialPrefs = resolveAnthropicAuthPrefs(root)
+  const controller = createSidebarController(resolveAnthropicAuthPrefs(root))
   api.slots.register({
     order: computeEffectiveOrder(root, PLUGIN_KEY, DEFAULT_SLOT_ORDER),
     slots: {
       sidebar_content(_ctx: unknown, _props: { session_id: string }) {
-        return <QuotaSidebar api={api} initialPrefs={initialPrefs} />
+        return <QuotaSidebar api={api} controller={controller} />
       },
     },
   })

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -486,15 +486,20 @@ function QuotaSidebar(props: {
     )
   }
   const activeQuotaTone = (): Tone => {
-    if (activePacingDeficit()) return 'err'
     const summary = activeQuotaSummary()
     const values = [
       summary.fiveHourUsedPercent,
       summary.sevenDayUsedPercent,
     ].filter((value): value is number => value != null)
-    return values.length > 0
-      ? usageTone(Math.max(...values), prefs().appearance)
-      : 'muted'
+    // Pacing deficit is an advisory projection, not actual quota exhaustion,
+    // so it can only BUMP the usage tone up to warn at most — never soften a
+    // real warn/err usage reading and never paint a true red.
+    const base: Tone =
+      values.length > 0
+        ? usageTone(Math.max(...values), prefs().appearance)
+        : 'muted'
+    if (!activePacingDeficit()) return base
+    return base === 'ok' || base === 'muted' ? 'warn' : base
   }
 
   const quotaBackedOff = () => state().main.quotaBackedOff === true

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -312,6 +312,11 @@ function QuotaSidebar(props: {
   // (which echo back through the watcher) don't churn the UI, and only sync
   // the collapsed signal when the persisted value actually changed — a local
   // click must not be clobbered by an unrelated file edit.
+  //
+  // `lastPersistedCollapsed` is advanced in the `.then()` of the write (see
+  // `toggleCollapsed`), not optimistically. While our write is in flight the
+  // marker still holds the previous persisted value, so any watcher event
+  // echoing that stale value is correctly rejected by the `!==` guard.
   let lastApplied = JSON.stringify(props.initialPrefs)
   const unwatch = watchTuiPreferences(() => {
     void (async () => {
@@ -342,8 +347,11 @@ function QuotaSidebar(props: {
     const next = !collapsed()
     setCollapsed(next)
     if (prefs().rememberCollapsed) {
-      lastPersistedCollapsed = next
-      void queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], next)
+      void queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], next).then(
+        () => {
+          lastPersistedCollapsed = next
+        },
+      )
     }
   }
 

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -104,6 +104,8 @@ const PACE_DEFICIT_CHAR = '\u2593'
 // segment covering the gap — headroom being banked (reserve, ok tone) or the
 // overshoot itself (deficit, err tone) — then empty cells. Without pacing the
 // bar renders as a single fill+empty pair, identical to the pre-pacing look.
+// Empty text nodes still occupy a phantom cell in the opentui flex row, so
+// zero-length segments are dropped from every return path (plain and pacing).
 function quotaBarSegments(
   usedPct: number,
   appearance: AppearancePrefs,
@@ -121,20 +123,24 @@ function quotaBarSegments(
       tone: fillTone,
     },
   ]
-  if (!pacing) return plain
+  if (!pacing) return plain.filter((segment) => segment.text.length > 0)
   const paceCells = cells(pacing.pacePercent)
   const lo = Math.min(usedCells, paceCells)
   const hi = Math.max(usedCells, paceCells)
-  if (hi === lo) return plain
+  if (hi === lo) return plain.filter((segment) => segment.text.length > 0)
   const overspent = usedCells > paceCells
-  return [
-    { text: appearance.barFilledChar.repeat(lo), tone: fillTone },
-    {
-      text: (overspent ? PACE_DEFICIT_CHAR : PACE_RESERVE_CHAR).repeat(hi - lo),
-      tone: overspent ? 'err' : 'ok',
-    },
-    { text: appearance.barEmptyChar.repeat(width - hi), tone: fillTone },
-  ]
+  return (
+    [
+      { text: appearance.barFilledChar.repeat(lo), tone: fillTone },
+      {
+        text: (overspent ? PACE_DEFICIT_CHAR : PACE_RESERVE_CHAR).repeat(
+          hi - lo,
+        ),
+        tone: overspent ? 'err' : 'ok',
+      },
+      { text: appearance.barEmptyChar.repeat(width - hi), tone: fillTone },
+    ] as BarSegment[]
+  ).filter((segment) => segment.text.length > 0)
 }
 
 function formatResetIn(resetsAt: string | undefined): string {

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -8,7 +8,14 @@ import type {
   TuiPluginApi,
   TuiPluginModule,
 } from '@opencode-ai/plugin/tui'
-import { createSignal, For, type JSX, onCleanup, Show } from 'solid-js'
+import {
+  createEffect,
+  createSignal,
+  For,
+  type JSX,
+  onCleanup,
+  Show,
+} from 'solid-js'
 
 import {
   type AccountQuota,
@@ -18,14 +25,19 @@ import {
   resolveActiveAccount,
   type SidebarState,
 } from './sidebar-state.js'
-
-const POLL_MS = 1500
-const REFRESH_DEBOUNCE_MS = 200
+import {
+  type AnthropicAuthTuiPrefs,
+  type AppearancePrefs,
+  computeEffectiveOrder,
+  DEFAULT_SLOT_ORDER,
+  PLUGIN_KEY,
+  queueTuiPreferenceUpdate,
+  readTuiPreferencesFile,
+  resolveAnthropicAuthPrefs,
+  watchTuiPreferences,
+} from './tui-preferences.js'
 
 const ID = 'cortexkit.anthropic-auth'
-const BAR_WIDTH = 10
-const BAR_FILLED = '\u2588'
-const BAR_EMPTY = '\u2591'
 
 // Plugin version for the header (mirrors the Magic Context / AFT convention).
 // Read at runtime from package.json relative to this module — NOT a TS JSON
@@ -70,18 +82,22 @@ function toneColor(theme: ThemeCurrent, tone: Tone): ThemeColor {
   }
 }
 
-function usageTone(usedPct: number): Tone {
-  if (usedPct < 50) return 'ok'
-  if (usedPct < 80) return 'warn'
+function usageTone(usedPct: number, appearance: AppearancePrefs): Tone {
+  if (usedPct < appearance.warnThreshold) return 'ok'
+  if (usedPct < appearance.errorThreshold) return 'warn'
   return 'err'
 }
 
-function quotaBar(usedPct: number, width = BAR_WIDTH): string {
+function quotaBar(usedPct: number, appearance: AppearancePrefs): string {
+  const width = appearance.barWidth
   const filled = Math.max(
     0,
     Math.min(Math.round((usedPct / 100) * width), width),
   )
-  return BAR_FILLED.repeat(filled) + BAR_EMPTY.repeat(width - filled)
+  return (
+    appearance.barFilledChar.repeat(filled) +
+    appearance.barEmptyChar.repeat(width - filled)
+  )
 }
 
 function formatResetIn(resetsAt: string | undefined): string {
@@ -157,6 +173,7 @@ function CollapsedRow(props: {
 // with an optional muted reset suffix.
 function QuotaRow(props: {
   theme: ThemeCurrent
+  appearance: AppearancePrefs
   label: string
   window: { usedPercent: number; resetsAt?: string } | undefined
 }) {
@@ -178,10 +195,14 @@ function QuotaRow(props: {
       <box width='100%' flexDirection='row' justifyContent='space-between'>
         <box flexDirection='row'>
           <text fg={props.theme.textMuted}>{props.label.padEnd(3)}</text>
-          <text fg={toneColor(props.theme, usageTone(used()))}>
-            {quotaBar(used())}
+          <text
+            fg={toneColor(props.theme, usageTone(used(), props.appearance))}
+          >
+            {quotaBar(used(), props.appearance)}
           </text>
-          <text fg={toneColor(props.theme, usageTone(used()))}>
+          <text
+            fg={toneColor(props.theme, usageTone(used(), props.appearance))}
+          >
             {` ${String(Math.round(used())).padStart(3)}%`}
           </text>
         </box>
@@ -196,6 +217,7 @@ function QuotaRow(props: {
 // Account block: header row (name + status word) then per-window quota rows.
 function AccountBlock(props: {
   theme: ThemeCurrent
+  appearance: AppearancePrefs
   name: string
   quota: AccountQuota | null
   active: boolean
@@ -219,11 +241,13 @@ function AccountBlock(props: {
       >
         <QuotaRow
           theme={props.theme}
+          appearance={props.appearance}
           label='5h'
           window={props.quota?.five_hour}
         />
         <QuotaRow
           theme={props.theme}
+          appearance={props.appearance}
           label='7d'
           window={props.quota?.seven_day}
         />
@@ -238,9 +262,20 @@ async function readStateFromFile(): Promise<SidebarState> {
   return getSidebarState()
 }
 
-function QuotaSidebar(props: { api: TuiPluginApi }) {
+function QuotaSidebar(props: {
+  api: TuiPluginApi
+  initialPrefs: AnthropicAuthTuiPrefs
+}) {
   const [state, setState] = createSignal<SidebarState>(DEFAULT_SIDEBAR_STATE)
-  const [collapsed, setCollapsed] = createSignal(false)
+  const [prefs, setPrefs] = createSignal<AnthropicAuthTuiPrefs>(
+    props.initialPrefs,
+  )
+  const seedCollapsed =
+    props.initialPrefs.rememberCollapsed && props.initialPrefs.collapsed != null
+      ? props.initialPrefs.collapsed
+      : props.initialPrefs.startCollapsed
+  const [collapsed, setCollapsed] = createSignal(seedCollapsed)
+  let lastPersistedCollapsed: boolean | null = props.initialPrefs.collapsed
   let lastUpdated = 0
   let debounce: ReturnType<typeof setTimeout> | null = null
 
@@ -257,30 +292,70 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
     debounce = setTimeout(() => {
       debounce = null
       void refresh()
-    }, REFRESH_DEBOUNCE_MS)
+    }, prefs().refreshDebounceMs)
   }
 
   // Background poller (server and TUI run as separate module instances, so we
   // sync through the state file) plus event-driven refreshes for low latency.
-  const timer = setInterval(refresh, POLL_MS)
+  // The interval rebuilds whenever pollMs changes.
+  createEffect(() => {
+    const timer = setInterval(refresh, prefs().pollMs)
+    onCleanup(() => clearInterval(timer))
+  })
   const unsubs = [
     props.api.event.on('session.updated', scheduleRefresh),
     props.api.event.on('message.updated', scheduleRefresh),
   ]
   setTimeout(refresh, 300)
+
+  // Live preference reload. Skip no-op updates so our own collapse writes
+  // (which echo back through the watcher) don't churn the UI, and only sync
+  // the collapsed signal when the persisted value actually changed — a local
+  // click must not be clobbered by an unrelated file edit.
+  let lastApplied = JSON.stringify(props.initialPrefs)
+  const unwatch = watchTuiPreferences(() => {
+    void (async () => {
+      const next = resolveAnthropicAuthPrefs(await readTuiPreferencesFile())
+      const serialized = JSON.stringify(next)
+      if (serialized === lastApplied) return
+      lastApplied = serialized
+      setPrefs(next)
+      if (
+        next.rememberCollapsed &&
+        next.collapsed != null &&
+        next.collapsed !== lastPersistedCollapsed
+      ) {
+        lastPersistedCollapsed = next.collapsed
+        setCollapsed(next.collapsed)
+      }
+    })()
+  })
+
   onCleanup(() => {
-    clearInterval(timer)
     if (debounce) clearTimeout(debounce)
     for (const u of unsubs) u()
+    unwatch()
   })
+
+  function toggleCollapsed() {
+    if (!hasData()) return
+    const next = !collapsed()
+    setCollapsed(next)
+    if (prefs().rememberCollapsed) {
+      lastPersistedCollapsed = next
+      void queueTuiPreferenceUpdate(PLUGIN_KEY, ['collapsed'], next)
+    }
+  }
 
   const theme = () => props.api.theme.current
   const enabledFallbacks = () => state().fallbacks.filter((f) => f.enabled)
   const hasData = () =>
     state().main.quota != null || enabledFallbacks().length > 0
 
-  const headerLabel = () =>
-    !hasData() ? 'CLAUDE' : collapsed() ? '\u25b6 CLAUDE' : '\u25bc CLAUDE'
+  const headerLabel = () => {
+    const name = prefs().header.label
+    return !hasData() ? name : collapsed() ? `\u25b6 ${name}` : `\u25bc ${name}`
+  }
   const activeAccount = () => resolveActiveAccount(state())
   const activeQuotaSummary = () =>
     getCollapsedQuotaSummary(activeAccount().quota)
@@ -290,7 +365,9 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
       summary.fiveHourUsedPercent,
       summary.sevenDayUsedPercent,
     ].filter((value): value is number => value != null)
-    return values.length > 0 ? usageTone(Math.max(...values)) : 'muted'
+    return values.length > 0
+      ? usageTone(Math.max(...values), prefs().appearance)
+      : 'muted'
   }
 
   const quotaBackedOff = () => state().main.quotaBackedOff === true
@@ -298,7 +375,8 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
   const degraded = () => quotaBackedOff() || refreshBackedOff()
 
   const cacheKeep = () => state().cacheKeep
-  const showCache = () => cacheKeep() != null && cacheKeep()?.window != null
+  const showCache = () =>
+    prefs().sections.cache && cacheKeep() != null && cacheKeep()?.window != null
   const relayValue = () => {
     const r = state().relay
     if (!r) return '\u2014'
@@ -323,9 +401,7 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
         flexDirection='row'
         justifyContent='space-between'
         alignItems='center'
-        onMouseDown={() => {
-          if (hasData()) setCollapsed((value) => !value)
-        }}
+        onMouseDown={toggleCollapsed}
       >
         <box paddingLeft={1} paddingRight={1} backgroundColor={theme().accent}>
           <text fg={theme().background}>
@@ -335,7 +411,7 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
         <Show
           when={degraded()}
           fallback={
-            <Show when={PLUGIN_VERSION !== ''}>
+            <Show when={prefs().header.showVersion && PLUGIN_VERSION !== ''}>
               <text fg={theme().textMuted}>{`v${PLUGIN_VERSION}`}</text>
             </Show>
           }
@@ -385,46 +461,54 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
           }
         >
           {/* Quota */}
-          <SectionHeader theme={theme()} title='Quota' />
-          <AccountBlock
-            theme={theme()}
-            name='main'
-            quota={state().main.quota}
-            active={state().activeId === 'main'}
-          />
-          <For each={enabledFallbacks()}>
-            {(fb) => (
-              <AccountBlock
-                theme={theme()}
-                name={fb.label ?? fb.id}
-                quota={fb.quota}
-                active={state().activeId === fb.id}
-                marginTop={1}
-              />
-            )}
-          </For>
+          <Show when={prefs().sections.quota}>
+            <SectionHeader theme={theme()} title='Quota' />
+            <AccountBlock
+              theme={theme()}
+              appearance={prefs().appearance}
+              name='main'
+              quota={state().main.quota}
+              active={state().activeId === 'main'}
+            />
+            <Show when={prefs().sections.fallbackAccounts}>
+              <For each={enabledFallbacks()}>
+                {(fb) => (
+                  <AccountBlock
+                    theme={theme()}
+                    appearance={prefs().appearance}
+                    name={fb.label ?? fb.id}
+                    quota={fb.quota}
+                    active={state().activeId === fb.id}
+                    marginTop={1}
+                  />
+                )}
+              </For>
+            </Show>
+          </Show>
         </Show>
 
         {/* Routing */}
-        <SectionHeader theme={theme()} title='Routing' />
-        <StatRow
-          theme={theme()}
-          label='Route'
-          value={state().route}
-          tone='accent'
-        />
-        <StatRow
-          theme={theme()}
-          label='Mode'
-          value={state().fastMode ? 'fast' : 'std'}
-          tone={state().fastMode ? 'accent' : 'muted'}
-        />
-        <StatRow
-          theme={theme()}
-          label='Relay'
-          value={relayValue()}
-          tone={state().relay?.enabled ? 'ok' : 'muted'}
-        />
+        <Show when={prefs().sections.routing}>
+          <SectionHeader theme={theme()} title='Routing' />
+          <StatRow
+            theme={theme()}
+            label='Route'
+            value={state().route}
+            tone='accent'
+          />
+          <StatRow
+            theme={theme()}
+            label='Mode'
+            value={state().fastMode ? 'fast' : 'std'}
+            tone={state().fastMode ? 'accent' : 'muted'}
+          />
+          <StatRow
+            theme={theme()}
+            label='Relay'
+            value={relayValue()}
+            tone={state().relay?.enabled ? 'ok' : 'muted'}
+          />
+        </Show>
 
         {/* Cache */}
         <Show when={showCache()}>
@@ -446,7 +530,7 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
         </Show>
 
         {/* Health — only when something is wrong */}
-        <Show when={degraded()}>
+        <Show when={degraded() && prefs().sections.health}>
           <SectionHeader theme={theme()} title='Health' />
           <Show when={quotaBackedOff()}>
             <StatRow
@@ -471,11 +555,13 @@ function QuotaSidebar(props: { api: TuiPluginApi }) {
 }
 
 const tui: TuiPlugin = async (api) => {
+  const root = await readTuiPreferencesFile()
+  const initialPrefs = resolveAnthropicAuthPrefs(root)
   api.slots.register({
-    order: 160,
+    order: computeEffectiveOrder(root, PLUGIN_KEY, DEFAULT_SLOT_ORDER),
     slots: {
       sidebar_content(_ctx: unknown, _props: { session_id: string }) {
-        return <QuotaSidebar api={api} />
+        return <QuotaSidebar api={api} initialPrefs={initialPrefs} />
       },
     },
   })

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -19,10 +19,14 @@ import {
 
 import {
   type AccountQuota,
+  computeQuotaPacing,
   DEFAULT_SIDEBAR_STATE,
+  FIVE_HOUR_MS,
   getCollapsedQuotaSummary,
   getSidebarState,
+  type QuotaPacing,
   resolveActiveAccount,
+  SEVEN_DAY_MS,
   type SidebarState,
 } from './sidebar-state.js'
 import {
@@ -88,16 +92,49 @@ function usageTone(usedPct: number, appearance: AppearancePrefs): Tone {
   return 'err'
 }
 
-function quotaBar(usedPct: number, appearance: AppearancePrefs): string {
+interface BarSegment {
+  text: string
+  tone: Tone
+}
+
+const PACE_RESERVE_CHAR = '\u2592'
+const PACE_DEFICIT_CHAR = '\u2593'
+
+// Variant C pacing bar: normal fill up to min(used, pace), then a pace
+// segment covering the gap — headroom being banked (reserve, ok tone) or the
+// overshoot itself (deficit, err tone) — then empty cells. Without pacing the
+// bar renders as a single fill+empty pair, identical to the pre-pacing look.
+function quotaBarSegments(
+  usedPct: number,
+  appearance: AppearancePrefs,
+  pacing: QuotaPacing | null,
+): BarSegment[] {
   const width = appearance.barWidth
-  const filled = Math.max(
-    0,
-    Math.min(Math.round((usedPct / 100) * width), width),
-  )
-  return (
-    appearance.barFilledChar.repeat(filled) +
-    appearance.barEmptyChar.repeat(width - filled)
-  )
+  const cells = (pct: number) =>
+    Math.max(0, Math.min(Math.round((pct / 100) * width), width))
+  const usedCells = cells(usedPct)
+  const fillTone = usageTone(usedPct, appearance)
+  const plain: BarSegment[] = [
+    { text: appearance.barFilledChar.repeat(usedCells), tone: fillTone },
+    {
+      text: appearance.barEmptyChar.repeat(width - usedCells),
+      tone: fillTone,
+    },
+  ]
+  if (!pacing) return plain
+  const paceCells = cells(pacing.pacePercent)
+  const lo = Math.min(usedCells, paceCells)
+  const hi = Math.max(usedCells, paceCells)
+  if (hi === lo) return plain
+  const overspent = usedCells > paceCells
+  return [
+    { text: appearance.barFilledChar.repeat(lo), tone: fillTone },
+    {
+      text: (overspent ? PACE_DEFICIT_CHAR : PACE_RESERVE_CHAR).repeat(hi - lo),
+      tone: overspent ? 'err' : 'ok',
+    },
+    { text: appearance.barEmptyChar.repeat(width - hi), tone: fillTone },
+  ]
 }
 
 function formatResetIn(resetsAt: string | undefined): string {
@@ -107,8 +144,13 @@ function formatResetIn(resetsAt: string | undefined): string {
   const mins = Math.floor(ms / 60_000)
   if (mins < 60) return `${mins}m`
   const hrs = Math.floor(mins / 60)
-  const rm = mins % 60
-  return rm > 0 ? `${hrs}h${rm}m` : `${hrs}h`
+  if (hrs < 24) {
+    const rm = mins % 60
+    return rm > 0 ? `${hrs}h${rm}m` : `${hrs}h`
+  }
+  const days = Math.floor(hrs / 24)
+  const rh = hrs % 24
+  return rh > 0 ? `${days}d${rh}h` : `${days}d`
 }
 
 function formatUntil(until: number | undefined): string {
@@ -170,15 +212,27 @@ function CollapsedRow(props: {
 }
 
 // Quota window row: muted label left, tone-colored bar + percentage right,
-// with an optional muted reset suffix.
+// with an optional muted reset suffix. When pacing data is present, the bar
+// gains a pace segment and an off-pace window adds a muted subline with the
+// reserve/deficit delta and the projected runout.
 function QuotaRow(props: {
   theme: ThemeCurrent
   appearance: AppearancePrefs
   label: string
   window: { usedPercent: number; resetsAt?: string } | undefined
+  pacing: QuotaPacing | null
 }) {
   const used = () => props.window?.usedPercent ?? 0
   const reset = () => formatResetIn(props.window?.resetsAt)
+  const paceLine = () => {
+    const pacing = props.pacing
+    if (!pacing || pacing.state === 'on-pace') return null
+    const pct = Math.round(Math.abs(pacing.deltaPercent))
+    if (pacing.state === 'reserve') return `reserve ${pct}% \u00b7 lasts`
+    return pacing.runsOutAt
+      ? `deficit ${pct}% \u00b7 out in ${formatResetIn(pacing.runsOutAt)}`
+      : `deficit ${pct}% \u00b7 lasts`
+  }
   return (
     <Show
       when={props.window}
@@ -195,11 +249,13 @@ function QuotaRow(props: {
       <box width='100%' flexDirection='row' justifyContent='space-between'>
         <box flexDirection='row'>
           <text fg={props.theme.textMuted}>{props.label.padEnd(3)}</text>
-          <text
-            fg={toneColor(props.theme, usageTone(used(), props.appearance))}
-          >
-            {quotaBar(used(), props.appearance)}
-          </text>
+          <For each={quotaBarSegments(used(), props.appearance, props.pacing)}>
+            {(segment) => (
+              <text fg={toneColor(props.theme, segment.tone)}>
+                {segment.text}
+              </text>
+            )}
+          </For>
           <text
             fg={toneColor(props.theme, usageTone(used(), props.appearance))}
           >
@@ -210,21 +266,46 @@ function QuotaRow(props: {
           <text fg={props.theme.textMuted}>{reset()}</text>
         </Show>
       </box>
+      <Show when={paceLine()}>
+        <box width='100%' flexDirection='row'>
+          <text fg={props.theme.textMuted}>{'   '}</text>
+          <text
+            fg={toneColor(
+              props.theme,
+              props.pacing?.state === 'deficit' ? 'warn' : 'muted',
+            )}
+          >
+            {paceLine()}
+          </text>
+        </box>
+      </Show>
     </Show>
   )
 }
 
 // Account block: header row (name + status word) then per-window quota rows.
+// Pacing is computed here — per window, against the wall clock at render time
+// (re-evaluated on every state poll) — and disabled by passing false.
 function AccountBlock(props: {
   theme: ThemeCurrent
   appearance: AppearancePrefs
   name: string
   quota: AccountQuota | null
   active: boolean
+  pacingEnabled: boolean
   marginTop?: number
 }) {
   const statusWord = () => (props.active ? 'active' : 'idle')
   const statusTone = (): Tone => (props.active ? 'ok' : 'muted')
+  const pacingFor = (
+    window:
+      | { usedPercent: number; remainingPercent: number; resetsAt?: string }
+      | undefined,
+    windowMs: number,
+  ) =>
+    props.pacingEnabled && window
+      ? computeQuotaPacing(window, windowMs, Date.now())
+      : null
   return (
     <box width='100%' flexDirection='column' marginTop={props.marginTop ?? 0}>
       <box width='100%' flexDirection='row' justifyContent='space-between'>
@@ -244,12 +325,14 @@ function AccountBlock(props: {
           appearance={props.appearance}
           label='5h'
           window={props.quota?.five_hour}
+          pacing={pacingFor(props.quota?.five_hour, FIVE_HOUR_MS)}
         />
         <QuotaRow
           theme={props.theme}
           appearance={props.appearance}
           label='7d'
           window={props.quota?.seven_day}
+          pacing={pacingFor(props.quota?.seven_day, SEVEN_DAY_MS)}
         />
       </Show>
     </box>
@@ -382,7 +465,22 @@ function QuotaSidebar(props: {
   const activeAccount = () => resolveActiveAccount(state())
   const activeQuotaSummary = () =>
     getCollapsedQuotaSummary(activeAccount().quota)
+  const activePacingDeficit = () => {
+    if (!prefs().sections.pacing) return false
+    const quota = activeAccount().quota
+    if (!quota) return false
+    const now = Date.now()
+    const windows: Array<[typeof quota.five_hour, number]> = [
+      [quota.five_hour, FIVE_HOUR_MS],
+      [quota.seven_day, SEVEN_DAY_MS],
+    ]
+    return windows.some(
+      ([w, ms]) =>
+        w != null && computeQuotaPacing(w, ms, now)?.state === 'deficit',
+    )
+  }
   const activeQuotaTone = (): Tone => {
+    if (activePacingDeficit()) return 'err'
     const summary = activeQuotaSummary()
     const values = [
       summary.fiveHourUsedPercent,
@@ -494,6 +592,7 @@ function QuotaSidebar(props: {
               name='main'
               quota={state().main.quota}
               active={state().activeId === 'main'}
+              pacingEnabled={prefs().sections.pacing}
             />
             <Show when={prefs().sections.fallbackAccounts}>
               <For each={enabledFallbacks()}>
@@ -504,6 +603,7 @@ function QuotaSidebar(props: {
                     name={fb.label ?? fb.id}
                     quota={fb.quota}
                     active={state().activeId === fb.id}
+                    pacingEnabled={prefs().sections.pacing}
                     marginTop={1}
                   />
                 )}


### PR DESCRIPTION
## Summary

Codex-style pacing for the 5h/7d quota windows in the TUI sidebar.

> **Stacked on #73** (`feat/tui-preferences`) — review the last 4 commits only (`85ebae8..d0dc5d8`). Merging #73 first reduces this diff to the pacing feature.

- **Math** (`sidebar-state.ts`, pure + tested): `computeQuotaPacing(window, windowMs, now)` →
  - `deltaPercent` = used % − even-burn pace % (positive = deficit, |Δ|<1 = on-pace)
  - `runsOutAt` = burn-rate projection; null when the window lasts until reset
  - null guards: missing/invalid `resetsAt`, <5 min or <1 % of window elapsed (noise), stale windows
- **Bar segments** (variant C): normal fill → `▒` headroom (under pace, green) / `▓` overshoot (over pace, red) → empty. On-pace bars render exactly as before.
- **Sublines**: off-pace windows add a muted row — `reserve 12% · lasts` / `deficit 10% · out in 2d 7h` (deficit in warn tone).
- **Collapsed view**: summary text turns red when any active-account window is in deficit.
- **Preference**: `sections.pacing` (default `true`) gates segments, sublines, and the tint; hot-reloads.
- `formatResetIn` is now day-aware (`6d12h` instead of `156h22m`).

## Testing

- 9 new `computeQuotaPacing` tests (reserve/deficit/on-pace, runout boundary at reset, zero-usage, noise guards, invalid input) — includes a case derived from real Codex bar values
- `sections.pacing` resolution tests
- Full suite: 444 pass / 1 pre-existing failure (provider.models cost test, unrelated)
- typecheck, lint, build all clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783815135&installation_id=135454708&pr_number=74&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F74&signature=0c0496943f762fbdafbd143002fe2c5914f181707ab9d603bd7cb7d7d59d5806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds even-burn quota pacing to the TUI sidebar with run-rate projection, plus a live-reloading `tui-preferences.jsonc` that persists collapse and customizes layout, sections, and appearance. Bars show reserve/deficit segments, off-pace rows show projected runout, and the collapsed header tints warn (never red) when the active account is over pace.

- **New Features**
  - Quota pacing: `computeQuotaPacing(window, windowMs, now)` returns `pacePercent`, `deltaPercent`, `state` (`reserve` | `deficit` | `on-pace`), and `runsOutAt | null`, with noise/stale guards; `formatResetIn` is day-aware.
  - Sidebar UI: bars add pace segments (`▒` reserve, `▓` deficit); off-pace rows show a subline with reserve/deficit and projected “out in …”; collapsed summary uses warn tone on active-window deficit; zero-length segments are dropped; gate via `sections.pacing` (default `true`).
  - TUI preferences: reads `tui-preferences.jsonc` (env `OPENCODE_TUI_PREFERENCES_FILE` or config dirs), hot-reloads, and writes atomically while preserving comments. Persists collapse across restarts and survives slot remounts. Controls layout (`forceToTop`, `order`), behavior (`startCollapsed`, `rememberCollapsed`, `pollMs`, `refreshDebounceMs`), header (`label`, `showVersion`), sections (quota, fallbackAccounts, routing, cache, health, pacing), and appearance (`barWidth`, bar chars, `warnThreshold`, `errorThreshold`). Shared helpers in `@cortexkit/opencode-anthropic-auth/tui-prefs`: `readTuiPreferencesFile`, `resolveAnthropicAuthPrefs`, `computeEffectiveOrder` (honors `forceToTop`), `watchTuiPreferences` (debounced, content-verified), `queueTuiPreferenceUpdate` (atomic writes).

- **Migration**
  - To restore per-session collapse, set `"rememberCollapsed": false` in `tui-preferences.jsonc`.

<sup>Written for commit e6325a68ddae0750d52c21c37724c42e51c73962. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

