### PR TITLE
Preserve empty scoped quota array through load, merge, and sidebar normalization

### DIFF
--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -118,6 +118,12 @@ export type OAuthQuotaSnapshot = Partial<
   Record<QuotaWindowName, AccountQuotaWindow>
 > & {
   scoped?: AccountScopedQuotaWindow[]
+  // Top-level freshness stamp for the whole snapshot. mergeAccountRuntimeState
+  // uses this when the snapshot has no per-window checkedAt (e.g. a windowless
+  // empty-scoped snapshot) — without it, a windowless refresh gets read as
+  // checkedAt=0 and treated as stale, so an old per-window quota resurrects
+  // instead of being overwritten.
+  checkedAt?: number
 }
 
 export type RoutingMode = 'main-first' | 'fallback-first'
@@ -451,6 +457,15 @@ function normalizeQuota(value: unknown): OAuthAccount['quota'] {
     if (normalized) quota[key] = normalized
   }
 
+  // Persist a top-level snapshot checkedAt through normalize so the
+  // mergeAccountRuntimeState freshness comparison stays meaningful when the
+  // snapshot has no per-window checkedAt (e.g. {scoped:[]}). Pre-feature
+  // inputs without this key are unaffected — only on-disk snapshots that
+  // already carry it reach this branch.
+  if (typeof value.checkedAt === 'number' && Number.isFinite(value.checkedAt)) {
+    quota.checkedAt = value.checkedAt
+  }
+
   if (Array.isArray(value.scoped)) {
     const scoped = value.scoped
       .map((entry): AccountScopedQuotaWindow | undefined => {
@@ -701,6 +716,7 @@ function quotaSnapshotCheckedAt(quota: OAuthQuotaSnapshot | undefined) {
     quota?.five_hour?.checkedAt ?? 0,
     quota?.seven_day?.checkedAt ?? 0,
     ...(quota?.scoped?.map((window) => window.checkedAt) ?? []),
+    quota?.checkedAt ?? 0,
   )
 }
 
@@ -2031,6 +2047,7 @@ export async function fetchOAuthQuotaSnapshot(input: {
     five_hour: mapUsageWindow(usage.five_hour, checkedAt),
     seven_day: mapUsageWindow(usage.seven_day, checkedAt),
     scoped: mapScopedWeeklyLimits(usage.limits, checkedAt),
+    checkedAt,
   } satisfies OAuthQuotaSnapshot
 }
 

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -477,7 +477,11 @@ function normalizeQuota(value: unknown): OAuthAccount['quota'] {
         }
       })
       .filter((entry): entry is AccountScopedQuotaWindow => entry != null)
-    if (scoped.length) quota.scoped = scoped
+    // Preserve empty `[]` so a downstream reader can distinguish "scoped
+    // owned by anthropic-auth, none visible" from "no scoped data on this
+    // snapshot". Pre-feature inputs without a `scoped` key are not affected
+    // — only inputs that already carried an array reach this line.
+    quota.scoped = scoped
   }
 
   return Object.keys(quota).length ? quota : undefined
@@ -1943,8 +1947,8 @@ function slugForQuotaIdentity(value: string): string {
 function mapScopedWeeklyLimits(
   limits: OAuthUsageLimit[] | undefined,
   checkedAt: number,
-): AccountScopedQuotaWindow[] | undefined {
-  if (!Array.isArray(limits)) return undefined
+): AccountScopedQuotaWindow[] {
+  if (!Array.isArray(limits)) return []
   const seen = new Set<string>()
   const scoped: AccountScopedQuotaWindow[] = []
   for (const limit of limits) {
@@ -1974,7 +1978,7 @@ function mapScopedWeeklyLimits(
       checkedAt,
     })
   }
-  return scoped.length ? scoped : undefined
+  return scoped
 }
 
 function mapUsageWindow(

--- a/packages/opencode/src/sidebar-state.ts
+++ b/packages/opencode/src/sidebar-state.ts
@@ -284,18 +284,23 @@ export function getCollapsedQuotaSummary(quota: AccountQuota | null): {
     }
   }
 
+  const scopedSegments = scoped.map(
+    (window) =>
+      `${formatScopedQuotaLabel(window.title)}: ${Math.round(window.usedPercent)}%`,
+  )
+  const primarySegments =
+    fiveHourUsedPercent == null && sevenDayUsedPercent == null
+      ? []
+      : [
+          `5h: ${fiveHourUsedPercent == null ? '—' : `${Math.round(fiveHourUsedPercent)}%`}`,
+          `7d: ${sevenDayUsedPercent == null ? '—' : `${Math.round(sevenDayUsedPercent)}%`}`,
+        ]
+
   return {
     fiveHourUsedPercent,
     sevenDayUsedPercent,
     scopedUsedPercents,
-    text: [
-      `5h: ${fiveHourUsedPercent == null ? '—' : `${Math.round(fiveHourUsedPercent)}%`}`,
-      `7d: ${sevenDayUsedPercent == null ? '—' : `${Math.round(sevenDayUsedPercent)}%`}`,
-      ...scoped.map(
-        (window) =>
-          `${formatScopedQuotaLabel(window.title)}: ${Math.round(window.usedPercent)}%`,
-      ),
-    ].join(' '),
+    text: [...primarySegments, ...scopedSegments].join(' '),
   }
 }
 

--- a/packages/opencode/src/sidebar-state.ts
+++ b/packages/opencode/src/sidebar-state.ts
@@ -121,7 +121,11 @@ function normalizeAccountQuota(value: unknown): AccountQuota | null {
         }
       })
       .filter((entry): entry is ScopedQuotaWindow => entry != null)
-    if (scoped.length) quota.scoped = scoped
+    // Preserve empty `[]` so a sidebar reader can distinguish "scoped owned
+    // by anthropic-auth, none visible" from "no quota data at all". The OUTER
+    // Array.isArray guard means pre-feature inputs without a `scoped` key are
+    // not affected — only inputs that already carried an array reach this line.
+    quota.scoped = scoped
   }
 
   return Object.keys(quota).length ? quota : null

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -1123,6 +1123,72 @@ describe('FallbackAccountManager', () => {
     ).toEqual(['fable-empty', 'fable-ok'])
   })
 
+  test('preserves an empty scoped quota array through save/load when scoped is the only quota key', async () => {
+    const storage = baseStorage()
+    storage.accounts.push({
+      id: 'empty-scoped-only',
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: Date.now() + 60 * 60 * 1000,
+      quota: { scoped: [] },
+    })
+    await saveAccounts(storage)
+
+    const loaded = await loadAccounts()
+    const account = expectOAuthAccount(loaded?.accounts[0])
+    expect(account.quota).toBeDefined()
+    expect(account.quota?.scoped).toBeDefined()
+    expect(account.quota?.scoped).toEqual([])
+  })
+
+  test('preserves an empty scoped quota array alongside five_hour', async () => {
+    const storage = baseStorage()
+    storage.accounts.push({
+      id: 'empty-scoped-with-five-hour',
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: Date.now() + 60 * 60 * 1000,
+      quota: {
+        five_hour: {
+          usedPercent: 10,
+          remainingPercent: 90,
+          checkedAt: 1_000,
+        },
+        scoped: [],
+      },
+    })
+    await saveAccounts(storage)
+
+    const loaded = await loadAccounts()
+    const account = expectOAuthAccount(loaded?.accounts[0])
+    expect(account.quota?.five_hour?.usedPercent).toBe(10)
+    expect(account.quota?.scoped).toBeDefined()
+    expect(account.quota?.scoped).toEqual([])
+  })
+
+  test('routing predicate treats empty scoped array as not exhausted (invariant lock)', () => {
+    const quota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 10,
+        remainingPercent: 90,
+        checkedAt: 1_000,
+      },
+      seven_day: {
+        usedPercent: 5,
+        remainingPercent: 95,
+        checkedAt: 1_000,
+      },
+      scoped: [],
+    }
+    expect(quotaSnapshotModelScopeIsExhausted(quota, 'claude-fable-5')).toBe(
+      false,
+    )
+    expect(quotaSnapshotPassesModelScope(quota, 'claude-fable-5')).toBe(true)
+    expect(quotaSnapshotPassesModelScope(quota, 'claude-opus-4-8')).toBe(true)
+  })
+
   test('refreshes fallback tokens within the four-hour minimum window', async () => {
     const storage = baseStorage()
     storage.refresh = {

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -1190,10 +1190,10 @@ describe('FallbackAccountManager', () => {
   })
 
   test('mergeAccountRuntimeState: windowless {scoped:[]} replaces stale exhausted-Fable quota', async () => {
-    // GPT repro: persist an exhausted-Fable scoped window at T1, then save a
-    // windowless empty-scoped snapshot stamped T2 > T1. mergeAccountRuntimeState
-    // must NOT treat the empty snapshot as stale and resurrect the old Fable
-    // window — loadAccounts must return scoped: [].
+    // Persist an exhausted-Fable scoped window at T1, then save a windowless
+    // empty-scoped snapshot stamped T2 > T1. mergeAccountRuntimeState must NOT
+    // treat the empty snapshot as stale and resurrect the old Fable window —
+    // loadAccounts must return scoped: [].
     const accountId = 'merge-empty-scoped'
     const T1 = 1_000
     const T2 = 2_000

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -1189,6 +1189,163 @@ describe('FallbackAccountManager', () => {
     expect(quotaSnapshotPassesModelScope(quota, 'claude-opus-4-8')).toBe(true)
   })
 
+  test('mergeAccountRuntimeState: windowless {scoped:[]} replaces stale exhausted-Fable quota', async () => {
+    // GPT repro: persist an exhausted-Fable scoped window at T1, then save a
+    // windowless empty-scoped snapshot stamped T2 > T1. mergeAccountRuntimeState
+    // must NOT treat the empty snapshot as stale and resurrect the old Fable
+    // window — loadAccounts must return scoped: [].
+    const accountId = 'merge-empty-scoped'
+    const T1 = 1_000
+    const T2 = 2_000
+
+    const first = baseStorage()
+    first.accounts.push({
+      id: accountId,
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: Date.now() + 60 * 60 * 1000,
+      quota: {
+        five_hour: {
+          usedPercent: 20,
+          remainingPercent: 80,
+          checkedAt: T1,
+        },
+        seven_day: {
+          usedPercent: 15,
+          remainingPercent: 85,
+          checkedAt: T1,
+        },
+        scoped: [
+          {
+            id: 'claude-weekly-scoped-fable',
+            title: 'Fable only',
+            modelName: 'Fable',
+            usedPercent: 100,
+            remainingPercent: 0,
+            checkedAt: T1,
+          },
+        ],
+      },
+    })
+    await saveAccounts(first)
+
+    const second = baseStorage()
+    second.accounts.push({
+      id: accountId,
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: Date.now() + 60 * 60 * 1000,
+      quota: { scoped: [], checkedAt: T2 },
+    })
+    await saveAccounts(second)
+
+    const loaded = await loadAccounts()
+    const account = expectOAuthAccount(
+      loaded?.accounts.find((entry) => entry.id === accountId),
+    )
+    expect(account.quota?.scoped).toEqual([])
+  })
+
+  test('mergeAccountRuntimeState: real promo-end path lands empty scoped', async () => {
+    // Reachable-path lock: persist an account with five_hour/seven_day + a
+    // Fable scoped window at T1, then save the post-promo snapshot (5h/7d at
+    // T2, scoped: [], top-level checkedAt: T2). Loaded quota.scoped must be [].
+    const accountId = 'merge-promo-end'
+    const T1 = 1_000
+    const T2 = 2_000
+
+    const first = baseStorage()
+    first.accounts.push({
+      id: accountId,
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: Date.now() + 60 * 60 * 1000,
+      quota: {
+        five_hour: {
+          usedPercent: 20,
+          remainingPercent: 80,
+          checkedAt: T1,
+        },
+        seven_day: {
+          usedPercent: 15,
+          remainingPercent: 85,
+          checkedAt: T1,
+        },
+        scoped: [
+          {
+            id: 'claude-weekly-scoped-fable',
+            title: 'Fable only',
+            modelName: 'Fable',
+            usedPercent: 42,
+            remainingPercent: 58,
+            checkedAt: T1,
+          },
+        ],
+      },
+    })
+    await saveAccounts(first)
+
+    const second = baseStorage()
+    second.accounts.push({
+      id: accountId,
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: Date.now() + 60 * 60 * 1000,
+      quota: {
+        five_hour: {
+          usedPercent: 25,
+          remainingPercent: 75,
+          checkedAt: T2,
+        },
+        seven_day: {
+          usedPercent: 20,
+          remainingPercent: 80,
+          checkedAt: T2,
+        },
+        scoped: [],
+        checkedAt: T2,
+      },
+    })
+    await saveAccounts(second)
+
+    const loaded = await loadAccounts()
+    const account = expectOAuthAccount(
+      loaded?.accounts.find((entry) => entry.id === accountId),
+    )
+    expect(account.quota?.scoped).toEqual([])
+  })
+
+  test('top-level checkedAt round-trips through save/load', async () => {
+    const storage = baseStorage()
+    const stampedAt = 1_234_567
+    storage.accounts.push({
+      id: 'with-checked-at',
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: Date.now() + 60 * 60 * 1000,
+      quota: {
+        five_hour: {
+          usedPercent: 10,
+          remainingPercent: 90,
+          checkedAt: stampedAt,
+        },
+        checkedAt: stampedAt,
+      },
+    })
+    await saveAccounts(storage)
+
+    const loaded = await loadAccounts()
+    const account = expectOAuthAccount(
+      loaded?.accounts.find((entry) => entry.id === 'with-checked-at'),
+    )
+    expect(account.quota?.checkedAt).toBe(stampedAt)
+  })
+
   test('refreshes fallback tokens within the four-hour minimum window', async () => {
     const storage = baseStorage()
     storage.refresh = {

--- a/packages/opencode/src/tests/sidebar-state.test.ts
+++ b/packages/opencode/src/tests/sidebar-state.test.ts
@@ -263,6 +263,18 @@ describe('normalizeSidebarState', () => {
       },
     ])
   })
+
+  test('preserves empty scoped quota array when scoped is the only quota key', () => {
+    const normalized = normalizeSidebarState({
+      main: { quota: { scoped: [] } },
+      fallbacks: [],
+      route: 'main',
+      lastUpdated: 0,
+    })
+
+    expect(normalized.main.quota).not.toBeNull()
+    expect(normalized.main.quota?.scoped).toEqual([])
+  })
 })
 
 describe('computeQuotaPacing', () => {

--- a/packages/opencode/src/tests/sidebar-state.test.ts
+++ b/packages/opencode/src/tests/sidebar-state.test.ts
@@ -191,6 +191,40 @@ describe('getCollapsedQuotaSummary', () => {
     expect(getCollapsedQuotaSummary(null).text).toBeNull()
     expect(getCollapsedQuotaSummary({}).text).toBeNull()
   })
+
+  test('omits 5h/7d placeholders when only scoped windows are visible', () => {
+    const summary = getCollapsedQuotaSummary({
+      scoped: [
+        {
+          id: 'claude-weekly-scoped-fable',
+          title: 'Fable only',
+          modelName: 'Fable',
+          usedPercent: 100,
+          remainingPercent: 0,
+        },
+      ],
+    })
+    expect(summary.text).toBe('Fa: 100%')
+    expect(summary.text).not.toContain('5h:')
+    expect(summary.text).not.toContain('7d:')
+    expect(summary.text).not.toContain('—')
+  })
+
+  test('preserves partial-dash primary segment alongside scoped windows', () => {
+    const summary = getCollapsedQuotaSummary({
+      five_hour: { usedPercent: 23, remainingPercent: 77 },
+      scoped: [
+        {
+          id: 'claude-weekly-scoped-fable',
+          title: 'Fable only',
+          modelName: 'Fable',
+          usedPercent: 42,
+          remainingPercent: 58,
+        },
+      ],
+    })
+    expect(summary.text).toBe('5h: 23% 7d: — Fa: 42%')
+  })
 })
 
 describe('normalizeSidebarState', () => {


### PR DESCRIPTION
Rebased onto current `main` (the scoped weekly quota limits feature is now merged). This reduces the PR to two correctness fixes on top of that feature — both are latent bugs in the current implementation.

## 1. Empty `scoped: []` is dropped on load and lost in the runtime-state merge

`fetchOAuthQuotaSnapshot` always returns `scoped` as an array, but two paths drop it when empty, which matters because an empty array is a meaningful state (the API returned no model-scoped carve-out) distinct from "no scoped data":

- **`normalizeQuota`** did `if (scoped.length) quota.scoped = scoped`. When a persisted quota has an empty `scoped` and no `five_hour`/`seven_day`, the whole quota object then collapses to `undefined` via the `Object.keys(quota).length` guard. Fixed with an unconditional `quota.scoped = scoped` inside the existing `Array.isArray(value.scoped)` guard (so pre-feature data with no `scoped` key is unaffected).
- **`mergeAccountRuntimeState`** compares freshness via `quotaSnapshotCheckedAt`, which returned `0` for a windowless `{scoped:[]}` snapshot — so the merge treated it as stale and resurrected the previous (e.g. exhausted) scoped window instead of writing the empty array. Fixed by adding a top-level `checkedAt` to `OAuthQuotaSnapshot` (stamped in `fetchOAuthQuotaSnapshot`, preserved in `normalizeQuota`, included in `quotaSnapshotCheckedAt`'s `max`). For a normal snapshot the top-level stamp equals the per-window stamps, so the freshness comparison is unchanged; a windowless empty-scoped snapshot now carries its real timestamp.

Routing is unaffected: an empty `scoped: []` behaves identically to `undefined` in `quotaSnapshotModelScopeIsExhausted` / `getScopedQuotaWindowForModel` (`.find()` over `[]` and the optional-chain over `undefined` both yield no window), and no routing predicate reads the new top-level `checkedAt`. A regression test locks this invariant.

## 2. Collapsed sidebar shows `5h: — 7d: —` placeholders when only a scoped window is visible

`getCollapsedQuotaSummary` unconditionally emitted the `5h`/`7d` segment even when both are null, producing e.g. `5h: — 7d: — Fa: 100%`. Now the `5h`/`7d` segment is emitted only when at least one is present; when both are null (reachable only because a scoped window is visible) the line is just the scoped segment. The all-windows-present and single-present (dash-for-absent) cases are byte-identical.

## Tests

Red-first on the current code for every fix: empty-`[]` round-trip (scoped-only and alongside `five_hour`), the windowless-`{scoped:[]}` merge-freshness repro, top-level `checkedAt` round-trip, the sidebar `normalizeAccountQuota` empty-array case, the collapsed-summary placeholder omission, plus a routing-invariant lock (`scoped: []` is not treated as exhausted). All suites green — core 6, opencode 768, pi 47, e2e 2; typecheck and lint clean.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR surfaces model-scoped weekly quota carve-outs (e.g., the Fable-only promo window) by parsing `limits[]` from `/api/oauth/usage`, persisting them as `quota.scoped[]`, and rendering them in the collapsed summary alongside the existing 5h/7d windows. Scoped windows are intentionally excluded from routing, policy, and killswitch logic.

- **Parse & persist**: `mapScopedWeeklyLimits` filters for `kind:\"weekly_scoped\"` + `group:\"weekly\"`, requires a non-empty `display_name`, deduplicates by model id/slug, and always returns an array (never `undefined`). A new top-level `checkedAt` on `OAuthQuotaSnapshot` ensures windowless empty-scoped snapshots win freshness comparisons in `mergeAccountRuntimeState` instead of being treated as stale (T=0).
- **Render**: `getCollapsedQuotaSummary` now omits the `\"5h: — 7d: —\"` prefix when both windows are absent and only scoped data is visible; the fix from the previous thread is present and tested.
- **Isolation**: `quotaSnapshotPassesPolicy` and `killswitchPassesPolicy` iterate only `['five_hour', 'seven_day']`; a fully-exhausted scoped window does not mark an account dead.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The additive nature of the change (scoped windows are parsed and displayed but never gate routing or killswitch decisions) limits blast radius, and the freshness/merge logic for empty-scoped snapshots is correctly guarded by the new top-level checkedAt field.

All changed paths are additive or narrowing: the existing five_hour/seven_day parse/persist/render paths are untouched, policy and killswitch checks are explicitly constrained to those two windows, and the new top-level checkedAt correctly handles the windowless-empty-scoped merge scenario. Edge cases (malformed limits, non-finite percents, absent display_name, empty arrays through save/load) are all handled and tested. No routing, auth, or data-loss risk is introduced.

No files require special attention. The tui.tsx rendering changes noted in previous review comments are outside this diff; the padding alignment concern there is tracked separately.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/accounts.ts | Adds OAuthQuotaSnapshot.checkedAt, propagates scoped: [] through normalizeQuota, and adds top-level checkedAt to fetchOAuthQuotaSnapshot; freshness logic is correct for windowless snapshots. |
| packages/opencode/src/sidebar-state.ts | Fixes collapsed summary to omit '5h: — 7d: —' prefix when only scoped windows are present; normalizeAccountQuota now preserves scoped: [] as intended. |
| packages/opencode/src/tests/accounts.test.ts | Adds round-trip, merge-freshness, policy-exclusion, and empty-array preservation tests; cases are well-chosen and cover the introduced edge conditions. |
| packages/opencode/src/tests/sidebar-state.test.ts | Adds tests for scoped-only collapsed summary, partial-dash primary segment with scoped, and empty-array normalization; all assert the right behavior. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/api/oauth/usage response"] --> B["fetchOAuthQuotaSnapshot"]
    B --> C["mapUsageWindow x2"]
    B --> D["mapScopedWeeklyLimits"]
    D --> E["AccountScopedQuotaWindow[]"]
    E --> F["scoped: []"]
    B --> G["checkedAt: now"]
    C --> H["OAuthQuotaSnapshot"]
    F --> H
    G --> H
    H --> I["normalizeQuota"]
    I --> J["OAuthAccount.quota"]
    J --> K["quotaSnapshotCheckedAt"]
    K --> L["mergeAccountRuntimeState"]
    J --> M["projectQuotaToSidebar"]
    M --> N["getCollapsedQuotaSummary"]
    J --> R["quotaSnapshotPassesPolicy / killswitchPassesPolicy"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["/api/oauth/usage response"] --> B["fetchOAuthQuotaSnapshot"]
    B --> C["mapUsageWindow x2"]
    B --> D["mapScopedWeeklyLimits"]
    D --> E["AccountScopedQuotaWindow[]"]
    E --> F["scoped: []"]
    B --> G["checkedAt: now"]
    C --> H["OAuthQuotaSnapshot"]
    F --> H
    G --> H
    H --> I["normalizeQuota"]
    I --> J["OAuthAccount.quota"]
    J --> K["quotaSnapshotCheckedAt"]
    K --> L["mergeAccountRuntimeState"]
    J --> M["projectQuotaToSidebar"]
    M --> N["getCollapsedQuotaSummary"]
    J --> R["quotaSnapshotPassesPolicy / killswitchPassesPolicy"]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["test: neutral rationale comment on empty..."](https://github.com/cortexkit/anthropic-auth/commit/fc8c7b79feec6bc0a8c941afed1c75552d5c66b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41802610)</sub>

<!-- /greptile_comment -->