### PR TITLE
fix: read runtime state when config file is absent

### DIFF
--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -402,6 +402,16 @@ function normalizeQuota(value: unknown): OAuthAccount['quota'] {
   return Object.keys(quota).length ? quota : undefined
 }
 
+// Fresh empty storage shell — main OpenCode OAuth account, no fallback
+// accounts. Returns a new object each call so mutating callers don't alias.
+export function createEmptyStorage(): AccountStorage {
+  return {
+    version: 1,
+    main: { type: 'opencode', provider: 'anthropic' },
+    accounts: [],
+  }
+}
+
 function normalizeStorage(value: unknown): AccountStorage | null {
   if (!isRecord(value) || !Array.isArray(value.accounts)) return null
   return {
@@ -497,9 +507,13 @@ function mergeConfigAndState(
 
 export async function loadAccounts(path = getAccountStoragePath()) {
   const config = await readJsonIfPresent(path)
-  if (!config.exists) return null
   const state = await readJsonIfPresent(getAccountStatePath(path))
-  return normalizeStorage(mergeConfigAndState(config.value, state.value))
+  // Runtime-only flows (main-OAuth refresh with no fallback accounts) write the
+  // state file but never the config file, so the store is absent only when
+  // neither exists. Synthesize an empty config to merge state into otherwise.
+  if (!config.exists && !state.exists) return null
+  const configValue = config.exists ? config.value : createEmptyStorage()
+  return normalizeStorage(mergeConfigAndState(configValue, state.value))
 }
 
 async function loadExistingTopLevelFields(path: string) {
@@ -1027,11 +1041,7 @@ export async function setCache1hPersistentEnabled(
   mode?: Cache1hMode,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.claudeCache = {
     ...(storage.claudeCache ?? {}),
     enabled,
@@ -1045,11 +1055,7 @@ export async function setCache1hPersistentMode(
   mode: Cache1hMode,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.claudeCache = {
     ...(storage.claudeCache ?? {}),
     enabled: storage.claudeCache?.enabled === true,
@@ -1067,11 +1073,7 @@ export async function setDumpPersistentEnabled(
   enabled: boolean,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.dump = {
     ...(storage.dump ?? {}),
     enabled,
@@ -1088,11 +1090,7 @@ export async function setFastModePersistentEnabled(
   enabled: boolean,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.claudeFast = {
     ...(storage.claudeFast ?? {}),
     enabled,
@@ -1106,11 +1104,7 @@ export async function setCacheKeepPersistentWindow(
   endHour: number,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.cacheKeep = {
     enabled: true,
     startHour,
@@ -1124,11 +1118,7 @@ export async function setCacheKeepPersistentEnabled(
   enabled: boolean,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.cacheKeep = {
     ...(storage.cacheKeep ?? {}),
     enabled,
@@ -1145,11 +1135,7 @@ export async function setCacheKeepSubagentsEnabled(
   enabled: boolean,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.cacheKeep = {
     ...(storage.cacheKeep ?? {}),
     subagents: enabled,
@@ -1340,11 +1326,7 @@ export async function setLogLevelPersistent(
   path = getAccountStoragePath(),
 ) {
   const { setLogLevel } = await import('./logger.ts')
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.logging = {
     ...(storage.logging ?? {}),
     level,
@@ -1512,11 +1494,7 @@ export async function setKillswitchPersistent(
   config: KillswitchConfig,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.killswitch = config
   await saveAccounts(storage, path)
   return storage
@@ -1559,11 +1537,7 @@ export async function addAccountPersistent(
   account: FallbackAccount,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   upsertAccount(storage, account)
   await saveAccounts(storage, path)
 }

--- a/packages/core/src/routing.ts
+++ b/packages/core/src/routing.ts
@@ -1,5 +1,6 @@
 import {
   type AccountStorage,
+  createEmptyStorage,
   getAccountStoragePath,
   loadAccounts,
   type RoutingMode,
@@ -33,11 +34,7 @@ export async function setRoutingMode(
   mode: RoutingMode,
   path = getAccountStoragePath(),
 ) {
-  const storage = (await loadAccounts(path)) ?? {
-    version: 1,
-    main: { type: 'opencode' as const, provider: 'anthropic' as const },
-    accounts: [],
-  }
+  const storage = (await loadAccounts(path)) ?? createEmptyStorage()
   storage.routing = {
     ...(storage.routing ?? {}),
     mode,

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -24,6 +24,7 @@ import {
   CLAUDE_LOGGING_COMMAND_NAME,
   CLAUDE_QUOTAS_COMMAND_NAME,
   CLAUDE_ROUTING_COMMAND_NAME,
+  createEmptyStorage,
   dumpDirectRequest,
   exchange,
   executeAccountCommand,
@@ -485,10 +486,8 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       fetchStartedAt,
     ) => {
       try {
-        const storage = (await loadAccounts(accountStoragePath)) ?? {
-          version: 1 as const,
-          accounts: [],
-        }
+        const storage =
+          (await loadAccounts(accountStoragePath)) ?? createEmptyStorage()
         const persisted = getPersistedMainQuota(storage)
         if (
           persisted &&
@@ -513,10 +512,8 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
     },
     onApiError: async (error) => {
       try {
-        const storage = (await loadAccounts(accountStoragePath)) ?? {
-          version: 1 as const,
-          accounts: [],
-        }
+        const storage =
+          (await loadAccounts(accountStoragePath)) ?? createEmptyStorage()
         storage.quota = storage.quota ?? {}
         storage.quota.mainLastQuotaApiError = error
         await saveAccountState(storage, accountStoragePath, { mainQuota: true })
@@ -1001,10 +998,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
     if (action.type === 'add-apikey') {
       if (!action.apiKey) {
         const accounts = buildAccountList(
-          (await loadAccounts(accountStoragePath)) ?? {
-            version: 1,
-            accounts: [],
-          },
+          (await loadAccounts(accountStoragePath)) ?? createEmptyStorage(),
         )
         return { text: 'API key is required', accounts }
       }
@@ -1014,10 +1008,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
         action.baseURL?.trim() || 'https://api.kie.ai/claude'
       if (!isValidApiBaseURL(resolvedBaseURL)) {
         const accounts = buildAccountList(
-          (await loadAccounts(accountStoragePath)) ?? {
-            version: 1,
-            accounts: [],
-          },
+          (await loadAccounts(accountStoragePath)) ?? createEmptyStorage(),
         )
         return {
           text: 'Invalid base URL. Must be an http(s) URL without embedded credentials.',
@@ -1070,10 +1061,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
         text: `Open this URL in your browser:\n${authResult.url}`,
         knobs: { oauthUrl: authResult.url },
         accounts: buildAccountList(
-          (await loadAccounts(accountStoragePath)) ?? {
-            version: 1,
-            accounts: [],
-          },
+          (await loadAccounts(accountStoragePath)) ?? createEmptyStorage(),
         ),
       }
     }
@@ -1084,10 +1072,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       const pending = takeOAuthPending(key)
       if (!pending) {
         const accounts = buildAccountList(
-          (await loadAccounts(accountStoragePath)) ?? {
-            version: 1,
-            accounts: [],
-          },
+          (await loadAccounts(accountStoragePath)) ?? createEmptyStorage(),
         )
         return {
           text: 'OAuth session expired. Please start again.',
@@ -1105,10 +1090,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
 
         if (result.type === 'failed') {
           const accounts = buildAccountList(
-            (await loadAccounts(accountStoragePath)) ?? {
-              version: 1,
-              accounts: [],
-            },
+            (await loadAccounts(accountStoragePath)) ?? createEmptyStorage(),
           )
           return {
             text: 'OAuth authentication failed. Please check the code and try again.',
@@ -1137,15 +1119,12 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
         const updatedStorage = await loadAccounts(accountStoragePath)
         await refreshSidebarAfterMutation(updatedStorage)
         const accounts = buildAccountList(
-          updatedStorage ?? { version: 1, accounts: [] },
+          updatedStorage ?? createEmptyStorage(),
         )
         return { text: `OAuth account added.`, accounts }
       } catch {
         const accounts = buildAccountList(
-          (await loadAccounts(accountStoragePath)) ?? {
-            version: 1,
-            accounts: [],
-          },
+          (await loadAccounts(accountStoragePath)) ?? createEmptyStorage(),
         )
         return {
           text: 'OAuth exchange failed due to a network error. Please try again.',
@@ -1595,13 +1574,9 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                 async function updateMainRefreshState(
                   update: (storage: AccountStorage) => void,
                 ) {
-                  const storage: AccountStorage = (await loadAccounts(
-                    accountStoragePath,
-                  )) ?? {
-                    version: 1,
-                    main: { type: 'opencode', provider: 'anthropic' },
-                    accounts: [],
-                  }
+                  const storage: AccountStorage =
+                    (await loadAccounts(accountStoragePath)) ??
+                    createEmptyStorage()
                   storage.refresh = storage.refresh ?? {}
                   update(storage)
                   await saveAccountState(storage, accountStoragePath, {

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -800,6 +800,70 @@ describe('account storage', () => {
     expect(saved?.claudeFast).toEqual({ enabled: false })
     expect(isFastModePersistentlyEnabled(saved)).toBe(false)
   })
+
+  test('returns null when neither config nor state file exists', async () => {
+    await expect(loadAccounts()).resolves.toBeNull()
+  })
+
+  test('reads runtime state when config file is absent (no fallback accounts)', async () => {
+    const statePath = getAccountStatePath(accountPath)
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        main: {
+          refreshLeaseId: 'lease-abc',
+          refreshLeaseUntil: 9_999_999_999_999,
+          refreshLeaseTokenHash: 'hash-xyz',
+          quota: {
+            five_hour: {
+              usedPercent: 33,
+              remainingPercent: 67,
+              checkedAt: 777,
+            },
+          },
+          quotaCheckedAt: 777,
+          quotaToken: 'token-state-only',
+        },
+      }),
+      'utf8',
+    )
+
+    // Config file must NOT exist for this scenario.
+    await expect(stat(accountPath)).rejects.toThrow()
+
+    const loaded = await loadAccounts()
+    expect(loaded).not.toBeNull()
+    expect(loaded?.accounts).toEqual([])
+    expect(loaded?.refresh?.mainRefreshLeaseId).toBe('lease-abc')
+    expect(loaded?.refresh?.mainRefreshLeaseUntil).toBe(9_999_999_999_999)
+    expect(loaded?.refresh?.mainRefreshLeaseTokenHash).toBe('hash-xyz')
+    expect(loaded?.quota?.mainQuotaToken).toBe('token-state-only')
+    expect(loaded?.quota?.mainQuota?.five_hour?.usedPercent).toBe(33)
+  })
+
+  test('lease written via saveAccountState is visible to loadAccounts without a config file', async () => {
+    const storage: AccountStorage = {
+      version: 1,
+      main: { type: 'opencode', provider: 'anthropic' },
+      accounts: [],
+      refresh: {
+        mainRefreshLeaseId: 'lease-from-save',
+        mainRefreshLeaseUntil: 9_999_999_999_999,
+        mainRefreshLeaseTokenHash: 'token-hash-from-save',
+      },
+    }
+    await saveAccountState(storage, accountPath, { mainRefresh: true })
+
+    // saveAccountState must not have created the config file.
+    await expect(stat(accountPath)).rejects.toThrow()
+
+    const loaded = await loadAccounts()
+    expect(loaded?.refresh?.mainRefreshLeaseId).toBe('lease-from-save')
+    expect(loaded?.refresh?.mainRefreshLeaseTokenHash).toBe(
+      'token-hash-from-save',
+    )
+  })
 })
 
 describe('FallbackAccountManager', () => {

--- a/packages/pi/src/commands.ts
+++ b/packages/pi/src/commands.ts
@@ -4,6 +4,7 @@ import {
   CLAUDE_ACCOUNT_COMMAND_NAME,
   CLAUDE_CACHE_KEEP_COMMAND_NAME,
   CLAUDE_ROUTING_COMMAND_NAME,
+  createEmptyStorage,
   executeAccountCommand,
   executeCache1hCommand,
   executeCacheKeepCommand,
@@ -237,7 +238,7 @@ export function registerCommands(pi: ExtensionAPI) {
       const storage = await loadAccounts(path)
       const result = executeAccountCommand({
         argumentsText: args ?? '',
-        storage: storage ?? { version: 1, accounts: [] },
+        storage: storage ?? createEmptyStorage(),
       })
 
       if (!result.updated) {


### PR DESCRIPTION
loadAccounts treated the config file (anthropic-auth.json) as a
gatekeeper: if it did not exist, it returned null without ever reading
the runtime state file (anthropic-auth-state.json). But the two files are
written independently, and runtime-only flows — notably main-OAuth
refresh with no fallback accounts — write the state file while never
creating the config file. As a result, for any user without fallback
accounts the config file never exists, so every reader got null and the
state file's refresh-lease, quota, and error data was invisible.

This broke the post-write lease verification as well as the backoff
check and lease-skip check in the same refresh path, all of which
silently received null storage.

Fix loadAccounts to read both files and return null only when neither
exists; when config is absent but state is present, synthesize an empty
config shell and merge state in as usual. This matches the documented
two-file design where the state file holds independent runtime data.

Also extract the repeated empty-storage literal into a shared
createEmptyStorage() factory in core and replace the 18 inline
duplicates across accounts.ts, routing.ts, index.ts, and pi/commands.ts.
The CLI's richer defaultStorage() (config bootstrap with seeded
defaults) is intentionally left separate.

Adds regression tests covering: null when neither file exists, runtime
state visible when config is absent, and a lease written via
saveAccountState being readable by loadAccounts without a config file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784913826&installation_id=135454708&pr_number=98&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F98&signature=1950ff21eb04d7f733bcb066f7e7ed2b9b359e6a2e9080fbc48f335ba886f075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `loadAccounts` to read runtime state when the config file is missing, restoring OAuth refresh/backoff behavior for users without fallback accounts. Adds `createEmptyStorage()` to dedupe empty-storage literals and includes regression tests.

- **Bug Fixes**
  - `loadAccounts` now returns null only when neither config nor state exists.
  - When config is absent but state exists, synthesize an empty config and merge state.
  - Restores post-write lease verification, backoff, and lease-skip checks in the OAuth refresh path.
  - Adds tests for: no files, state-only reads, and reading a lease saved via `saveAccountState` without a config file.

- **Refactors**
  - Introduced `createEmptyStorage()` in core and replaced inline defaults across `accounts.ts`, `routing.ts`, `opencode/index.ts`, and `pi/commands.ts`.

<sup>Written for commit 6d8d69f4c97d6263a6247a39a61ea629638fa689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `loadAccounts` so it reads runtime state even when the config file (`anthropic-auth.json`) is absent, which was silently causing null storage for users without fallback accounts. It also extracts the repeated inline empty-storage literal into a shared `createEmptyStorage()` factory.

- **Core logic fix** (`accounts.ts`): `loadAccounts` now reads both files before deciding, returns `null` only when neither exists, and synthesizes an empty config shell to merge state into when only the state file is present.
- **Deduplication** (`accounts.ts`, `routing.ts`, `index.ts`, `pi/commands.ts`): replaces 18 copies of `{ version: 1, accounts: [] }` (some of which were missing the `main` field) with `createEmptyStorage()`, which always includes `main: { type: 'opencode', provider: 'anthropic' }`.
- **Regression tests** (`accounts.test.ts`): three new tests cover null-when-neither, state-visible-without-config, and round-trip lease write/read without a config file.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is well-scoped, regression-tested, and the deduplication is a straightforward mechanical refactor.

The loadAccounts change is the only logic mutation; the rest of the PR replaces identical inline literals with the new factory. The fix is logically sound: mergeConfigAndState already handles a null/absent state value, and normalizeStorage correctly validates the merged output before returning it. The three new tests directly exercise each changed code path. No callers are broken by the behavioral change where some old fallbacks were missing the main field.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/accounts.ts | Core fix: loadAccounts now reads state file unconditionally and synthesizes an empty config when only state is present; createEmptyStorage() factory extracted and exported cleanly. |
| packages/core/src/routing.ts | Mechanical substitution of inline empty-storage literal with createEmptyStorage(); no logic change. |
| packages/opencode/src/index.ts | Replaces 10 inline empty-storage literals with createEmptyStorage(); some old literals were missing the main field which createEmptyStorage now always includes — an improvement. |
| packages/opencode/src/tests/accounts.test.ts | Three new regression tests covering null-when-neither, state-visible-without-config, and lease round-trip without a config file — all exercising the fixed code path. |
| packages/pi/src/commands.ts | Single literal replaced with createEmptyStorage(); the old literal was missing main, which is now correctly included. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[loadAccounts called] --> B[readJsonIfPresent config file]
    A --> C[readJsonIfPresent state file]
    B --> D{config.exists?}
    C --> E{state.exists?}
    D -- No --> F{state.exists?}
    E -- No --> F
    D -- Yes --> G[use config.value]
    E -- Yes --> H[use state.value]
    F -- No --> I[return null]
    F -- Yes --> J[synthesize createEmptyStorage as configValue]
    G --> K[mergeConfigAndState configValue + state.value]
    J --> K
    H --> K
    K --> L[normalizeStorage merged result]
    L --> M[return AccountStorage]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[loadAccounts called] --> B[readJsonIfPresent config file]
    A --> C[readJsonIfPresent state file]
    B --> D{config.exists?}
    C --> E{state.exists?}
    D -- No --> F{state.exists?}
    E -- No --> F
    D -- Yes --> G[use config.value]
    E -- Yes --> H[use state.value]
    F -- No --> I[return null]
    F -- Yes --> J[synthesize createEmptyStorage as configValue]
    G --> K[mergeConfigAndState configValue + state.value]
    J --> K
    H --> K
    K --> L[normalizeStorage merged result]
    L --> M[return AccountStorage]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: read runtime state when config file..."](https://github.com/cortexkit/anthropic-auth/commit/6d8d69f4c97d6263a6247a39a61ea629638fa689) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39613002)</sub>

<!-- /greptile_comment -->