### PR TITLE
fix(core): align request fidelity with genuine Claude Code CLI (2.1.177)

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,8 +1,10 @@
 import {
   AUTHORIZE_URLS,
+  AXIOS_USER_AGENT,
   CLIENT_ID,
   CODE_CALLBACK_URL,
   OAUTH_SCOPES,
+  REFRESH_SCOPE,
   TOKEN_URL,
 } from './constants.ts'
 import { generatePKCE } from './pkce.ts'
@@ -82,13 +84,14 @@ export async function refreshClaudeOAuthToken(input: {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Accept: 'application/json',
-          'User-Agent': 'axios/1.13.6',
+          Accept: 'application/json, text/plain, */*',
+          'User-Agent': AXIOS_USER_AGENT,
         },
         body: JSON.stringify({
           grant_type: 'refresh_token',
           refresh_token: input.refreshToken,
           client_id: CLIENT_ID,
+          scope: REFRESH_SCOPE,
         }),
       })
 
@@ -178,7 +181,7 @@ async function exchangeCode(
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json, text/plain, */*',
-      'User-Agent': 'axios/1.13.6',
+      'User-Agent': AXIOS_USER_AGENT,
     },
     body: JSON.stringify({
       code: callback.code,

--- a/packages/core/src/claude-code.ts
+++ b/packages/core/src/claude-code.ts
@@ -162,15 +162,14 @@ export function applyClaudeCodeMetadata(
 }
 
 export const CLAUDE_CODE_FULL_AGENT_BETAS = [
-  'claude-code-20250219',
   'oauth-2025-04-20',
   'interleaved-thinking-2025-05-14',
+  'thinking-token-count-2026-05-13',
   'context-management-2025-06-27',
   'prompt-caching-scope-2026-01-05',
+  'claude-code-20250219',
   'advisor-tool-2026-03-01',
   'advanced-tool-use-2025-11-20',
-  'context-1m-2025-08-07',
-  'effort-2025-11-24',
   'extended-cache-ttl-2025-04-11',
   'cache-diagnosis-2026-04-07',
 ] as const
@@ -178,6 +177,7 @@ export const CLAUDE_CODE_FULL_AGENT_BETAS = [
 const CLAUDE_CODE_STRUCTURED_OUTPUT_BETAS = [
   'oauth-2025-04-20',
   'interleaved-thinking-2025-05-14',
+  'thinking-token-count-2026-05-13',
   'context-management-2025-06-27',
   'prompt-caching-scope-2026-01-05',
   'advisor-tool-2026-03-01',
@@ -188,9 +188,12 @@ const CLAUDE_CODE_STRUCTURED_OUTPUT_BETAS = [
 const CLAUDE_CODE_BASE_BETAS = [
   'oauth-2025-04-20',
   'interleaved-thinking-2025-05-14',
+  'thinking-token-count-2026-05-13',
   'context-management-2025-06-27',
   'prompt-caching-scope-2026-01-05',
   'advisor-tool-2026-03-01',
+  'advanced-tool-use-2025-11-20',
+  'extended-cache-ttl-2025-04-11',
   'cache-diagnosis-2026-04-07',
 ] as const
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -54,7 +54,7 @@ export function isFastModeSupportedModel(model: unknown) {
 
 export const OPENCODE_IDENTITY_PREFIX = 'You are OpenCode'
 export const CLAUDE_CODE_IDENTITY =
-  "You are a Claude agent, built on Anthropic's Claude Agent SDK."
+  "You are Claude Code, Anthropic's official CLI for Claude."
 
 export const PARALLEL_TOOL_CALLS_SYSTEM_PROMPT = [
   '<use_parallel_tool_calls>',
@@ -66,13 +66,13 @@ export const PARALLEL_TOOL_CALLS_SYSTEM_PROMPT = [
 
 export const CCH_SALT = '59cf53e54c78'
 export const CCH_POSITIONS = [4, 7, 20]
-export const CLAUDE_CODE_VERSION = '2.1.141'
-export const CLAUDE_CODE_BUILD_HASH = '67b'
-export const CLAUDE_CODE_ENTRYPOINT = 'sdk-cli'
+export const CLAUDE_CODE_VERSION = '2.1.177'
+export const CLAUDE_CODE_BUILD_HASH = '3bf'
+export const CLAUDE_CODE_ENTRYPOINT = 'cli'
 export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.94.0'
 export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v24.3.0'
 
-export const USER_AGENT = 'claude-cli/2.1.141 (external, sdk-cli)'
+export const USER_AGENT = 'claude-cli/2.1.177 (external, cli)'
 
 export const CACHE_1H_MODES = ['explicit', 'automatic', 'hybrid'] as const
 export type Cache1hMode = (typeof CACHE_1H_MODES)[number]

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,13 +2,15 @@ export const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
 
 export const AUTHORIZE_URLS = {
   console: 'https://platform.claude.com/oauth/authorize',
-  max: 'https://claude.ai/oauth/authorize',
+  max: 'https://claude.com/cai/oauth/authorize',
 } as const
 
 export const CODE_CALLBACK_URL =
   'https://platform.claude.com/oauth/code/callback'
 
 export const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token'
+
+export const AXIOS_USER_AGENT = 'axios/1.15.2'
 
 export const OAUTH_SCOPES = [
   'org:create_api_key',
@@ -18,6 +20,9 @@ export const OAUTH_SCOPES = [
   'user:mcp_servers',
   'user:file_upload',
 ]
+
+export const REFRESH_SCOPE =
+  'user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload'
 
 export const TOOL_PREFIX = 'mcp_'
 

--- a/packages/opencode/src/tests/__snapshots__/transform.test.ts.snap
+++ b/packages/opencode/src/tests/__snapshots__/transform.test.ts.snap
@@ -146,11 +146,11 @@ exports[`sanitizeSystemText – realistic prompt rewriteRequestBody output snaps
   ],
   "system": [
     {
-      "text": "x-anthropic-billing-header: cc_version=<daily>; cc_entrypoint=sdk-cli; cch=<signed>;",
+      "text": "x-anthropic-billing-header: cc_version=<daily>; cc_entrypoint=cli; cch=<signed>;",
       "type": "text",
     },
     {
-      "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+      "text": "You are Claude Code, Anthropic's official CLI for Claude.",
       "type": "text",
     },
     {

--- a/packages/opencode/src/tests/auth.test.ts
+++ b/packages/opencode/src/tests/auth.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import {
+  AXIOS_USER_AGENT,
   authorize,
   CLIENT_ID,
   ClaudeOAuthRefreshError,
   CODE_CALLBACK_URL,
   exchange,
   OAUTH_SCOPES,
+  REFRESH_SCOPE,
   refreshClaudeOAuthToken,
+  TOKEN_URL,
 } from '@cortexkit/anthropic-auth-core'
 
 const originalSetTimeout = globalThis.setTimeout
@@ -25,8 +28,8 @@ describe('authorize', () => {
     expect(result.verifier).toBeString()
 
     const url = new URL(result.url)
-    expect(url.origin).toBe('https://claude.ai')
-    expect(url.pathname).toBe('/oauth/authorize')
+    expect(url.origin).toBe('https://claude.com')
+    expect(url.pathname).toBe('/cai/oauth/authorize')
     expect(url.searchParams.get('redirect_uri')).toBe(CODE_CALLBACK_URL)
   })
 
@@ -176,12 +179,22 @@ describe('refreshClaudeOAuthToken', () => {
       }) as unknown as typeof fetch,
     })
 
+    expect(capturedUrl).toBe(TOKEN_URL)
     expect(capturedUrl).toBe('https://platform.claude.com/v1/oauth/token')
     expect(capturedHeaders?.get('content-type')).toBe('application/json')
+    expect(capturedHeaders?.get('accept')).toBe(
+      'application/json, text/plain, */*',
+    )
+    expect(capturedHeaders?.get('user-agent')).toBe(AXIOS_USER_AGENT)
+    expect(capturedHeaders?.get('user-agent')).toBe('axios/1.15.2')
     const body = JSON.parse(capturedBody ?? '{}')
     expect(body.grant_type).toBe('refresh_token')
     expect(body.refresh_token).toBe('old-refresh')
     expect(body.client_id).toBe(CLIENT_ID)
+    expect(body.scope).toBe(REFRESH_SCOPE)
+    expect(body.scope).toBe(
+      'user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload',
+    )
     expect(result).toEqual({
       access: 'new-access',
       refresh: 'old-refresh',

--- a/packages/opencode/src/tests/cachekeep.test.ts
+++ b/packages/opencode/src/tests/cachekeep.test.ts
@@ -60,7 +60,7 @@ describe('cachekeep prewarm body', () => {
       system: [
         {
           type: 'text',
-          text: 'x-anthropic-billing-header: cc_version=2.1.141.67b; cc_entrypoint=sdk-cli; cch=abcde;',
+          text: 'x-anthropic-billing-header: cc_version=2.1.177.3bf; cc_entrypoint=cli; cch=abcde;',
         },
         { type: 'text', text: 'identity' },
         {

--- a/packages/opencode/src/tests/cch.test.ts
+++ b/packages/opencode/src/tests/cch.test.ts
@@ -30,7 +30,7 @@ describe('billing header helpers', () => {
   })
 
   test('computes the captured Claude Code build suffix for the default version', () => {
-    expect(computeVersionSuffix('2.1.141', new Date('2026-04-29'))).toBe('67b')
+    expect(computeVersionSuffix('2.1.177', new Date('2026-04-29'))).toBe('3bf')
   })
 
   test('keeps custom version suffixes stable across date boundaries', () => {

--- a/packages/opencode/src/tests/claude-code.test.ts
+++ b/packages/opencode/src/tests/claude-code.test.ts
@@ -103,9 +103,7 @@ describe('Claude Code fingerprint helpers', () => {
       { body, identity },
     )
 
-    expect(headers.get('user-agent')).toBe(
-      'claude-cli/2.1.141 (external, sdk-cli)',
-    )
+    expect(headers.get('user-agent')).toBe('claude-cli/2.1.177 (external, cli)')
     expect(headers.get('x-claude-code-session-id')).toBe(identity.sessionId)
     expect(headers.get('x-stainless-package-version')).toBe('0.94.0')
     expect(headers.get('x-stainless-runtime-version')).toBe('v24.3.0')
@@ -156,11 +154,11 @@ describe('Claude Code bootstrap identity lookup', () => {
       async (input: string | URL | Request, init?: RequestInit) => {
         const url = new URL(input.toString())
         expect(url.pathname).toBe('/api/claude_cli/bootstrap')
-        expect(url.searchParams.get('entrypoint')).toBe('sdk-cli')
+        expect(url.searchParams.get('entrypoint')).toBe('cli')
         expect(url.searchParams.get('model')).toBe('claude-sonnet-4-6')
 
         const headers = new Headers(init?.headers)
-        expect(headers.get('user-agent')).toBe('claude-code/2.1.141')
+        expect(headers.get('user-agent')).toBe('claude-code/2.1.177')
         expect(headers.get('anthropic-beta')).toBe('oauth-2025-04-20')
         expect(headers.get('content-type')).toBe('application/json')
 

--- a/packages/opencode/src/tests/claude-code.test.ts
+++ b/packages/opencode/src/tests/claude-code.test.ts
@@ -27,6 +27,13 @@ describe('Claude Code fingerprint helpers', () => {
     expect(selectClaudeCodeBetas(body).split(',')).toEqual([
       ...CLAUDE_CODE_FULL_AGENT_BETAS,
     ])
+    const fullBetas = selectClaudeCodeBetas(body).split(',')
+    expect(fullBetas[0]).toBe('oauth-2025-04-20')
+    expect(fullBetas).toContain('thinking-token-count-2026-05-13')
+    expect(fullBetas).not.toContain('redact-thinking-2026-02-12')
+    expect(fullBetas).toContain('claude-code-20250219')
+    expect(fullBetas).not.toContain('context-1m-2025-08-07')
+    expect(fullBetas).not.toContain('effort-2025-11-24')
   })
 
   test('selects structured-output betas without full-agent private betas', () => {
@@ -40,6 +47,8 @@ describe('Claude Code fingerprint helpers', () => {
     }).split(',')
 
     expect(betas).toContain('structured-outputs-2025-12-15')
+    expect(betas).toContain('thinking-token-count-2026-05-13')
+    expect(betas).not.toContain('redact-thinking-2026-02-12')
     expect(betas).not.toContain('claude-code-20250219')
     expect(betas).not.toContain('advanced-tool-use-2025-11-20')
     expect(betas).not.toContain('context-1m-2025-08-07')
@@ -55,17 +64,23 @@ describe('Claude Code fingerprint helpers', () => {
       stream: true,
     }).split(',')
 
-    expect(betas).not.toContain('advanced-tool-use-2025-11-20')
+    expect(betas).toContain('thinking-token-count-2026-05-13')
+    expect(betas).toContain('advanced-tool-use-2025-11-20')
+    expect(betas).toContain('extended-cache-ttl-2025-04-11')
+    expect(betas).not.toContain('claude-code-20250219')
     expect(betas).not.toContain('context-1m-2025-08-07')
     expect(betas).not.toContain('effort-2025-11-24')
-    expect(betas).not.toContain('extended-cache-ttl-2025-04-11')
+    expect(betas).not.toContain('redact-thinking-2026-02-12')
   })
 
   test('does not add full-agent betas when request shape is unavailable', () => {
     const betas = selectClaudeCodeBetas(null).split(',')
 
     for (const beta of REQUIRED_BETAS) expect(betas).toContain(beta)
-    expect(betas).not.toContain('advanced-tool-use-2025-11-20')
+    expect(betas[0]).toBe('oauth-2025-04-20')
+    expect(betas).toContain('thinking-token-count-2026-05-13')
+    expect(betas).not.toContain('redact-thinking-2026-02-12')
+    expect(betas).not.toContain('claude-code-20250219')
   })
 
   test('applies Claude Code headers and couples session id to metadata', () => {

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -314,6 +314,19 @@ describe('auth.methods', () => {
 })
 
 describe('provider.models', () => {
+  beforeEach(async () => {
+    await useTempAccountFile(createFallbackStorage({ accounts: [] }))
+  })
+
+  afterEach(async () => {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_FILE
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_SIDEBAR_STATE_FILE
+    if (tempConfigDir) {
+      await rm(tempConfigDir, { recursive: true, force: true })
+      tempConfigDir = undefined
+    }
+  })
+
   test('zeros out Anthropic model costs for OAuth auth', async () => {
     const plugin = await getPlugin()
     const models = {

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -1348,7 +1348,7 @@ describe('auth.loader', () => {
     expect(parsedBody.system).toHaveLength(3)
     expect(parsedBody.system[0].text).toContain('x-anthropic-billing-header')
     expect(parsedBody.system[1].text).toBe(
-      "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+      "You are Claude Code, Anthropic's official CLI for Claude.",
     )
     expect(parsedBody.system[2].text).toBe('You are a helpful assistant.')
     // User message is untouched

--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -1836,8 +1836,8 @@ describe('sanitizeSystemText – realistic prompt', () => {
     const result = await rewriteRequestBody(body)
     const parsed = JSON.parse(result)
     parsed.system[0].text = parsed.system[0].text.replace(
-      /cc_version=[^;]+; cc_entrypoint=sdk-cli; cch=[0-9a-f]{5};/,
-      'cc_version=<daily>; cc_entrypoint=sdk-cli; cch=<signed>;',
+      /cc_version=[^;]+; cc_entrypoint=cli; cch=[0-9a-f]{5};/,
+      'cc_version=<daily>; cc_entrypoint=cli; cch=<signed>;',
     )
     expect(parsed).toMatchSnapshot()
   })


### PR DESCRIPTION
## Summary

Aligns the plugin's Anthropic request fingerprint with genuine Claude Code interactive-CLI traffic, captured + live-verified via MITM on 2026-06-14. Three independently-reviewed commits.

### 1. `anthropic-beta` correctness (`packages/core/src/claude-code.ts`)
- Removed `context-1m-2025-08-07` and `effort-2025-11-24` from the full-agent set — **verified**: `context-1m` returns `400 "long context beta is not yet available for this subscription"` on Max.
- Added `thinking-token-count-2026-05-13` as always-on (BASE/FULL/structured).
- Added `advanced-tool-use-2025-11-20` + `extended-cache-ttl-2025-04-11` to BASE (genuine simple turns send them).
- Reordered both sets to the captured sequence: lead with `oauth-2025-04-20`; `claude-code-20250219` sits after `prompt-caching-scope-2026-01-05` and only on tool-bearing turns.
- **Deliberate divergence:** `redact-thinking-2026-02-12` is intentionally NOT sent (product decision), even though genuine CLI includes it. A test pins its absence.

### 2. OAuth refresh + login fidelity (`packages/core/src/{constants,auth}.ts`)
- `axios/1.13.6` → `axios/1.15.2` (extracted to `AXIOS_USER_AGENT`), on both refresh and code-exchange.
- Refresh: `Accept: application/json, text/plain, */*` + body `scope` (`REFRESH_SCOPE`, which omits `org:create_api_key` — matches genuine refresh; login keeps it).
- `AUTHORIZE_URLS.max` → `https://claude.com/cai/oauth/authorize` (genuine post-rebrand host; verified 307→claude.ai preserving PKCE `code_challenge`/`state`).

### 3. Interactive-CLI identity (`packages/core/src/constants.ts`)
All-or-nothing fingerprint swap from the Agent-SDK persona to the interactive CLI:
- `USER_AGENT` → `claude-cli/2.1.177 (external, cli)`, `CLAUDE_CODE_VERSION` → `2.1.177`, `CLAUDE_CODE_BUILD_HASH` → `3bf`, `CLAUDE_CODE_ENTRYPOINT` → `cli`, identity → `"You are Claude Code, Anthropic's official CLI for Claude."`
- Emitted billing header is now `cc_version=2.1.177.3bf; cc_entrypoint=cli`. cch signing mechanism untouched.
- ⚠️ `3bf` is a per-build hash that churns; re-confirm against a fresh capture on future bumps.

### Test isolation fix (`index.test.ts`)
The `provider.models` suite read the real `~/.config/opencode/anthropic-auth.json` instead of an isolated temp file, so the cost-zeroing test failed on any machine that opted out of cost-zeroing (passed only in clean CI). Added `beforeEach`/`afterEach` config isolation mirroring the `auth.loader` block.

## Testing
- `bun run build` / `bun run typecheck` clean
- `bun test`: **496 pass / 0 fail**
- Cross-family independent review: correctness + security, both APPROVED for all three commits

## Out of scope
- cch signing internals (unchanged), the full Claude Code system-prompt body (only the identity block gates OAuth), any "cowork route" for quota (verified dead-end — same unified pool).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784041889&installation_id=135454708&pr_number=75&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F75&signature=80592f5f63a9248eb9dce237b9c5d23bfc93c2d37f5ca6fce7ad804f807592a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns our Anthropic request and identity to the genuine Claude Code interactive CLI 2.1.177 for higher fidelity and fewer auth/feature mismatches. Updates beta headers, OAuth requests, and CLI identity; fixes flaky test config isolation.

- **Bug Fixes**
  - Betas: reordered to start with `oauth-2025-04-20`; added `thinking-token-count-2026-05-13`; moved `claude-code-20250219` after `prompt-caching-scope-2026-01-05` only on tool turns; added `advanced-tool-use-2025-11-20` and `extended-cache-ttl-2025-04-11` to BASE; removed `context-1m-2025-08-07` and `effort-2025-11-24`; intentionally omit `redact-thinking-2026-02-12`.
  - OAuth: refresh/login use `Accept: application/json, text/plain, */*` and `AXIOS_USER_AGENT` (`axios/1.15.2`); refresh body includes `scope` (`REFRESH_SCOPE`); `AUTHORIZE_URLS.max` now `https://claude.com/cai/oauth/authorize`.
  - Identity: switch to CLI persona (`USER_AGENT` `claude-cli/2.1.177 (external, cli)`; `CLAUDE_CODE_VERSION=2.1.177`, `CLAUDE_CODE_BUILD_HASH=3bf`, `CLAUDE_CODE_ENTRYPOINT=cli`); system identity updated; billing header now uses `cc_entrypoint=cli`.

- **Tests**
  - Isolated `provider.models` from real user config (temp files in `beforeEach/afterEach`).
  - Updated snapshots and expectations for new headers, identity text, and URLs.

<sup>Written for commit 18c4649fc4afb7d45b812213035400715116e278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

