### PR TITLE
Make Claude Sonnet 5 adaptive thinking visible

### DIFF
--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -50,6 +50,25 @@ export function isClaudeFableOrMythos5Model(model: unknown) {
   )
 }
 
+export const CLAUDE_SONNET_5_MODEL_ID = 'claude-sonnet-5'
+
+/**
+ * Sonnet 5 enables adaptive thinking by default but ships `display: "omitted"`,
+ * so the `thinking` field returns empty and the user sees nothing. Injecting
+ * this makes the adaptive thinking summary visible. Reuses the Fable/Mythos
+ * shape because the API contract is identical.
+ */
+export const CLAUDE_SONNET_5_ADAPTIVE_THINKING =
+  CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING
+
+export function isClaudeSonnet5Model(model: unknown) {
+  return (
+    typeof model === 'string' &&
+    (model === CLAUDE_SONNET_5_MODEL_ID ||
+      model.startsWith(`${CLAUDE_SONNET_5_MODEL_ID}-`))
+  )
+}
+
 export function isOpenAIReasoningSignature(value: unknown): boolean {
   if (typeof value !== 'string') return false
   if (value.startsWith('gAAAA')) return true

--- a/packages/core/src/tests/models.test.ts
+++ b/packages/core/src/tests/models.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test'
+import { isClaudeSonnet5Model } from '../models'
+
+describe('isClaudeSonnet5Model', () => {
+  test('matches the bare claude-sonnet-5 id', () => {
+    expect(isClaudeSonnet5Model('claude-sonnet-5')).toBe(true)
+  })
+
+  test('matches a dated claude-sonnet-5 snapshot', () => {
+    expect(isClaudeSonnet5Model('claude-sonnet-5-20260630')).toBe(true)
+  })
+
+  test('does not match claude-sonnet-4-6', () => {
+    expect(isClaudeSonnet5Model('claude-sonnet-4-6')).toBe(false)
+  })
+
+  test('does not match the Fable/Mythos ids', () => {
+    expect(isClaudeSonnet5Model('claude-fable-5')).toBe(false)
+    expect(isClaudeSonnet5Model('claude-mythos-5')).toBe(false)
+  })
+
+  test('does not match a non-dash prefix collision', () => {
+    expect(isClaudeSonnet5Model('claude-sonnet-5x')).toBe(false)
+  })
+
+  test('does not match non-string input', () => {
+    expect(isClaudeSonnet5Model(undefined)).toBe(false)
+    expect(isClaudeSonnet5Model(42)).toBe(false)
+  })
+})

--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -938,6 +938,66 @@ describe('rewriteRequestBody', () => {
     expect(result.output_config).toEqual({ effort: 'xhigh' })
   })
 
+  test('requests summarized adaptive thinking for Sonnet 5 without thinking', async () => {
+    const body = JSON.stringify({
+      model: 'claude-sonnet-5',
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+
+    const result = JSON.parse(await rewriteRequestBody(body))
+
+    expect(result.thinking).toEqual({ type: 'adaptive', display: 'summarized' })
+  })
+
+  test('replaces manual enabled thinking with adaptive summarized for Sonnet 5', async () => {
+    const body = JSON.stringify({
+      model: 'claude-sonnet-5-20260630',
+      messages: [{ role: 'user', content: 'hi' }],
+      thinking: { type: 'enabled', budget_tokens: 10_000 },
+    })
+
+    const result = JSON.parse(await rewriteRequestBody(body))
+
+    expect(result.thinking).toEqual({ type: 'adaptive', display: 'summarized' })
+    expect(result.thinking.budget_tokens).toBeUndefined()
+  })
+
+  test('preserves explicitly disabled thinking for Sonnet 5', async () => {
+    const body = JSON.stringify({
+      model: 'claude-sonnet-5',
+      messages: [{ role: 'user', content: 'hi' }],
+      thinking: { type: 'disabled' },
+    })
+
+    const result = JSON.parse(await rewriteRequestBody(body))
+
+    expect(result.thinking).toEqual({ type: 'disabled' })
+  })
+
+  test('strips display from disabled thinking for Sonnet 5', async () => {
+    const body = JSON.stringify({
+      model: 'claude-sonnet-5',
+      messages: [{ role: 'user', content: 'hi' }],
+      thinking: { type: 'disabled', display: 'summarized' },
+    })
+
+    const result = JSON.parse(await rewriteRequestBody(body))
+
+    expect(result.thinking).toEqual({ type: 'disabled' })
+  })
+
+  test('does not touch thinking for non-Sonnet5 models', async () => {
+    const body = JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      messages: [{ role: 'user', content: 'hi' }],
+      thinking: { type: 'enabled', budget_tokens: 5_000 },
+    })
+
+    const result = JSON.parse(await rewriteRequestBody(body))
+
+    expect(result.thinking).toEqual({ type: 'enabled', budget_tokens: 5_000 })
+  })
+
   test('strips OpenAI encrypted reasoning blocks before sending to Anthropic', async () => {
     const body = JSON.stringify({
       model: 'claude-opus-4-8',

--- a/packages/opencode/src/transform.ts
+++ b/packages/opencode/src/transform.ts
@@ -6,9 +6,11 @@ import {
   CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_IDENTITY,
   CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING,
+  CLAUDE_SONNET_5_ADAPTIVE_THINKING,
   type ClaudeCodeIdentity,
   FAST_MODE_BETA,
   isClaudeFableOrMythos5Model,
+  isClaudeSonnet5Model,
   isFastModeSupportedModel,
   isOpenAIReasoningSignature,
   mergeAnthropicBetas,
@@ -776,6 +778,31 @@ function normalizeFableMythosRequest(
   return { replacedExisting: hadThinking }
 }
 
+/**
+ * Sonnet 5 has adaptive thinking on by default but defaults `display` to
+ * "omitted", so the thinking field returns empty. Inject
+ * `{type:"adaptive",display:"summarized"}` to make it visible — UNLESS the
+ * caller explicitly disabled thinking. Unlike Fable/Mythos (which reject a
+ * disable), Sonnet 5 accepts `{type:"disabled"}`, so an intentional opt-out is
+ * preserved rather than force-enabled. A manual `{type:"enabled",budget_tokens}`
+ * would 400 on Sonnet 5, so it is overwritten with the adaptive form.
+ */
+function normalizeSonnet5Request(
+  parsed: Record<string, unknown>,
+): { replacedExisting: boolean; display: 'summarized' | 'disabled' } | null {
+  if (!isClaudeSonnet5Model(parsed.model)) return null
+  const hadThinking = Object.hasOwn(parsed, 'thinking')
+  const thinking = parsed.thinking
+  if (isRecord(thinking) && thinking.type === 'disabled') {
+    // `display` is invalid alongside `type:"disabled"` (nothing to display) and
+    // can 400; canonicalize to a bare disabled object while keeping thinking off.
+    parsed.thinking = { type: 'disabled' }
+    return { replacedExisting: hadThinking, display: 'disabled' }
+  }
+  parsed.thinking = { ...CLAUDE_SONNET_5_ADAPTIVE_THINKING }
+  return { replacedExisting: hadThinking, display: 'summarized' }
+}
+
 function applyCache1hStrategy(
   parsed: Record<string, unknown>,
   options: { enabled: boolean; mode: Cache1hMode },
@@ -902,6 +929,7 @@ export async function rewriteRequestBody(
     const modelNormalizeStart = rewriteNowMs()
     const removedNonAnthropicThinking = stripNonAnthropicThinkingBlocks(parsed)
     const fableMythosThinking = normalizeFableMythosRequest(parsed)
+    const sonnet5Thinking = normalizeSonnet5Request(parsed)
     options.perf?.('model_normalize', {
       ms: rewriteRoundMs(rewriteNowMs() - modelNormalizeStart),
       model: typeof parsed.model === 'string' ? parsed.model : undefined,
@@ -910,6 +938,8 @@ export async function rewriteRequestBody(
         : undefined,
       replacedFableMythosThinking:
         fableMythosThinking?.replacedExisting ?? false,
+      sonnet5ThinkingDisplay: sonnet5Thinking?.display,
+      replacedSonnet5Thinking: sonnet5Thinking?.replacedExisting ?? false,
       removedNonAnthropicThinking,
       hasOutputConfig: Object.hasOwn(parsed, 'output_config'),
     })

--- a/packages/pi/src/convert.ts
+++ b/packages/pi/src/convert.ts
@@ -4,6 +4,7 @@ import {
   type Cache1hMode,
   CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_IDENTITY,
+  CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING,
   CLAUDE_SONNET_5_ADAPTIVE_THINKING,
   type ClaudeCodeIdentity,
   isClaudeFableOrMythos5Model,
@@ -412,7 +413,9 @@ export async function buildAnthropicRequest(
   // thinking visible (display defaults to "omitted") and map reasoning to
   // output_config effort. Pi's typed options cannot express thinking-disabled,
   // so there is no disable case here (see transform.ts for the raw-body path).
-  if (isFableOrMythos5 || isSonnet5) {
+  if (isFableOrMythos5) {
+    body.thinking = { ...CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING }
+  } else if (isSonnet5) {
     body.thinking = { ...CLAUDE_SONNET_5_ADAPTIVE_THINKING }
   }
 

--- a/packages/pi/src/convert.ts
+++ b/packages/pi/src/convert.ts
@@ -4,9 +4,10 @@ import {
   type Cache1hMode,
   CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_IDENTITY,
-  CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING,
+  CLAUDE_SONNET_5_ADAPTIVE_THINKING,
   type ClaudeCodeIdentity,
   isClaudeFableOrMythos5Model,
+  isClaudeSonnet5Model,
   isFastModeSupportedModel,
   isOpenAIReasoningSignature,
   orderClaudeCodeBody,
@@ -406,12 +407,17 @@ export async function buildAnthropicRequest(
   }
 
   const isFableOrMythos5 = isClaudeFableOrMythos5Model(modelId)
-  if (isFableOrMythos5) {
-    body.thinking = { ...CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING }
+  const isSonnet5 = isClaudeSonnet5Model(modelId)
+  // Sonnet 5 shares Fable/Mythos's adaptive-summarized contract: make adaptive
+  // thinking visible (display defaults to "omitted") and map reasoning to
+  // output_config effort. Pi's typed options cannot express thinking-disabled,
+  // so there is no disable case here (see transform.ts for the raw-body path).
+  if (isFableOrMythos5 || isSonnet5) {
+    body.thinking = { ...CLAUDE_SONNET_5_ADAPTIVE_THINKING }
   }
 
   if (options?.reasoning) {
-    if (isFableOrMythos5) {
+    if (isFableOrMythos5 || isSonnet5) {
       body.output_config = { effort: options.reasoning }
     } else {
       const budgets: Record<string, number> = {

--- a/packages/pi/src/tests/convert.test.ts
+++ b/packages/pi/src/tests/convert.test.ts
@@ -364,6 +364,42 @@ describe('buildAnthropicRequest — Fable/Mythos thinking', () => {
   })
 })
 
+describe('buildAnthropicRequest — Sonnet 5 thinking', () => {
+  test('requests summarized adaptive thinking for Sonnet 5 without reasoning', async () => {
+    const { body } = await buildAnthropicRequest(
+      'claude-sonnet-5',
+      { messages: [userMsg('hello')], systemPrompt: 'test', tools: [] } as any,
+      {} as any,
+      defaultCache,
+    )
+
+    expect(body.thinking).toEqual({ type: 'adaptive', display: 'summarized' })
+  })
+
+  test('replaces manual reasoning budget with adaptive summarized for Sonnet 5', async () => {
+    const { body } = await buildAnthropicRequest(
+      'claude-sonnet-5-20260630',
+      { messages: [userMsg('hello')], systemPrompt: 'test', tools: [] } as any,
+      { reasoning: 'high' } as any,
+      defaultCache,
+    )
+
+    expect(body.thinking).toEqual({ type: 'adaptive', display: 'summarized' })
+    expect(body.output_config).toEqual({ effort: 'high' })
+  })
+
+  test('sets display summarized (not omitted) so Sonnet 5 thinking is visible', async () => {
+    const { body } = await buildAnthropicRequest(
+      'claude-sonnet-5',
+      { messages: [userMsg('hello')], systemPrompt: 'test', tools: [] } as any,
+      {} as any,
+      defaultCache,
+    )
+
+    expect((body.thinking as { display?: string }).display).toBe('summarized')
+  })
+})
+
 describe('convertMessages — empty error tool_result guard', () => {
   test('injects Error placeholder when is_error=true and content is empty', async () => {
     const messages = await buildMessages([


### PR DESCRIPTION
## Problem

Claude Sonnet 5 (`claude-sonnet-5`) enables adaptive thinking by default, but its `thinking.display` defaults to `"omitted"` — so the `thinking` field returns empty and thinking is invisible to the user. This is a silent change from earlier models where `display` defaulted to `"summarized"`.

## Fix

Normalize the request body for `claude-sonnet-5` so adaptive thinking is visible:

- If thinking is not explicitly disabled → set `thinking: {type: "adaptive", display: "summarized"}`.
- If the caller explicitly sent `{type: "disabled"}` → preserve the disable, canonicalized to a bare `{type: "disabled"}` (the `display` field is invalid alongside `type: "disabled"` and can 400).
- A manual `{type: "enabled", budget_tokens}` would 400 on Sonnet 5, so it is overwritten with the adaptive form.

This mirrors the existing Fable/Mythos 5 handling, with the Sonnet-5-specific difference that `{type: "disabled"}` is accepted (Fable/Mythos reject it).

`claude-sonnet-5` is in the native model catalog, so no model registration is added.

## Changes

- `packages/core/src/models.ts` — `isClaudeSonnet5Model`, `CLAUDE_SONNET_5_MODEL_ID`, `CLAUDE_SONNET_5_ADAPTIVE_THINKING`.
- `packages/opencode/src/transform.ts` — `normalizeSonnet5Request`, called alongside the Fable/Mythos normalizer.
- `packages/pi/src/convert.ts` — Sonnet 5 folded into the adaptive-thinking branch (Pi's typed options cannot express disable, so it always emits adaptive + summarized and maps reasoning to effort).

## Tests

- `isClaudeSonnet5Model` precision: matches `claude-sonnet-5` and dated snapshots; rejects `claude-sonnet-4-6`, Fable/Mythos ids, and `claude-sonnet-5x`.
- Transform: no-thinking → adaptive+summarized; manual enabled+budget → overwritten (budget dropped); explicit disabled → preserved and stripped to bare `{type:"disabled"}`; non-Sonnet-5 untouched.
- Pi: produces `display: "summarized"` for `claude-sonnet-5`; reasoning→effort mapping intact.

All suites green (opencode 744, pi 47, e2e 2), typecheck and lint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785443414&installation_id=135454708&pr_number=100&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F100&signature=ae01b9c6c25bf48d0079e932c80c685fc5ea82f9dc9e808446a325b990173709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make adaptive thinking visible for `claude-sonnet-5`. Requests now default `thinking` to `{type: "adaptive", display: "summarized"}` unless explicitly disabled, preventing empty `thinking` responses.

- **Bug Fixes**
  - Normalize Sonnet 5 in `packages/opencode/src/transform.ts`: preserve `{type:"disabled"}` (strip `display`), override `{type:"enabled", budget_tokens}` to adaptive summarized, and set adaptive summarized when missing; non-Sonnet-5 untouched.
  - Add Sonnet 5 detection/constants in `packages/core`; update `packages/pi` to emit adaptive summarized and map `reasoning` → `output_config.effort` (Pi cannot disable).
  - Refactor `packages/pi` to use each model family's constant (`CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING` vs `CLAUDE_SONNET_5_ADAPTIVE_THINKING`) so configs stay independent.

<sup>Written for commit 893c7c9af2cb710d54a2dc42910e40a8ee767e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes Claude Sonnet 5's adaptive thinking visible by injecting `{type:"adaptive",display:"summarized"}` into requests that would otherwise silently return an empty `thinking` field (Sonnet 5 defaults `display` to `"omitted"`). The change mirrors existing Fable/Mythos 5 handling in both the raw-body transform path and the Pi typed-options path.

- **`packages/core/src/models.ts`**: Adds `CLAUDE_SONNET_5_MODEL_ID`, the `CLAUDE_SONNET_5_ADAPTIVE_THINKING` constant (currently aliased to `CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING`), and `isClaudeSonnet5Model()` with dash-prefix matching for dated snapshots.
- **`packages/opencode/src/transform.ts`**: Introduces `normalizeSonnet5Request()` which—unlike the Fable/Mythos normalizer—preserves an explicit `{type:"disabled"}` (stripping invalid `display`), overwrites `{type:"enabled",budget_tokens}` (which would 400 on Sonnet 5), and defaults everything else to adaptive+summarized.
- **`packages/pi/src/convert.ts`**: Folds Sonnet 5 into the adaptive-summarized branch and maps `reasoning` to `output_config.effort`; Pi's typed surface cannot express disable, so no disable case is needed here.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to Sonnet 5 model IDs and all non-Sonnet-5 requests are left completely untouched.

The normalizer correctly identifies the three distinct thinking states (absent/enabled → adaptive+summarized, explicit disabled → canonicalized bare disabled) with no overlap with the Fable/Mythos path. Tests cover all branches including the dash-prefix false-positive guard. Both code paths (raw transform and Pi typed interface) are updated consistently.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/models.ts | Adds CLAUDE_SONNET_5_MODEL_ID, CLAUDE_SONNET_5_ADAPTIVE_THINKING (aliased to Fable/Mythos constant), and isClaudeSonnet5Model() with correct dash-prefix snapshot matching. No logic errors; test coverage is thorough. |
| packages/opencode/src/transform.ts | normalizeSonnet5Request correctly handles the three cases (no thinking → adaptive+summarized, type:enabled → overwrite, type:disabled → canonicalize). Perf telemetry captures both replacedExisting and display mode. No overlap with normalizeFableMythosRequest since model IDs don't intersect. |
| packages/pi/src/convert.ts | Sonnet 5 folded cleanly into the adaptive-summarized + output_config.effort branch. The inability to express disable via Pi's typed surface is acknowledged in the comment. Uses CLAUDE_SONNET_5_ADAPTIVE_THINKING for the Sonnet 5 branch while Fable/Mythos retains its own constant. |
| packages/core/src/tests/models.test.ts | New test file; covers bare ID, dated snapshot, negative cases (claude-sonnet-4-6, Fable/Mythos, no-dash suffix collision, non-string inputs). All edge cases for isClaudeSonnet5Model are exercised. |
| packages/opencode/src/tests/transform.test.ts | Five new tests cover: no-thinking → adaptive+summarized; enabled+budget → overwrite with budget dropped; explicit disabled → preserved; disabled+display → stripped to bare disabled; non-Sonnet5 model → untouched. |
| packages/pi/src/tests/convert.test.ts | Three new tests confirm adaptive+summarized output, output_config.effort mapping with reasoning, and display:'summarized' assertion for Sonnet 5 via the Pi path. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming request body] --> B{isClaudeSonnet5Model?}
    B -- No --> C[normalizeSonnet5Request returns null]
    B -- Yes --> D{thinking present AND type is disabled?}
    D -- Yes --> E[Canonicalize to bare disabled object, strip display field]
    D -- No --> F[Set thinking to adaptive plus summarized, overwrite any enabled plus budget value]
    E --> G[Log sonnet5ThinkingDisplay as disabled]
    F --> H[Log sonnet5ThinkingDisplay as summarized]
    G --> I[Continue pipeline]
    H --> I

    subgraph Pi path
        P1[buildAnthropicRequest] --> P2{isClaudeSonnet5Model?}
        P2 -- Yes --> P3[body.thinking = adaptive plus summarized]
        P3 --> P4{options.reasoning set?}
        P4 -- Yes --> P5[body.output_config = effort]
        P4 -- No --> P6[No output_config]
        P2 -- No --> P7[Fable/Mythos or budget-based path]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming request body] --> B{isClaudeSonnet5Model?}
    B -- No --> C[normalizeSonnet5Request returns null]
    B -- Yes --> D{thinking present AND type is disabled?}
    D -- Yes --> E[Canonicalize to bare disabled object, strip display field]
    D -- No --> F[Set thinking to adaptive plus summarized, overwrite any enabled plus budget value]
    E --> G[Log sonnet5ThinkingDisplay as disabled]
    F --> H[Log sonnet5ThinkingDisplay as summarized]
    G --> I[Continue pipeline]
    H --> I

    subgraph Pi path
        P1[buildAnthropicRequest] --> P2{isClaudeSonnet5Model?}
        P2 -- Yes --> P3[body.thinking = adaptive plus summarized]
        P3 --> P4{options.reasoning set?}
        P4 -- Yes --> P5[body.output_config = effort]
        P4 -- No --> P6[No output_config]
        P2 -- No --> P7[Fable/Mythos or budget-based path]
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/pi/src/convert.ts`, line 1-15 ([link](https://github.com/cortexkit/anthropic-auth/blob/d4d90ebcadb93ce69d53b93601169e4a5c254995/packages/pi/src/convert.ts#L1-L15)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING` import was dropped and replaced with `CLAUDE_SONNET_5_ADAPTIVE_THINKING` for both model families. Since `CLAUDE_SONNET_5_ADAPTIVE_THINKING` is currently just an alias (`= CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING`), they are identical today — but the Fable/Mythos spread now silently depends on the Sonnet 5 constant. If a future commit adjusts `CLAUDE_SONNET_5_ADAPTIVE_THINKING` to carry a Sonnet-5-specific value, Fable/Mythos behavior in this file changes without any signal at the call site. Keeping the original import alive makes each family independently evolvable.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(pi): use each model family&#39;s ow..."](https://github.com/cortexkit/anthropic-auth/commit/893c7c9af2cb710d54a2dc42910e40a8ee767e2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40932709)</sub>

<!-- /greptile_comment -->