### PR TITLE
fix: do not quota-backoff OAuth 403 checks

### DIFF
--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -1808,6 +1808,12 @@ function formatErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error)
 }
 
+function isQuotaPolicyAuthError(error: unknown) {
+  const status = (error as { status?: unknown }).status
+  if (status === 403) return true
+  return /Claude quota check failed: 403\b/.test(formatErrorMessage(error))
+}
+
 function recordRefreshError(
   account: OAuthAccount,
   error: unknown,
@@ -1826,6 +1832,7 @@ function recordQuotaRefreshError(
   error: unknown,
   now: number,
 ) {
+  if (isQuotaPolicyAuthError(error)) return
   account.lastQuotaRefreshError = buildQuotaOperationError({
     error,
     now,

--- a/packages/core/src/quota-manager.ts
+++ b/packages/core/src/quota-manager.ts
@@ -555,12 +555,12 @@ export class QuotaManager {
     })
   }
 
-  // A 401 is an auth/token problem, not a rate limit. The caller refreshes the
-  // token and retries; backing off the quota API here would block that retry,
-  // so surface 401s without recording backoff state.
+  // A 401 is an auth/token problem and a 403 is an account/org policy problem,
+  // not a rate limit. Surface them without recording quota backoff state so
+  // callers can refresh, re-auth, or try a fallback account immediately.
   private static isAuthError(error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error)
-    return /quota check failed: 401\b/.test(message)
+    return /quota check failed: (401|403)\b/.test(message)
   }
 
   /** Main quota failure: arms main-only backoff and persists via onApiError. */

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -2194,6 +2194,67 @@ describe('recordQuotaRefreshError refresh-backoff arming', () => {
     expect(account?.lastQuotaRefreshError).toBeDefined()
     expect(account?.lastQuotaRefreshError?.checkedAt).toBe(now)
   })
+
+  test('quota-endpoint 403 does NOT arm quota backoff', async () => {
+    const now = 1_000_000
+    const storage = baseStorage()
+    storage.accounts.push({
+      id: 'fb-quota-403',
+      type: 'oauth',
+      access: 'old-access',
+      refresh: 'old-refresh',
+      expires: now + 24 * 60 * 60_000,
+    })
+    await saveAccounts(storage)
+
+    const fetchImpl = mock((input: string | URL | Request) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof Request
+            ? input.url
+            : input.href
+      if (url.includes('/v1/oauth/token')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              access_token: 'new-access',
+              refresh_token: 'new-refresh',
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            type: 'error',
+            error: {
+              type: 'permission_error',
+              message:
+                'OAuth authentication is currently not allowed for this organization.',
+            },
+          }),
+          { status: 403 },
+        ),
+      )
+    }) as unknown as typeof fetch
+
+    const manager = new FallbackAccountManager({
+      fetchImpl,
+      now: () => now,
+    })
+
+    await manager.refreshQuotaForDueAccounts()
+
+    const loaded = await loadAccounts()
+    const account = loaded?.accounts.find((a) => a.id === 'fb-quota-403') as
+      | OAuthAccount
+      | undefined
+    expect(account?.lastRefreshError).toBeUndefined()
+    expect(account?.lastQuotaRefreshError).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Treat Claude OAuth quota-check 403s as auth/org-policy failures, not quota API backoff.
- Avoid persisting `lastQuotaRefreshError` for quota-check 403s in fallback account quota refresh.
- Add a regression test for the Anthropic `permission_error` response: "OAuth authentication is currently not allowed for this organization."

Closes #85.

## Validation

```text
bun run typecheck
bun run test
```

Result: 707 tests passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784844661&installation_id=135454708&pr_number=86&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F86&signature=50028b6f3395a1ae03281c8039a4ee46c7c9324b08f1fa928c0f7fff299e5d22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat OAuth 403s from Claude quota checks as auth/org-policy errors instead of quota backoff, allowing immediate re-auth or fallback. Skip persisting `lastQuotaRefreshError` for these 403s and add a regression test for the Anthropic `permission_error` case.

- **Bug Fixes**
  - `QuotaManager`: treat `quota check failed: 401|403` as auth/policy; do not record quota backoff.
  - `accounts`: do not set `lastQuotaRefreshError` for 403 quota-check errors.
  - Tests: add case ensuring a 403 permission error does not arm backoff or store refresh errors.

<sup>Written for commit 4114b8bb2e47c953fc00fb166954af01625e2b89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related problems: quota-check 403s (org/policy errors) were previously treated as rate-limit failures and armed quota backoff, and `lastQuotaRefreshError` was persisted for those 403s in the fallback manager's periodic refresh loop. The fix adds `isQuotaPolicyAuthError` in `accounts.ts` and extends `QuotaManager.isAuthError` to include 403 alongside 401.

- **`quota-manager.ts`**: The `isAuthError` regex is extended from `401` to `(401|403)`, cleanly preventing in-memory quota backoff for org-policy 403s. The message-only check is appropriately specific.
- **`accounts.ts`**: `isQuotaPolicyAuthError` is introduced to short-circuit `recordQuotaRefreshError`, but its first branch (`status === 403`) is too broad — `ClaudeOAuthRefreshError` also carries `status: number`, so a 403 from the token refresh endpoint would hit this guard and silently prevent `recordRefreshError` from being called, leaving the refresh backoff permanently unarmed.
- **`accounts.test.ts`**: A regression test covers the quota-endpoint 403 path (token refresh succeeds, quota returns 403). The complementary case — token refresh itself returning 403 — is not tested.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge for the quota-check 403 case, but the `status === 403` shortcut in `isQuotaPolicyAuthError` can match token-refresh errors too, silently suppressing refresh-backoff recording when the token endpoint returns 403.

The `quota-manager.ts` change is clean and self-contained. The `accounts.ts` guard has an unintended side-effect: `ClaudeOAuthRefreshError` carries `public readonly status: number`, so a 403 from the token-refresh endpoint hits the early return before the `isRefreshError` branch, leaving `lastRefreshError` permanently unset and the refresh loop unbounded. The test suite covers the happy path for the stated fix but does not exercise the token-refresh-403 variant that exposes the masking.

packages/core/src/accounts.ts — specifically the `isQuotaPolicyAuthError` function and its interaction with `ClaudeOAuthRefreshError`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/accounts.ts | Adds `isQuotaPolicyAuthError` guard in `recordQuotaRefreshError`; the `status === 403` branch is overly broad and can match `ClaudeOAuthRefreshError`, silently suppressing refresh-backoff recording when token refresh itself returns 403. |
| packages/core/src/quota-manager.ts | Extends `isAuthError` regex from `401` to `(401|403)`, correctly preventing quota backoff for org-policy 403s. Message-only check is appropriately specific. |
| packages/opencode/src/tests/accounts.test.ts | Adds a regression test for quota-endpoint 403; correctly verifies neither `lastRefreshError` nor `lastQuotaRefreshError` is armed, but does not cover the token-refresh-403 path. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[refreshQuotaForDueAccounts] --> B{Token needs refresh?}
    B -- Yes --> C{refreshBackoffActive?}
    C -- Yes --> SKIP[continue / skip account]
    C -- No --> D[refreshAccount → token endpoint]
    D -- 200 OK --> E[proceed to quota check]
    D -- "403 ClaudeOAuthRefreshError\n(status=403, isRefreshError=true)" --> CATCH
    B -- No --> E
    E --> F[refreshAccountQuota → quota endpoint]
    F -- 200 OK --> G[update quota, clear errors]
    F -- "403 quota-check error\n(message='Claude quota check failed: 403')" --> CATCH
    CATCH[outer catch: recordQuotaRefreshError] --> GUARD{isQuotaPolicyAuthError?}
    GUARD -- "status===403 matches BOTH error types" --> SKIP2[early return — no backoff armed]
    GUARD -- No --> ARM[arm lastQuotaRefreshError + recordRefreshError if isRefreshError]
    SKIP2 -. Bug: ClaudeOAuthRefreshError skips recordRefreshError too .-> LOOP[retry next tick — refresh backoff never armed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[refreshQuotaForDueAccounts] --> B{Token needs refresh?}
    B -- Yes --> C{refreshBackoffActive?}
    C -- Yes --> SKIP[continue / skip account]
    C -- No --> D[refreshAccount → token endpoint]
    D -- 200 OK --> E[proceed to quota check]
    D -- "403 ClaudeOAuthRefreshError\n(status=403, isRefreshError=true)" --> CATCH
    B -- No --> E
    E --> F[refreshAccountQuota → quota endpoint]
    F -- 200 OK --> G[update quota, clear errors]
    F -- "403 quota-check error\n(message='Claude quota check failed: 403')" --> CATCH
    CATCH[outer catch: recordQuotaRefreshError] --> GUARD{isQuotaPolicyAuthError?}
    GUARD -- "status===403 matches BOTH error types" --> SKIP2[early return — no backoff armed]
    GUARD -- No --> ARM[arm lastQuotaRefreshError + recordRefreshError if isRefreshError]
    SKIP2 -. Bug: ClaudeOAuthRefreshError skips recordRefreshError too .-> LOOP[retry next tick — refresh backoff never armed]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: do not quota-backoff OAuth 403 chec..."](https://github.com/cortexkit/anthropic-auth/commit/4114b8bb2e47c953fc00fb166954af01625e2b89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39416962)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->