### PR TITLE
feat: interactive command modals for the OpenCode TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,22 @@ The sidebar polls plugin state and refreshes on OpenCode session and message eve
 
 Click the `CLAUDE` header to collapse or expand the sidebar. Collapsed, it shows the active account's 5-hour quota usage and a fast-mode row when fast mode is on; the header shows the plugin version (or a `LIMITED` badge when degraded). Collapse state persists across restarts by default via `tui-preferences.jsonc` (`rememberCollapsed`); set `"rememberCollapsed": false` for the old per-session behavior.
 
+### Command modals (OpenCode TUI)
+
+In the OpenCode TUI, the `/claude-*` commands open interactive modal dialogs instead of posting a text reply:
+
+- `/claude-quota` — a read-only view rendering the same per-account quota bars and pacing as the sidebar.
+- `/claude-routing` — select main-first or fallback-first.
+- `/claude-fast` — toggle fast mode on or off.
+- `/claude-dump` — toggle request dump capture on or off.
+- `/claude-cache` — select the 1-hour cache mode (off, explicit, automatic, or hybrid).
+- `/claude-cachekeep` — enter a cache keepalive window (`HH-HH`) or `off`.
+- `/claude-killswitch` — enable or disable the killswitch, or edit per-account `5h,1w` thresholds.
+
+Applying a change in a modal persists it through the same configuration the slash arguments use, so the modal and the typed command (`/claude-routing fallback-first`, etc.) are equivalent. Outside the OpenCode TUI (OpenCode desktop or headless), the commands print their text summary as before; Pi is unaffected.
+
+The modal bridge runs a loopback-only RPC server (bound to `127.0.0.1`, bearer-authenticated) so the OpenCode server process can signal the separate TUI process. Its runtime directory defaults to a per-project path under the OpenCode state directory; override it with `OPENCODE_ANTHROPIC_AUTH_RPC_DIR`.
+
 ## TUI preferences
 
 The TUI sidebar reads `tui-preferences.jsonc` from the opencode config
@@ -584,6 +600,7 @@ Dump state is persisted in the active sidecar config as `dump.enabled` (`~/.conf
 | `ANTHROPIC_BASE_URL` | Override the Anthropic API endpoint. Must be HTTP(S). |
 | `ANTHROPIC_INSECURE` | Set to `1` or `true` to skip TLS verification when `ANTHROPIC_BASE_URL` is set. |
 | `OPENCODE_ANTHROPIC_AUTH_FILE` | Override the OpenCode sidecar config path. |
+| `OPENCODE_ANTHROPIC_AUTH_RPC_DIR` | Override the directory for the OpenCode TUI command-modal RPC bridge (port file + token). Defaults to a per-project path under the OpenCode state directory. |
 | `PI_ANTHROPIC_AUTH_FILE` | Override the Pi sidecar config path. |
 | `PI_AGENT_DIR` | Override Pi's agent directory when deriving the default sidecar path. |
 | `CLOUDFLARE_API_TOKEN` | Cloudflare token used by `bunx @cortexkit/opencode-anthropic-auth relay setup`. Not stored. |

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -36,6 +36,7 @@
   "files": [
     "dist",
     "src/tui.tsx",
+    "src/tui/command-dialogs.tsx",
     "src/sidebar-state.ts",
     "src/tui-preferences.ts",
     "src/rpc",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -38,11 +38,12 @@
     "src/tui.tsx",
     "src/sidebar-state.ts",
     "src/tui-preferences.ts",
+    "src/rpc",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/cli.ts src/sidebar-state.ts src/tui-preferences.ts --outdir dist --target node --format esm --splitting --external @opencode-ai/plugin --minify && tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "build": "rm -rf dist && bun build src/index.ts src/cli.ts src/sidebar-state.ts src/tui-preferences.ts src/rpc/rpc-client.ts src/rpc/port-file.ts src/rpc/protocol.ts src/rpc/rpc-dir.ts --outdir dist --target node --format esm --splitting --external @opencode-ai/plugin --minify && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:dev": "rm -rf dist && tsc -p tsconfig.build.json",
     "dev": "bun ../../scripts/dev.ts",
     "dev:clean": "bun ../../scripts/dev-clean.ts",

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -91,8 +91,20 @@ import {
   shouldFallbackStatus,
 } from '@cortexkit/anthropic-auth-core'
 import type { Plugin } from '@opencode-ai/plugin'
-
 import { resolvePromptContext } from './prompt-context.ts'
+import {
+  drainNotifications,
+  isTuiConnected,
+  pushNotification,
+} from './rpc/notifications.ts'
+import type {
+  ApplyRequest,
+  ApplyResult,
+  CommandModalName,
+  OpenDialogPayload,
+} from './rpc/protocol.ts'
+import { getRpcDir } from './rpc/rpc-dir.ts'
+import { type RpcServerHandle, startRpcServer } from './rpc/rpc-server.ts'
 import { type SidebarState, setSidebarState } from './sidebar-state.ts'
 import {
   addFastModeBetaHeader,
@@ -278,7 +290,11 @@ async function sendIgnoredMessage(
   )
 }
 
-function throwHandledSentinel(): never {
+function _throwHandledSentinel(): never {
+  throw new Error(HANDLED_SENTINEL)
+}
+
+function cleanAbort(): never {
   throw new Error(HANDLED_SENTINEL)
 }
 
@@ -485,6 +501,21 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
   })
   setDumpEnabled(isDumpPersistentlyEnabled(initialStorage))
   setFastModeEnabled(isFastModePersistentlyEnabled(initialStorage))
+
+  let _rpcServer: RpcServerHandle | null = null
+  if (ctx.directory) {
+    try {
+      _rpcServer = await startRpcServer({
+        dir: getRpcDir(ctx.directory),
+        drain: drainNotifications,
+        apply: applyCommand,
+      })
+    } catch (error) {
+      log('[rpc] failed to start', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
 
   // Remembers the last explicit routing decision so quota-only sidebar refreshes
   // (background main/fallback quota landing) do not reset the active account.
@@ -827,6 +858,79 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
     })
   }
 
+  async function buildDialogPayload(
+    command: CommandModalName,
+    args: string,
+  ): Promise<OpenDialogPayload> {
+    if (command === 'claude-quota')
+      return { command, text: await buildQuotaCommandSummary(), knobs: {} }
+    if (command === 'claude-routing') {
+      const storage = await loadAccounts(accountStoragePath)
+      return {
+        command,
+        text: await executePersistentRoutingCommand(args),
+        knobs: { mode: getRoutingMode(storage) },
+      }
+    }
+    if (command === 'claude-fast') {
+      const storage = await loadAccounts(accountStoragePath)
+      return {
+        command,
+        text: await executePersistentFastModeCommand(args),
+        knobs: { enabled: isFastModePersistentlyEnabled(storage) },
+      }
+    }
+    if (command === 'claude-dump') {
+      const storage = await loadAccounts(accountStoragePath)
+      return {
+        command,
+        text: await executePersistentDumpCommand(args),
+        knobs: { enabled: isDumpPersistentlyEnabled(storage) },
+      }
+    }
+    if (command === 'claude-cache') {
+      const storage = await loadAccounts(accountStoragePath)
+      return {
+        command,
+        text: await executePersistentCache1hCommand(args),
+        knobs: {
+          enabled: isCache1hPersistentlyEnabled(storage),
+          mode: getCache1hPersistentMode(storage),
+        },
+      }
+    }
+    if (command === 'claude-cachekeep') {
+      const storage = await loadAccounts(accountStoragePath)
+      return {
+        command,
+        text: await executePersistentCacheKeepCommand(args),
+        knobs: { window: getCacheKeepWindow(storage) },
+      }
+    }
+    const storage = await loadAccounts()
+    const config = getKillswitchConfig(storage)
+    const accountIds = (storage?.accounts ?? [])
+      .filter((a) => a.enabled !== false)
+      .map((a) => a.id)
+    const result = executeKillswitchCommand({
+      argumentsText: args,
+      config,
+      accountIds,
+    })
+    if (result.updatedConfig)
+      await setKillswitchPersistent(result.updatedConfig)
+    return {
+      command,
+      text: result.text,
+      knobs: { config: getKillswitchConfig(await loadAccounts()), accountIds },
+    }
+  }
+
+  async function applyCommand(request: ApplyRequest): Promise<ApplyResult> {
+    const payload = await buildDialogPayload(request.command, request.arguments)
+    return { text: payload.text, knobs: payload.knobs }
+  }
+
   function quotaBar(pct: number, width = 10): string {
     const filled = Math.max(0, Math.min(Math.round((pct / 100) * width), width))
     return '█'.repeat(filled) + '░'.repeat(width - filled)
@@ -1004,30 +1108,19 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       arguments: string
       sessionID: string
     }) => {
-      if (input.command === CACHE_1H_COMMAND_NAME) {
-        await sendIgnoredMessage(
-          ctx,
-          input.sessionID,
-          await executePersistentCache1hCommand(input.arguments),
-        )
-        throwHandledSentinel()
-      }
-
-      if (input.command === CLAUDE_CACHE_KEEP_COMMAND_NAME) {
-        await sendIgnoredMessage(
-          ctx,
-          input.sessionID,
-          await executePersistentCacheKeepCommand(input.arguments),
-        )
-        throwHandledSentinel()
-      }
-
-      if (input.command === CLAUDE_QUOTAS_COMMAND_NAME) {
-        await sendIgnoredMessage(
-          ctx,
-          input.sessionID,
-          await buildQuotaCommandSummary(),
-        )
+      const modalCommands: CommandModalName[] = [
+        'claude-cache',
+        'claude-cachekeep',
+        'claude-quota',
+        'claude-dump',
+        'claude-fast',
+        'claude-routing',
+        'claude-killswitch',
+      ]
+      if (!modalCommands.includes(input.command as CommandModalName)) return
+      const command = input.command as CommandModalName
+      const payload = await buildDialogPayload(command, input.arguments)
+      if (command === 'claude-quota') {
         const cmdStorage = await loadAccounts()
         const cmdAuth = latestGetAuth
           ? await latestGetAuth().catch(() => undefined)
@@ -1038,53 +1131,13 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
           mainAccessToken: cmdAuth?.access,
           mainRefreshToken: cmdAuth?.refresh,
         })
-        throwHandledSentinel()
       }
-
-      if (input.command === CLAUDE_DUMP_COMMAND_NAME) {
-        await sendIgnoredMessage(
-          ctx,
-          input.sessionID,
-          await executePersistentDumpCommand(input.arguments),
-        )
-        throwHandledSentinel()
+      if (isTuiConnected(input.sessionID)) {
+        pushNotification(payload, input.sessionID)
+      } else {
+        await sendIgnoredMessage(ctx, input.sessionID, payload.text)
       }
-
-      if (input.command === CLAUDE_FAST_COMMAND_NAME) {
-        await sendIgnoredMessage(
-          ctx,
-          input.sessionID,
-          await executePersistentFastModeCommand(input.arguments),
-        )
-        throwHandledSentinel()
-      }
-
-      if (input.command === CLAUDE_ROUTING_COMMAND_NAME) {
-        await sendIgnoredMessage(
-          ctx,
-          input.sessionID,
-          await executePersistentRoutingCommand(input.arguments),
-        )
-        throwHandledSentinel()
-      }
-
-      if (input.command === KILLSWITCH_COMMAND_NAME) {
-        const storage = await loadAccounts()
-        const config = getKillswitchConfig(storage)
-        const accountIds = (storage?.accounts ?? [])
-          .filter((a) => a.enabled !== false)
-          .map((a) => a.id)
-        const result = executeKillswitchCommand({
-          argumentsText: input.arguments,
-          config,
-          accountIds,
-        })
-        if (result.updatedConfig) {
-          await setKillswitchPersistent(result.updatedConfig)
-        }
-        await sendIgnoredMessage(ctx, input.sessionID, result.text)
-        throwHandledSentinel()
-      }
+      cleanAbort()
     },
     auth: {
       provider: 'anthropic',

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -502,14 +502,22 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
   setDumpEnabled(isDumpPersistentlyEnabled(initialStorage))
   setFastModeEnabled(isFastModePersistentlyEnabled(initialStorage))
 
-  let _rpcServer: RpcServerHandle | null = null
+  let rpcServer: RpcServerHandle | null = null
   if (ctx.directory) {
+    const rpcGlobal = globalThis as {
+      __anthropicAuthRpcServer?: RpcServerHandle
+    }
+    if (rpcGlobal.__anthropicAuthRpcServer) {
+      await rpcGlobal.__anthropicAuthRpcServer.stop().catch(() => {})
+      rpcGlobal.__anthropicAuthRpcServer = undefined
+    }
     try {
-      _rpcServer = await startRpcServer({
+      rpcServer = await startRpcServer({
         dir: getRpcDir(ctx.directory),
         drain: drainNotifications,
         apply: applyCommand,
       })
+      rpcGlobal.__anthropicAuthRpcServer = rpcServer
     } catch (error) {
       log('[rpc] failed to start', {
         error: error instanceof Error ? error.message : String(error),
@@ -865,34 +873,34 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
     if (command === 'claude-quota')
       return { command, text: await buildQuotaCommandSummary(), knobs: {} }
     if (command === 'claude-routing') {
+      const text = await executePersistentRoutingCommand(args)
       const storage = await loadAccounts(accountStoragePath)
-      return {
-        command,
-        text: await executePersistentRoutingCommand(args),
-        knobs: { mode: getRoutingMode(storage) },
-      }
+      return { command, text, knobs: { mode: getRoutingMode(storage) } }
     }
     if (command === 'claude-fast') {
+      const text = await executePersistentFastModeCommand(args)
       const storage = await loadAccounts(accountStoragePath)
       return {
         command,
-        text: await executePersistentFastModeCommand(args),
+        text,
         knobs: { enabled: isFastModePersistentlyEnabled(storage) },
       }
     }
     if (command === 'claude-dump') {
+      const text = await executePersistentDumpCommand(args)
       const storage = await loadAccounts(accountStoragePath)
       return {
         command,
-        text: await executePersistentDumpCommand(args),
+        text,
         knobs: { enabled: isDumpPersistentlyEnabled(storage) },
       }
     }
     if (command === 'claude-cache') {
+      const text = await executePersistentCache1hCommand(args)
       const storage = await loadAccounts(accountStoragePath)
       return {
         command,
-        text: await executePersistentCache1hCommand(args),
+        text,
         knobs: {
           enabled: isCache1hPersistentlyEnabled(storage),
           mode: getCache1hPersistentMode(storage),
@@ -900,12 +908,9 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       }
     }
     if (command === 'claude-cachekeep') {
+      const text = await executePersistentCacheKeepCommand(args)
       const storage = await loadAccounts(accountStoragePath)
-      return {
-        command,
-        text: await executePersistentCacheKeepCommand(args),
-        knobs: { window: getCacheKeepWindow(storage) },
-      }
+      return { command, text, knobs: { window: getCacheKeepWindow(storage) } }
     }
     const storage = await loadAccounts()
     const config = getKillswitchConfig(storage)

--- a/packages/opencode/src/rpc/notifications.ts
+++ b/packages/opencode/src/rpc/notifications.ts
@@ -28,7 +28,11 @@ export function drainNotifications(
     n.sessionId === undefined ||
     n.sessionId === sessionId
   if (lastReceivedId > 0) {
-    queue = queue.filter((n) => !(n.id <= lastReceivedId && matches(n)))
+    queue = queue.filter((n) => {
+      if (n.id > lastReceivedId) return true
+      if (sessionId === undefined) return false
+      return n.sessionId !== sessionId
+    })
   }
   return queue.filter((n) => n.id > lastReceivedId && matches(n))
 }

--- a/packages/opencode/src/rpc/notifications.ts
+++ b/packages/opencode/src/rpc/notifications.ts
@@ -1,0 +1,50 @@
+import type { OpenDialogPayload, RpcNotification } from './protocol'
+
+const QUEUE_CAP = 100
+const TUI_CONNECTED_WINDOW_MS = 3_000
+
+let queue: RpcNotification[] = []
+let nextId = 1
+let lastDrainAtAny = 0
+const lastDrainAtBySession = new Map<string, number>()
+
+export function pushNotification(
+  payload: OpenDialogPayload,
+  sessionId?: string,
+): void {
+  queue.push({ id: nextId++, type: 'open-dialog', payload, sessionId })
+  if (queue.length > QUEUE_CAP) queue = queue.slice(queue.length - QUEUE_CAP)
+}
+
+export function drainNotifications(
+  lastReceivedId = 0,
+  sessionId?: string,
+): RpcNotification[] {
+  const now = Date.now()
+  lastDrainAtAny = now
+  if (sessionId !== undefined) lastDrainAtBySession.set(sessionId, now)
+  const matches = (n: RpcNotification) =>
+    sessionId === undefined ||
+    n.sessionId === undefined ||
+    n.sessionId === sessionId
+  if (lastReceivedId > 0) {
+    queue = queue.filter((n) => !(n.id <= lastReceivedId && matches(n)))
+  }
+  return queue.filter((n) => n.id > lastReceivedId && matches(n))
+}
+
+export function isTuiConnected(sessionId?: string): boolean {
+  const now = Date.now()
+  if (sessionId !== undefined) {
+    const at = lastDrainAtBySession.get(sessionId) ?? 0
+    return at > 0 && now - at < TUI_CONNECTED_WINDOW_MS
+  }
+  return lastDrainAtAny > 0 && now - lastDrainAtAny < TUI_CONNECTED_WINDOW_MS
+}
+
+export function resetNotificationsForTest(): void {
+  queue = []
+  nextId = 1
+  lastDrainAtAny = 0
+  lastDrainAtBySession.clear()
+}

--- a/packages/opencode/src/rpc/port-file.ts
+++ b/packages/opencode/src/rpc/port-file.ts
@@ -1,4 +1,11 @@
-import { mkdir, readdir, readFile, rename, writeFile } from 'node:fs/promises'
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
 import { join } from 'node:path'
 
 export interface PortFileEntry {
@@ -46,8 +53,10 @@ export async function discoverPortFile(
       const parsed = JSON.parse(
         await readFile(join(dir, name), 'utf8'),
       ) as PortFileEntry
-      if (Number.isFinite(parsed.port) && pidAlive(parsed.pid))
-        live.push(parsed)
+      if (Number.isFinite(parsed.port)) {
+        if (pidAlive(parsed.pid)) live.push(parsed)
+        else unlink(join(dir, name)).catch(() => {})
+      }
     } catch {}
   }
   if (live.length === 0) return null

--- a/packages/opencode/src/rpc/port-file.ts
+++ b/packages/opencode/src/rpc/port-file.ts
@@ -1,0 +1,55 @@
+import { mkdir, readdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export interface PortFileEntry {
+  port: number
+  token: string
+  pid: number
+  startedAt: number
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+export async function writePortFile(
+  dir: string,
+  entry: { port: number; token: string; pid: number },
+): Promise<string> {
+  await mkdir(dir, { recursive: true })
+  const full: PortFileEntry = { ...entry, startedAt: Date.now() }
+  const target = join(dir, `port-${entry.pid}.json`)
+  const tmp = `${target}.${process.pid}.tmp`
+  await writeFile(tmp, JSON.stringify(full), { encoding: 'utf8', mode: 0o600 })
+  await rename(tmp, target)
+  return target
+}
+
+export async function discoverPortFile(
+  dir: string,
+): Promise<PortFileEntry | null> {
+  let names: string[]
+  try {
+    names = await readdir(dir)
+  } catch {
+    return null
+  }
+  const live: PortFileEntry[] = []
+  for (const name of names) {
+    if (!name.startsWith('port-') || !name.endsWith('.json')) continue
+    try {
+      const parsed = JSON.parse(
+        await readFile(join(dir, name), 'utf8'),
+      ) as PortFileEntry
+      if (Number.isFinite(parsed.port) && pidAlive(parsed.pid))
+        live.push(parsed)
+    } catch {}
+  }
+  if (live.length === 0) return null
+  return live.sort((a, b) => b.startedAt - a.startedAt)[0] ?? null
+}

--- a/packages/opencode/src/rpc/protocol.ts
+++ b/packages/opencode/src/rpc/protocol.ts
@@ -1,0 +1,31 @@
+export type CommandModalName =
+  | 'claude-cache'
+  | 'claude-cachekeep'
+  | 'claude-quota'
+  | 'claude-dump'
+  | 'claude-fast'
+  | 'claude-routing'
+  | 'claude-killswitch'
+
+export interface OpenDialogPayload {
+  command: CommandModalName
+  text: string
+  knobs: Record<string, unknown>
+}
+
+export interface RpcNotification {
+  id: number
+  type: 'open-dialog'
+  payload: OpenDialogPayload
+  sessionId?: string
+}
+
+export interface ApplyRequest {
+  command: CommandModalName
+  arguments: string
+}
+
+export interface ApplyResult {
+  text: string
+  knobs: Record<string, unknown>
+}

--- a/packages/opencode/src/rpc/rpc-client.ts
+++ b/packages/opencode/src/rpc/rpc-client.ts
@@ -1,0 +1,55 @@
+import { discoverPortFile } from './port-file'
+import type { ApplyRequest, ApplyResult, RpcNotification } from './protocol'
+
+export interface RpcClient {
+  pending: (
+    lastReceivedId: number,
+    sessionId?: string,
+  ) => Promise<RpcNotification[]>
+  apply: (request: ApplyRequest) => Promise<ApplyResult>
+}
+
+async function call<T>(
+  dir: string,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<T | null> {
+  const entry = await discoverPortFile(dir)
+  if (!entry) return null
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 2_000)
+  try {
+    const res = await fetch(`http://127.0.0.1:${entry.port}/rpc/${method}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${entry.token}`,
+      },
+      body: JSON.stringify(params),
+      signal: controller.signal,
+    })
+    if (!res.ok) return null
+    return (await res.json()) as T
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export function createRpcClient(dir: string): RpcClient {
+  return {
+    async pending(lastReceivedId, sessionId) {
+      const out = await call<{ messages: RpcNotification[] }>(
+        dir,
+        'pending-notifications',
+        { lastReceivedId, sessionId },
+      )
+      return out?.messages ?? []
+    },
+    async apply(request) {
+      const out = await call<ApplyResult>(dir, 'apply', { ...request })
+      return out ?? { text: 'apply failed', knobs: {} }
+    },
+  }
+}

--- a/packages/opencode/src/rpc/rpc-dir.ts
+++ b/packages/opencode/src/rpc/rpc-dir.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'node:crypto'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const RPC_DIR_ENV = 'OPENCODE_ANTHROPIC_AUTH_RPC_DIR'
+
+// Both processes must resolve the SAME dir from the SAME project directory.
+export function getRpcDir(projectDirectory: string): string {
+  const override = process.env[RPC_DIR_ENV]?.trim()
+  if (override) return override
+  const hash = createHash('sha256')
+    .update(projectDirectory)
+    .digest('hex')
+    .slice(0, 16)
+  const base = process.env.XDG_STATE_HOME || join(homedir(), '.local', 'state')
+  return join(base, 'cortexkit', 'anthropic-auth', 'rpc', hash)
+}
+
+export { tmpdir }

--- a/packages/opencode/src/rpc/rpc-server.ts
+++ b/packages/opencode/src/rpc/rpc-server.ts
@@ -27,7 +27,10 @@ function readBody(req: IncomingMessage): Promise<string> {
     let data = ''
     req.on('data', (chunk) => {
       data += chunk
-      if (data.length > 1_000_000) reject(new Error('body too large'))
+      if (data.length > 1_000_000) {
+        req.destroy()
+        reject(new Error('body too large'))
+      }
     })
     req.on('end', () => resolve(data))
     req.on('error', reject)
@@ -95,7 +98,12 @@ export async function startRpcServer(
     })
   })
   server.unref()
-  await writePortFile(options.dir, { port, token, pid: process.pid })
+  try {
+    await writePortFile(options.dir, { port, token, pid: process.pid })
+  } catch (error) {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    throw error
+  }
 
   return {
     port,

--- a/packages/opencode/src/rpc/rpc-server.ts
+++ b/packages/opencode/src/rpc/rpc-server.ts
@@ -24,15 +24,18 @@ export interface RpcServerOptions {
 
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
-    let data = ''
-    req.on('data', (chunk) => {
-      data += chunk
-      if (data.length > 1_000_000) {
+    const chunks: Buffer[] = []
+    let size = 0
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length
+      if (size > 1_000_000) {
         req.destroy()
         reject(new Error('body too large'))
+        return
       }
+      chunks.push(chunk)
     })
-    req.on('end', () => resolve(data))
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
     req.on('error', reject)
   })
 }

--- a/packages/opencode/src/rpc/rpc-server.ts
+++ b/packages/opencode/src/rpc/rpc-server.ts
@@ -1,0 +1,110 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import { unlink } from 'node:fs/promises'
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http'
+import { join } from 'node:path'
+import type { drainNotifications } from './notifications'
+import { writePortFile } from './port-file'
+import type { ApplyRequest, ApplyResult } from './protocol'
+
+export interface RpcServerHandle {
+  port: number
+  token: string
+  stop: () => Promise<void>
+}
+
+export interface RpcServerOptions {
+  dir: string
+  drain: typeof drainNotifications
+  apply: (request: ApplyRequest) => Promise<ApplyResult>
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = ''
+    req.on('data', (chunk) => {
+      data += chunk
+      if (data.length > 1_000_000) reject(new Error('body too large'))
+    })
+    req.on('end', () => resolve(data))
+    req.on('error', reject)
+  })
+}
+
+function tokenOk(header: string | undefined, token: string): boolean {
+  if (!header?.startsWith('Bearer ')) return false
+  const got = Buffer.from(header.slice(7))
+  const want = Buffer.from(token)
+  return got.length === want.length && timingSafeEqual(got, want)
+}
+
+export async function startRpcServer(
+  options: RpcServerOptions,
+): Promise<RpcServerHandle> {
+  const token = randomBytes(32).toString('hex')
+  const server = createServer((req, res) => {
+    void dispatch(req, res)
+  })
+
+  async function dispatch(req: IncomingMessage, res: ServerResponse) {
+    const json = (status: number, value: unknown) => {
+      res.writeHead(status, { 'content-type': 'application/json' })
+      res.end(JSON.stringify(value))
+    }
+    try {
+      const url = req.url ?? ''
+      if (req.method === 'GET' && url === '/health')
+        return json(200, { ok: true })
+      if (req.method !== 'POST' || !url.startsWith('/rpc/'))
+        return json(404, { error: 'not found' })
+      if (!tokenOk(req.headers.authorization, token))
+        return json(401, { error: 'unauthorized' })
+      const method = url.slice('/rpc/'.length)
+      const params = JSON.parse((await readBody(req)) || '{}') as Record<
+        string,
+        unknown
+      >
+      if (method === 'pending-notifications') {
+        const messages = options.drain(
+          Number(params.lastReceivedId ?? 0),
+          typeof params.sessionId === 'string' ? params.sessionId : undefined,
+        )
+        return json(200, { messages })
+      }
+      if (method === 'apply') {
+        const result = await options.apply(params as unknown as ApplyRequest)
+        return json(200, result)
+      }
+      return json(404, { error: 'unknown method' })
+    } catch (error) {
+      json(500, {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const port = await new Promise<number>((resolve, reject) => {
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      if (addr && typeof addr === 'object') resolve(addr.port)
+      else reject(new Error('no port'))
+    })
+  })
+  server.unref()
+  await writePortFile(options.dir, { port, token, pid: process.pid })
+
+  return {
+    port,
+    token,
+    async stop() {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await unlink(join(options.dir, `port-${process.pid}.json`)).catch(
+        () => {},
+      )
+    },
+  }
+}

--- a/packages/opencode/src/tests/rpc-notifications.test.ts
+++ b/packages/opencode/src/tests/rpc-notifications.test.ts
@@ -52,4 +52,16 @@ describe('notifications', () => {
     const all = drainNotifications(0, 's1')
     expect(all.length).toBe(100)
   })
+
+  test('a global notification reaches every session and is not pruned by one ack', () => {
+    // push a global (no sessionId) notification
+    pushNotification(payload('claude-quota'))
+    const a = drainNotifications(0, 's1')
+    expect(a.length).toBe(1)
+    // s1 acks it
+    drainNotifications(a[0]?.id as number, 's1')
+    // s2 must STILL receive it
+    const b = drainNotifications(0, 's2')
+    expect(b.length).toBe(1)
+  })
 })

--- a/packages/opencode/src/tests/rpc-notifications.test.ts
+++ b/packages/opencode/src/tests/rpc-notifications.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import {
+  drainNotifications,
+  isTuiConnected,
+  pushNotification,
+  resetNotificationsForTest,
+} from '../rpc/notifications'
+import type { OpenDialogPayload } from '../rpc/protocol'
+
+const payload = (command: OpenDialogPayload['command']): OpenDialogPayload => ({
+  command,
+  text: 'x',
+  knobs: {},
+})
+
+describe('notifications', () => {
+  beforeEach(() => resetNotificationsForTest())
+
+  test('push then drain returns the item once, ordered', () => {
+    pushNotification(payload('claude-quota'), 's1')
+    pushNotification(payload('claude-fast'), 's1')
+    const first = drainNotifications(0, 's1')
+    expect(first.map((n) => n.payload.command)).toEqual([
+      'claude-quota',
+      'claude-fast',
+    ])
+    expect(first[0]?.id).toBeLessThan(first[1]?.id as number)
+    const second = drainNotifications(first[1]?.id as number, 's1')
+    expect(second).toEqual([])
+  })
+
+  test('session scoping: a session only drains its own + global', () => {
+    pushNotification(payload('claude-quota'), 's1')
+    pushNotification(payload('claude-dump'), 's2')
+    expect(drainNotifications(0, 's1').map((n) => n.payload.command)).toEqual([
+      'claude-quota',
+    ])
+    expect(drainNotifications(0, 's2').map((n) => n.payload.command)).toEqual([
+      'claude-dump',
+    ])
+  })
+
+  test('isTuiConnected reflects a recent drain within the window', () => {
+    expect(isTuiConnected('s1')).toBe(false)
+    drainNotifications(0, 's1')
+    expect(isTuiConnected('s1')).toBe(true)
+  })
+
+  test('queue cap evicts oldest beyond 100', () => {
+    for (let i = 0; i < 130; i++)
+      pushNotification(payload('claude-quota'), 's1')
+    const all = drainNotifications(0, 's1')
+    expect(all.length).toBe(100)
+  })
+})

--- a/packages/opencode/src/tests/rpc-port-file.test.ts
+++ b/packages/opencode/src/tests/rpc-port-file.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { discoverPortFile, writePortFile } from '../rpc/port-file'
+
+let dir: string
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'aa-rpc-'))
+})
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('port-file', () => {
+  test('writePortFile then discover returns the entry for a live pid', async () => {
+    await writePortFile(dir, { port: 5123, token: 'tok', pid: process.pid })
+    const found = await discoverPortFile(dir)
+    expect(found?.port).toBe(5123)
+    expect(found?.token).toBe('tok')
+  })
+
+  test('discover ignores dead pids', async () => {
+    await writeFile(
+      join(dir, 'port-99999999.json'),
+      JSON.stringify({ port: 1, token: 'x', pid: 99999999, startedAt: 1 }),
+      'utf8',
+    )
+    expect(await discoverPortFile(dir)).toBeNull()
+  })
+
+  test('discover picks the newest startedAt among live entries', async () => {
+    await writePortFile(dir, { port: 1, token: 'a', pid: process.pid })
+    await new Promise((r) => setTimeout(r, 5))
+    await writePortFile(dir, { port: 2, token: 'b', pid: process.pid })
+    expect((await discoverPortFile(dir))?.port).toBe(2)
+  })
+})

--- a/packages/opencode/src/tests/rpc-server.test.ts
+++ b/packages/opencode/src/tests/rpc-server.test.ts
@@ -73,4 +73,69 @@ describe('rpc-server', () => {
     expect(applyOk.status).toBe(200)
     expect(await applyOk.json()).toEqual({ text: 'ok', knobs: {} })
   })
+
+  test('rejects body exceeding 1 MB byte limit', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'aa-rpcsrv-'))
+    const server = await startRpcServer({
+      dir,
+      drain: drainNotifications,
+      apply: async () => ({ text: 'ok', knobs: {} }),
+    })
+    stop = server.stop
+    const base = `http://127.0.0.1:${server.port}`
+
+    // ASCII body > 1 MB bytes
+    const huge = 'x'.repeat(1_000_001)
+    let rejected = false
+    try {
+      await fetch(`${base}/rpc/apply`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${server.token}`,
+        },
+        body: JSON.stringify({ command: 'test', arguments: huge }),
+      })
+    } catch {
+      rejected = true
+    }
+    expect(rejected).toBe(true)
+  })
+
+  test('rejects multibyte body where byte length exceeds limit but string length does not', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'aa-rpcsrv-'))
+    const server = await startRpcServer({
+      dir,
+      drain: drainNotifications,
+      apply: async () => ({ text: 'ok', knobs: {} }),
+    })
+    stop = server.stop
+    const base = `http://127.0.0.1:${server.port}`
+
+    // Each CJK char is 3 bytes in UTF-8 but 1 UTF-16 code unit
+    const cjk = '好'.repeat(400_000)
+    // String length (UTF-16) is ~400k — below the old 1M limit
+    expect(cjk.length).toBeLessThan(1_000_000)
+    // Byte length (UTF-8) is ~1.2M — above the 1M limit
+    expect(Buffer.byteLength(cjk, 'utf8')).toBeGreaterThan(1_000_000)
+
+    const body = JSON.stringify({ command: 'test', arguments: cjk })
+    // The full JSON payload byte length must also exceed 1 MB
+    expect(Buffer.byteLength(body, 'utf8')).toBeGreaterThan(1_000_000)
+
+    let rejected = false
+    try {
+      await fetch(`${base}/rpc/apply`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${server.token}`,
+        },
+        body,
+      })
+    } catch {
+      rejected = true
+    }
+    expect(rejected).toBe(true)
+  })
 })

--- a/packages/opencode/src/tests/rpc-server.test.ts
+++ b/packages/opencode/src/tests/rpc-server.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  drainNotifications,
+  pushNotification,
+  resetNotificationsForTest,
+} from '../rpc/notifications'
+import { startRpcServer } from '../rpc/rpc-server'
+
+let stop: (() => Promise<void>) | null = null
+let dir: string
+
+afterEach(async () => {
+  await stop?.()
+  stop = null
+  if (dir) await rm(dir, { recursive: true, force: true })
+  resetNotificationsForTest()
+})
+
+describe('rpc-server', () => {
+  test('health is open; pending-notifications requires bearer and drains', async () => {
+    resetNotificationsForTest()
+    dir = await mkdtemp(join(tmpdir(), 'aa-rpcsrv-'))
+    const server = await startRpcServer({
+      dir,
+      drain: drainNotifications,
+      apply: async () => ({ text: 'ok', knobs: {} }),
+    })
+    stop = server.stop
+    const base = `http://127.0.0.1:${server.port}`
+
+    expect((await fetch(`${base}/health`)).status).toBe(200)
+
+    const noAuth = await fetch(`${base}/rpc/pending-notifications`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lastReceivedId: 0 }),
+    })
+    expect(noAuth.status).toBe(401)
+
+    pushNotification({ command: 'claude-quota', text: 'x', knobs: {} }, 's1')
+    const ok = await fetch(`${base}/rpc/pending-notifications`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${server.token}`,
+      },
+      body: JSON.stringify({ lastReceivedId: 0, sessionId: 's1' }),
+    })
+    expect(ok.status).toBe(200)
+    const body = (await ok.json()) as {
+      messages: Array<{ payload: { command: string } }>
+    }
+    expect(body.messages[0]?.payload.command).toBe('claude-quota')
+  })
+})

--- a/packages/opencode/src/tests/rpc-server.test.ts
+++ b/packages/opencode/src/tests/rpc-server.test.ts
@@ -54,5 +54,23 @@ describe('rpc-server', () => {
       messages: Array<{ payload: { command: string } }>
     }
     expect(body.messages[0]?.payload.command).toBe('claude-quota')
+
+    const applyNoAuth = await fetch(`${base}/rpc/apply`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ command: 'claude-quota', arguments: '' }),
+    })
+    expect(applyNoAuth.status).toBe(401)
+
+    const applyOk = await fetch(`${base}/rpc/apply`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${server.token}`,
+      },
+      body: JSON.stringify({ command: 'claude-quota', arguments: '' }),
+    })
+    expect(applyOk.status).toBe(200)
+    expect(await applyOk.json()).toEqual({ text: 'ok', knobs: {} })
   })
 })

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -350,6 +350,58 @@ function AccountBlock(props: {
   )
 }
 
+// --- Quota dialog content ---------------------------------------------------
+
+// Renders the same rich visualization as the sidebar (account blocks with
+// quota bars + pacing) so the modal matches the sidebar look.
+function QuotaDialogContent(props: {
+  api: TuiPluginApi
+  controller: SidebarController
+}) {
+  const prefs = props.controller.prefs
+  const [state, setState] = createSignal<SidebarState>(DEFAULT_SIDEBAR_STATE)
+  let lastUpdated = 0
+  async function refresh() {
+    const next = await readStateFromFile()
+    if (next.lastUpdated !== lastUpdated) {
+      lastUpdated = next.lastUpdated
+      setState(next)
+    }
+  }
+  createEffect(() => {
+    const timer = setInterval(refresh, prefs().pollMs)
+    onCleanup(() => clearInterval(timer))
+  })
+  setTimeout(refresh, 0)
+  const theme = () => props.api.theme.current
+  const enabledFallbacks = () => state().fallbacks.filter((f) => f.enabled)
+  return (
+    <box flexDirection='column' padding={1} width='100%'>
+      <AccountBlock
+        theme={theme()}
+        appearance={prefs().appearance}
+        name='main'
+        quota={state().main.quota}
+        active={state().activeId === 'main'}
+        pacingEnabled={prefs().sections.pacing}
+      />
+      <For each={enabledFallbacks()}>
+        {(fb) => (
+          <AccountBlock
+            theme={theme()}
+            appearance={prefs().appearance}
+            name={fb.label ?? fb.id}
+            quota={fb.quota}
+            active={state().activeId === fb.id}
+            pacingEnabled={prefs().sections.pacing}
+            marginTop={1}
+          />
+        )}
+      </For>
+    </box>
+  )
+}
+
 // --- State plumbing ---------------------------------------------------------
 
 async function readStateFromFile(): Promise<SidebarState> {
@@ -726,6 +778,13 @@ const tui: TuiPlugin = async (api) => {
         .then((messages) => {
           for (const message of [...messages].sort((a, b) => a.id - b.id)) {
             lastNotificationId = Math.max(lastNotificationId, message.id)
+            if (message.payload.command === 'claude-quota') {
+              api.ui.dialog.setSize('xlarge')
+              api.ui.dialog.replace(() => (
+                <QuotaDialogContent api={api} controller={controller} />
+              ))
+              continue
+            }
             openCommandDialog(api, message.payload, (command, args) =>
               rpcClient.apply({ command, arguments: args }),
             )

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -376,31 +376,37 @@ function QuotaDialogContent(props: {
   const theme = () => props.api.theme.current
   const enabledFallbacks = () => state().fallbacks.filter((f) => f.enabled)
   return (
-    <box flexDirection='column' padding={1} width='100%'>
-      <SectionHeader theme={theme()} title='Quota' />
-      <AccountBlock
-        theme={theme()}
-        appearance={prefs().appearance}
-        name='main'
-        quota={state().main.quota}
-        active={state().activeId === 'main'}
-        pacingEnabled={prefs().sections.pacing}
-      />
-      <Show when={prefs().sections.fallbackAccounts}>
-        <For each={enabledFallbacks()}>
-          {(fb) => (
-            <AccountBlock
-              theme={theme()}
-              appearance={prefs().appearance}
-              name={fb.label ?? fb.id}
-              quota={fb.quota}
-              active={state().activeId === fb.id}
-              pacingEnabled={prefs().sections.pacing}
-              marginTop={1}
-            />
-          )}
-        </For>
-      </Show>
+    <box flexDirection='column' padding={2} width='100%' alignItems='center'>
+      <box flexDirection='column' width={58}>
+        <box width='100%' justifyContent='center' marginBottom={1}>
+          <text fg={theme().text}>
+            <b>Quota</b>
+          </text>
+        </box>
+        <AccountBlock
+          theme={theme()}
+          appearance={prefs().appearance}
+          name='main'
+          quota={state().main.quota}
+          active={state().activeId === 'main'}
+          pacingEnabled={prefs().sections.pacing}
+        />
+        <Show when={prefs().sections.fallbackAccounts}>
+          <For each={enabledFallbacks()}>
+            {(fb) => (
+              <AccountBlock
+                theme={theme()}
+                appearance={prefs().appearance}
+                name={fb.label ?? fb.id}
+                quota={fb.quota}
+                active={state().activeId === fb.id}
+                pacingEnabled={prefs().sections.pacing}
+                marginTop={1}
+              />
+            )}
+          </For>
+        </Show>
+      </box>
     </box>
   )
 }

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -377,6 +377,7 @@ function QuotaDialogContent(props: {
   const enabledFallbacks = () => state().fallbacks.filter((f) => f.enabled)
   return (
     <box flexDirection='column' padding={1} width='100%'>
+      <SectionHeader theme={theme()} title='Quota' />
       <AccountBlock
         theme={theme()}
         appearance={prefs().appearance}
@@ -385,19 +386,21 @@ function QuotaDialogContent(props: {
         active={state().activeId === 'main'}
         pacingEnabled={prefs().sections.pacing}
       />
-      <For each={enabledFallbacks()}>
-        {(fb) => (
-          <AccountBlock
-            theme={theme()}
-            appearance={prefs().appearance}
-            name={fb.label ?? fb.id}
-            quota={fb.quota}
-            active={state().activeId === fb.id}
-            pacingEnabled={prefs().sections.pacing}
-            marginTop={1}
-          />
-        )}
-      </For>
+      <Show when={prefs().sections.fallbackAccounts}>
+        <For each={enabledFallbacks()}>
+          {(fb) => (
+            <AccountBlock
+              theme={theme()}
+              appearance={prefs().appearance}
+              name={fb.label ?? fb.id}
+              quota={fb.quota}
+              active={state().activeId === fb.id}
+              pacingEnabled={prefs().sections.pacing}
+              marginTop={1}
+            />
+          )}
+        </For>
+      </Show>
     </box>
   )
 }

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -44,6 +44,7 @@ import {
 } from './tui-preferences.js'
 
 const RPC_POLL_MS = 500
+let rpcPollStarted = false
 
 const ID = 'cortexkit.anthropic-auth'
 
@@ -706,30 +707,34 @@ const tui: TuiPlugin = async (api) => {
     },
   })
 
-  const rpcClient = createRpcClient(getRpcDir(api.state.path.directory ?? ''))
-  let lastNotificationId = 0
-  let rpcInFlight = false
-  setInterval(() => {
-    if (rpcInFlight) return
-    const current = (api.route as { current?: unknown }).current
-    const resolved =
-      typeof current === 'function' ? (current as () => unknown)() : current
-    const sessionId = (
-      resolved as { params?: { sessionID?: string } } | undefined
-    )?.params?.sessionID
-    rpcInFlight = true
-    void rpcClient
-      .pending(lastNotificationId, sessionId)
-      .then((messages) => {
-        for (const message of [...messages].sort((a, b) => a.id - b.id)) {
-          lastNotificationId = Math.max(lastNotificationId, message.id)
-          openCommandDialog(api, message.payload)
-        }
-      })
-      .finally(() => {
-        rpcInFlight = false
-      })
-  }, RPC_POLL_MS)
+  if (!rpcPollStarted) {
+    rpcPollStarted = true
+    const rpcClient = createRpcClient(getRpcDir(api.state.path.directory ?? ''))
+    let lastNotificationId = 0
+    let rpcInFlight = false
+    setInterval(() => {
+      if (rpcInFlight) return
+      const current = (api.route as { current?: unknown }).current
+      const resolved =
+        typeof current === 'function' ? (current as () => unknown)() : current
+      const sessionId = (
+        resolved as { params?: { sessionID?: string } } | undefined
+      )?.params?.sessionID
+      rpcInFlight = true
+      void rpcClient
+        .pending(lastNotificationId, sessionId)
+        .then((messages) => {
+          for (const message of [...messages].sort((a, b) => a.id - b.id)) {
+            lastNotificationId = Math.max(lastNotificationId, message.id)
+            openCommandDialog(api, message.payload)
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          rpcInFlight = false
+        })
+    }, RPC_POLL_MS)
+  }
 }
 
 const plugin: TuiPluginModule & { id: string } = {

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -16,7 +16,8 @@ import {
   onCleanup,
   Show,
 } from 'solid-js'
-
+import { createRpcClient } from './rpc/rpc-client.js'
+import { getRpcDir } from './rpc/rpc-dir.js'
 import {
   type AccountQuota,
   computeQuotaPacing,
@@ -29,6 +30,7 @@ import {
   SEVEN_DAY_MS,
   type SidebarState,
 } from './sidebar-state.js'
+import { openCommandDialog } from './tui/command-dialogs.js'
 import {
   type AnthropicAuthTuiPrefs,
   type AppearancePrefs,
@@ -40,6 +42,8 @@ import {
   resolveAnthropicAuthPrefs,
   watchTuiPreferences,
 } from './tui-preferences.js'
+
+const RPC_POLL_MS = 500
 
 const ID = 'cortexkit.anthropic-auth'
 
@@ -701,6 +705,31 @@ const tui: TuiPlugin = async (api) => {
       },
     },
   })
+
+  const rpcClient = createRpcClient(getRpcDir(api.state.path.directory ?? ''))
+  let lastNotificationId = 0
+  let rpcInFlight = false
+  setInterval(() => {
+    if (rpcInFlight) return
+    const current = (api.route as { current?: unknown }).current
+    const resolved =
+      typeof current === 'function' ? (current as () => unknown)() : current
+    const sessionId = (
+      resolved as { params?: { sessionID?: string } } | undefined
+    )?.params?.sessionID
+    rpcInFlight = true
+    void rpcClient
+      .pending(lastNotificationId, sessionId)
+      .then((messages) => {
+        for (const message of [...messages].sort((a, b) => a.id - b.id)) {
+          lastNotificationId = Math.max(lastNotificationId, message.id)
+          openCommandDialog(api, message.payload)
+        }
+      })
+      .finally(() => {
+        rpcInFlight = false
+      })
+  }, RPC_POLL_MS)
 }
 
 const plugin: TuiPluginModule & { id: string } = {

--- a/packages/opencode/src/tui.tsx
+++ b/packages/opencode/src/tui.tsx
@@ -726,7 +726,9 @@ const tui: TuiPlugin = async (api) => {
         .then((messages) => {
           for (const message of [...messages].sort((a, b) => a.id - b.id)) {
             lastNotificationId = Math.max(lastNotificationId, message.id)
-            openCommandDialog(api, message.payload)
+            openCommandDialog(api, message.payload, (command, args) =>
+              rpcClient.apply({ command, arguments: args }),
+            )
           }
         })
         .catch(() => {})

--- a/packages/opencode/src/tui/command-dialogs.tsx
+++ b/packages/opencode/src/tui/command-dialogs.tsx
@@ -74,6 +74,81 @@ export function openCommandDialog(
     return
   }
 
-  // fallback for quota, cache, cachekeep, killswitch (interactive versions land later)
+  if (payload.command === 'claude-cache') {
+    const enabled = payload.knobs.enabled === true
+    const mode = (payload.knobs.mode as string) ?? 'hybrid'
+    const currentValue = enabled ? mode : 'off'
+    const DialogSelect = api.ui.DialogSelect<string>
+    api.ui.dialog.setSize('large')
+    api.ui.dialog.replace(() => (
+      <DialogSelect
+        title='Claude 1h cache'
+        current={currentValue}
+        options={[
+          { title: 'Off', value: 'off', description: 'Disable 1h cache' },
+          {
+            title: 'Explicit',
+            value: 'explicit',
+            description: 'Existing OpenCode breakpoints',
+          },
+          {
+            title: 'Automatic',
+            value: 'automatic',
+            description: 'Top-level cache_control only',
+          },
+          {
+            title: 'Hybrid',
+            value: 'hybrid',
+            description: 'system + messages[0] + top-level',
+          },
+        ]}
+        onSelect={(option) => {
+          if (option.value === 'off') {
+            void apply('claude-cache', 'off').then((r) => {
+              api.ui.toast({ message: r.text })
+              api.ui.dialog.clear()
+            })
+            return
+          }
+          void apply('claude-cache', `mode ${option.value}`)
+            .then(() => apply('claude-cache', 'on'))
+            .then((r) => {
+              api.ui.toast({ message: r.text })
+              api.ui.dialog.clear()
+            })
+        }}
+      />
+    ))
+    return
+  }
+
+  if (payload.command === 'claude-cachekeep') {
+    const window = payload.knobs.window as
+      | { startHour: number; endHour: number }
+      | undefined
+    const seed = window
+      ? `${String(window.startHour).padStart(2, '0')}-${String(window.endHour).padStart(2, '0')}`
+      : ''
+    const DialogPrompt = api.ui.DialogPrompt
+    api.ui.dialog.setSize('large')
+    api.ui.dialog.replace(() => (
+      <DialogPrompt
+        title='Claude cachekeep window'
+        description={() => <text>{payload.text}</text>}
+        placeholder="HH-HH (e.g. 08-20) or 'off'"
+        value={seed}
+        onConfirm={(value: string) => {
+          void apply('claude-cachekeep', value.trim()).then((r) => {
+            api.ui.toast({ message: r.text })
+            api.ui.dialog.clear()
+          })
+        }}
+        onCancel={() => api.ui.dialog.clear()}
+      />
+    ))
+    return
+  }
+
+  // fallback for quota, killswitch (interactive versions land later)
   showText(api, payload.text)
 }

--- a/packages/opencode/src/tui/command-dialogs.tsx
+++ b/packages/opencode/src/tui/command-dialogs.tsx
@@ -195,7 +195,6 @@ export function openCommandDialog(
     api.ui.dialog.replace(() => (
       <DialogSelect
         title='Claude killswitch'
-        current={enabled ? 'on' : 'off'}
         options={[
           {
             title: enabled ? 'Disable killswitch' : 'Enable killswitch',

--- a/packages/opencode/src/tui/command-dialogs.tsx
+++ b/packages/opencode/src/tui/command-dialogs.tsx
@@ -24,7 +24,7 @@ export function openCommandDialog(
   if (payload.command === 'claude-routing') {
     const current = (payload.knobs.mode as string) ?? 'main-first'
     const DialogSelect = api.ui.DialogSelect<string>
-    api.ui.dialog.setSize('large')
+    api.ui.dialog.setSize('xlarge')
     api.ui.dialog.replace(() => (
       <DialogSelect
         title='Claude routing'
@@ -57,7 +57,7 @@ export function openCommandDialog(
     const label =
       payload.command === 'claude-fast' ? 'fast mode' : 'request dump'
     const DialogConfirm = api.ui.DialogConfirm
-    api.ui.dialog.setSize('large')
+    api.ui.dialog.setSize('xlarge')
     api.ui.dialog.replace(() => (
       <DialogConfirm
         title={`Claude ${label}`}
@@ -79,7 +79,7 @@ export function openCommandDialog(
     const mode = (payload.knobs.mode as string) ?? 'hybrid'
     const currentValue = enabled ? mode : 'off'
     const DialogSelect = api.ui.DialogSelect<string>
-    api.ui.dialog.setSize('large')
+    api.ui.dialog.setSize('xlarge')
     api.ui.dialog.replace(() => (
       <DialogSelect
         title='Claude 1h cache'
@@ -130,7 +130,7 @@ export function openCommandDialog(
       ? `${String(window.startHour).padStart(2, '0')}-${String(window.endHour).padStart(2, '0')}`
       : ''
     const DialogPrompt = api.ui.DialogPrompt
-    api.ui.dialog.setSize('large')
+    api.ui.dialog.setSize('xlarge')
     api.ui.dialog.replace(() => (
       <DialogPrompt
         title='Claude cachekeep window'

--- a/packages/opencode/src/tui/command-dialogs.tsx
+++ b/packages/opencode/src/tui/command-dialogs.tsx
@@ -1,0 +1,14 @@
+/** @jsxImportSource @opentui/solid */
+import type { TuiPluginApi } from '@opencode-ai/plugin/tui'
+import type { OpenDialogPayload } from '../rpc/protocol.js'
+
+export function openCommandDialog(
+  api: TuiPluginApi,
+  payload: OpenDialogPayload,
+) {
+  api.ui.dialog.replace(() => (
+    <box flexDirection='column' padding={1}>
+      <text>{payload.text}</text>
+    </box>
+  ))
+}

--- a/packages/opencode/src/tui/command-dialogs.tsx
+++ b/packages/opencode/src/tui/command-dialogs.tsx
@@ -2,14 +2,78 @@
 import type { TuiPluginApi } from '@opencode-ai/plugin/tui'
 import type { OpenDialogPayload } from '../rpc/protocol.js'
 
-export function openCommandDialog(
-  api: TuiPluginApi,
-  payload: OpenDialogPayload,
-) {
+type ApplyFn = (
+  command: OpenDialogPayload['command'],
+  args: string,
+) => Promise<{ text: string }>
+
+function showText(api: TuiPluginApi, text: string) {
   api.ui.dialog.setSize('xlarge')
   api.ui.dialog.replace(() => (
     <box flexDirection='column' padding={1} width='100%'>
-      <text>{payload.text}</text>
+      <text>{text}</text>
     </box>
   ))
+}
+
+export function openCommandDialog(
+  api: TuiPluginApi,
+  payload: OpenDialogPayload,
+  apply: ApplyFn,
+) {
+  if (payload.command === 'claude-routing') {
+    const current = (payload.knobs.mode as string) ?? 'main-first'
+    const DialogSelect = api.ui.DialogSelect<string>
+    api.ui.dialog.setSize('large')
+    api.ui.dialog.replace(() => (
+      <DialogSelect
+        title='Claude routing'
+        current={current}
+        options={[
+          {
+            title: 'Main first',
+            value: 'main-first',
+            description: 'Use the main account until exhausted',
+          },
+          {
+            title: 'Fallback first',
+            value: 'fallback-first',
+            description: 'Prefer fallback accounts, preserve main',
+          },
+        ]}
+        onSelect={(option) => {
+          void apply('claude-routing', String(option.value)).then((r) => {
+            api.ui.toast({ message: r.text })
+            api.ui.dialog.clear()
+          })
+        }}
+      />
+    ))
+    return
+  }
+
+  if (payload.command === 'claude-fast' || payload.command === 'claude-dump') {
+    const enabled = payload.knobs.enabled === true
+    const label =
+      payload.command === 'claude-fast' ? 'fast mode' : 'request dump'
+    const DialogConfirm = api.ui.DialogConfirm
+    api.ui.dialog.setSize('large')
+    api.ui.dialog.replace(() => (
+      <DialogConfirm
+        title={`Claude ${label}`}
+        message={`${payload.text}\n\n${enabled ? 'Disable' : 'Enable'} ${label}?`}
+        onConfirm={() => {
+          void apply(payload.command, enabled ? 'off' : 'on').then((r) => {
+            api.ui.toast({ message: r.text })
+            api.ui.dialog.clear()
+          })
+        }}
+        onCancel={() => api.ui.dialog.clear()}
+      />
+    ))
+    return
+  }
+
+  // fallback for quota, cache, cachekeep, killswitch (interactive versions land later)
+  showText(api, payload.text)
 }

--- a/packages/opencode/src/tui/command-dialogs.tsx
+++ b/packages/opencode/src/tui/command-dialogs.tsx
@@ -149,6 +149,82 @@ export function openCommandDialog(
     return
   }
 
-  // fallback for quota, killswitch (interactive versions land later)
+  if (payload.command === 'claude-killswitch') {
+    const config = (payload.knobs.config ?? {}) as {
+      enabled?: boolean
+      main?: Record<string, number>
+      accounts?: Record<string, Record<string, number>>
+    }
+    const accountIds = (payload.knobs.accountIds as string[]) ?? []
+    const enabled = config.enabled === true
+    const readT = (t: Record<string, number> | undefined) => {
+      const fh = t?.five_hour ?? t?.['5h'] ?? 5
+      const sd = t?.seven_day ?? t?.['1w'] ?? 10
+      return { fh, sd }
+    }
+    const mainT = readT(config.main)
+    const seedParts = [`main:${mainT.fh},${mainT.sd}`]
+    for (const id of accountIds) {
+      const t = readT(config.accounts?.[id] ?? config.main)
+      seedParts.push(`${id}:${t.fh},${t.sd}`)
+    }
+    const seed = seedParts.join(' ')
+
+    const openEdit = () => {
+      const DialogPrompt = api.ui.DialogPrompt
+      api.ui.dialog.setSize('xlarge')
+      api.ui.dialog.replace(() => (
+        <DialogPrompt
+          title='Killswitch thresholds'
+          description={() => <text>{payload.text}</text>}
+          placeholder='main:5,10 work-alt:5,10'
+          value={seed}
+          onConfirm={(value: string) => {
+            void apply('claude-killswitch', `set ${value.trim()}`).then((r) => {
+              api.ui.toast({ message: r.text })
+              api.ui.dialog.clear()
+            })
+          }}
+          onCancel={() => api.ui.dialog.clear()}
+        />
+      ))
+    }
+
+    const DialogSelect = api.ui.DialogSelect<string>
+    api.ui.dialog.setSize('xlarge')
+    api.ui.dialog.replace(() => (
+      <DialogSelect
+        title='Claude killswitch'
+        current={enabled ? 'on' : 'off'}
+        options={[
+          {
+            title: enabled ? 'Disable killswitch' : 'Enable killswitch',
+            value: enabled ? 'off' : 'on',
+            description: enabled
+              ? 'Stop hard-blocking on low quota'
+              : 'Hard-block requests when quota drops below thresholds',
+          },
+          {
+            title: 'Edit thresholds…',
+            value: 'edit',
+            description: 'Set per-account 5h,1w cutoffs',
+          },
+        ]}
+        onSelect={(option) => {
+          if (option.value === 'edit') {
+            openEdit()
+            return
+          }
+          void apply('claude-killswitch', String(option.value)).then((r) => {
+            api.ui.toast({ message: r.text })
+            api.ui.dialog.clear()
+          })
+        }}
+      />
+    ))
+    return
+  }
+
+  // fallback for quota (display-only)
   showText(api, payload.text)
 }

--- a/packages/opencode/src/tui/command-dialogs.tsx
+++ b/packages/opencode/src/tui/command-dialogs.tsx
@@ -6,8 +6,9 @@ export function openCommandDialog(
   api: TuiPluginApi,
   payload: OpenDialogPayload,
 ) {
+  api.ui.dialog.setSize('xlarge')
   api.ui.dialog.replace(() => (
-    <box flexDirection='column' padding={1}>
+    <box flexDirection='column' padding={1} width='100%'>
       <text>{payload.text}</text>
     </box>
   ))


### PR DESCRIPTION
## Summary

In the OpenCode TUI, the seven `/claude-*` slash commands now open **interactive modal dialogs** instead of posting a text reply. Applying a change in a modal persists it through the same configuration the slash arguments already use, so a modal and the typed command (e.g. `/claude-routing fallback-first`) are equivalent. Outside the OpenCode TUI (OpenCode desktop or headless) the commands print their text summary exactly as before, and Pi is unaffected (separate plugin, no TUI).

| Command | Modal |
| --- | --- |
| `/claude-quota` | Read-only view rendering the same per-account quota bars + pacing as the sidebar |
| `/claude-routing` | Select main-first / fallback-first |
| `/claude-fast` | Toggle fast mode on/off |
| `/claude-dump` | Toggle request-dump capture on/off |
| `/claude-cache` | Select 1h cache mode (off / explicit / automatic / hybrid) |
| `/claude-cachekeep` | Prompt for a keepalive window (`HH-HH`) or `off` |
| `/claude-killswitch` | Enable/disable + per-account `5h,1w` threshold editor |

## How it works

The OpenCode server process and the TUI run as separate processes, so the command hook (server side) can't open a dialog (TUI side) directly. This adds a small **loopback RPC bridge**:

- A localhost-only HTTP server (bound to `127.0.0.1`, ephemeral port, bearer-authenticated, body-size capped) started from the plugin's server entry.
- A port file written atomically (temp + rename, mode `0600`) under a per-project path in the OpenCode state dir, discovered by the TUI via live-pid matching. Override with `OPENCODE_ANTHROPIC_AUTH_RPC_DIR`.
- An in-memory notification queue (session-scoped + global, capped, evict-oldest) with a TUI heartbeat.
- The TUI polls the bridge (~500ms), opens the matching dialog, and applies changes back through the bridge to the existing `executePersistent*` setters.

The command hook pushes a dialog notification when a TUI is connected, otherwise falls back to the existing ignored-message text path; either way it aborts the command so the slash template never reaches the model. The `/claude-quota` modal reuses the sidebar's `AccountBlock` components fed by the same state file + theme, so it matches the sidebar's bars/pacing and respects the same section prefs.

## Testing

- New unit suites for the RPC transport: `rpc-notifications`, `rpc-port-file`, `rpc-server` (queue scoping/eviction, port-file atomicity + dead-pid pruning, bearer 401/200, oversized-body rejection, the apply route).
- Full workspace gates green: `format`, `lint`, `typecheck`, `build`, and the full test suite — no regressions.
- All seven dialogs were exercised live in the OpenCode TUI (open, apply, re-open to confirm persistence); the quota modal was visually confirmed against the sidebar.

## Notes

- Built and reviewed cross-family with an implement→review→fix loop; reviews caught and fixed a global-notification prune bug, an RPC body-size DoS, a stale-knob-after-mutation bug, and a quota-modal section-gating parity gap.
- Known cosmetic: running a `/claude-*` command still emits a single `err_… failed` line in the OpenCode log, because the command hook aborts via a thrown sentinel (the existing mechanism — same as the prior text-mode commands and as other plugins do). The command works correctly; silencing that log cleanly is a possible follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784064432&installation_id=135454708&pr_number=76&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F76&signature=3a9f94b3fca00268099059e4ccb317af98755d6fd9df3fb9ddcde2716b9bd7b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds interactive modals for the seven `/claude-*` commands in the OpenCode TUI; changes made in a modal persist the same as typed slash args. Adds a localhost, bearer‑auth RPC bridge so the server can trigger TUI dialogs; outside the TUI, commands still print text summaries.

- **New Features**
  - TUI modals for: quota (read‑only), routing, fast, dump, cache (off/explicit/automatic/hybrid), cachekeep window, and killswitch (enable/disable + per‑account 5h/1w thresholds).
  - Quota modal mirrors the sidebar’s bars/pacing and respects section visibility.
  - Local RPC bridge: localhost‑only, bearer‑auth, ephemeral port + port file, 1 MB byte‑accurate body cap; override dir with `OPENCODE_ANTHROPIC_AUTH_RPC_DIR`.
  - TUI polls ~500ms with a per‑session notification queue; falls back to text when no TUI is connected.
  - Apply route persists changes via existing setters; dialogs and typed commands are equivalent.
  - Tests cover notifications, port‑file discovery, and RPC server (including oversized‑body rejection); build includes new `src/rpc/*` and dialog modules; docs updated.

- **Bug Fixes**
  - Enforce the RPC request body limit by UTF‑8 byte length to block multibyte bypasses; tests added.

<sup>Written for commit 6c6ecfc93fa0e5a95bd6b941f171e5575d49b783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

