### PR TITLE
Add per-model scoped killswitch threshold

### DIFF
--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -123,7 +123,7 @@ export type OAuthQuotaSnapshot = Partial<
 export type RoutingMode = 'main-first' | 'fallback-first'
 
 export type KillswitchThresholds = Partial<
-  Record<QuotaWindowName | '5h' | '1w', number>
+  Record<QuotaWindowName | '5h' | '1w' | 'scoped', number>
 >
 
 export type KillswitchConfig = {
@@ -1656,16 +1656,21 @@ export function quotaSnapshotPassesPolicy(
 // thresholds, even if the API would still accept them.
 // ---------------------------------------------------------------------------
 
-export const DEFAULT_KILLSWITCH_THRESHOLDS: Record<QuotaWindowName, number> = {
+export const DEFAULT_KILLSWITCH_THRESHOLDS: Record<
+  QuotaWindowName | 'scoped',
+  number
+> = {
   five_hour: 5,
   seven_day: 10,
+  scoped: 0,
 }
 
-function normalizeKillswitchThresholds(
+export function normalizeKillswitchThresholds(
   thresholds: KillswitchThresholds | undefined,
-): Record<QuotaWindowName, number> {
+): Record<QuotaWindowName | 'scoped', number> {
   const fiveHour = thresholds?.five_hour ?? thresholds?.['5h']
   const sevenDay = thresholds?.seven_day ?? thresholds?.['1w']
+  const scoped = thresholds?.scoped
   return {
     five_hour:
       typeof fiveHour === 'number' && Number.isFinite(fiveHour)
@@ -1675,6 +1680,10 @@ function normalizeKillswitchThresholds(
       typeof sevenDay === 'number' && Number.isFinite(sevenDay)
         ? sevenDay
         : DEFAULT_KILLSWITCH_THRESHOLDS.seven_day,
+    scoped:
+      typeof scoped === 'number' && Number.isFinite(scoped)
+        ? scoped
+        : DEFAULT_KILLSWITCH_THRESHOLDS.scoped,
   }
 }
 
@@ -1682,10 +1691,10 @@ export function isKillswitchEnabled(storage: AccountStorage | null) {
   return storage?.killswitch?.enabled === true
 }
 
-function getKillswitchThresholdsForAccount(
+export function getKillswitchThresholdsForAccount(
   storage: AccountStorage | null,
   accountId?: string,
-): Record<QuotaWindowName, number> {
+): Record<QuotaWindowName | 'scoped', number> {
   if (!storage?.killswitch) return DEFAULT_KILLSWITCH_THRESHOLDS
   if (accountId && storage.killswitch.accounts?.[accountId]) {
     return normalizeKillswitchThresholds(storage.killswitch.accounts[accountId])
@@ -1696,11 +1705,16 @@ function getKillswitchThresholdsForAccount(
 /**
  * Returns true if the account's quota is above its killswitch threshold.
  * When killswitch is disabled, always returns true.
+ *
+ * When `modelId` is provided, the per-account `scoped` threshold is also
+ * evaluated against the quota window matching that model — additive to the
+ * 5h/7d check. A model with no matching scoped window is unaffected.
  */
 export function killswitchPassesPolicy(
   quota: OAuthQuotaSnapshot | undefined,
   storage: AccountStorage | null,
   accountId?: string,
+  modelId?: string,
 ) {
   if (!isKillswitchEnabled(storage)) return true
   const thresholds = getKillswitchThresholdsForAccount(storage, accountId)
@@ -1721,23 +1735,51 @@ export function killswitchPassesPolicy(
     if (window.remainingPercent < thresholds[key]) return false
   }
   if (sawUnknownWindow) return !failClosedOnUnknownQuota(storage)
+  if (modelId) {
+    // Scoped check is additive to the 5h/7d evaluation above. A missing
+    // scoped window (no carve-out for this model) is not "unknown quota" —
+    // only a PRESENT window at/below threshold blocks. The comparison is
+    // inclusive (`<=`) so the default 0 fires at exhaustion.
+    const scopedWindow = getScopedQuotaWindowForModel(quota, modelId)
+    if (
+      scopedWindow &&
+      Number.isFinite(scopedWindow.remainingPercent) &&
+      scopedWindow.remainingPercent <= thresholds.scoped
+    ) {
+      return false
+    }
+  }
   return true
 }
 
 /**
  * Find the earliest reset time across all accounts' quota windows.
  * Returns seconds from `now` until that reset, or 300 as a fallback.
+ *
+ * When `scopedModelId` is provided, the matched scoped window's `resetsAt`
+ * is also considered so the retry hint reflects the weekly reset for a
+ * scoped-driven block.
  */
 export function killswitchRetryAfterSeconds(
   mainQuota: OAuthQuotaSnapshot | undefined,
   fallbackAccounts: Array<{ quota?: OAuthQuotaSnapshot }>,
   now: number,
+  scopedModelId?: string,
 ): number {
   const resetTimes: number[] = []
   const allQuotas = [mainQuota, ...fallbackAccounts.map((a) => a.quota)]
   for (const quota of allQuotas) {
     for (const key of ['five_hour', 'seven_day'] as const) {
       const resetStr = quota?.[key]?.resetsAt
+      if (!resetStr) continue
+      const resetTime = Date.parse(resetStr)
+      if (Number.isFinite(resetTime) && resetTime > now) {
+        resetTimes.push(resetTime)
+      }
+    }
+    if (scopedModelId) {
+      const scopedWindow = getScopedQuotaWindowForModel(quota, scopedModelId)
+      const resetStr = scopedWindow?.resetsAt
       if (!resetStr) continue
       const resetTime = Date.parse(resetStr)
       if (Number.isFinite(resetTime) && resetTime > now) {

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -1734,12 +1734,15 @@ export function killswitchPassesPolicy(
     }
     if (window.remainingPercent < thresholds[key]) return false
   }
-  if (sawUnknownWindow) return !failClosedOnUnknownQuota(storage)
+  // Scoped check is additive to the 5h/7d evaluation above and is an
+  // INDEPENDENT block reason — it must run before the unknown-window
+  // fail-closed decision, so an exhausted scoped window blocks even when
+  // 5h/7d is missing/non-finite (the latter only changes the fall-through
+  // for accounts that did not already block on scoped). A missing scoped
+  // window (no carve-out for this model) is not "unknown quota" — only a
+  // PRESENT window at/below threshold blocks. The comparison is inclusive
+  // (`<=`) so the default 0 fires at exhaustion.
   if (modelId) {
-    // Scoped check is additive to the 5h/7d evaluation above. A missing
-    // scoped window (no carve-out for this model) is not "unknown quota" —
-    // only a PRESENT window at/below threshold blocks. The comparison is
-    // inclusive (`<=`) so the default 0 fires at exhaustion.
     const scopedWindow = getScopedQuotaWindowForModel(quota, modelId)
     if (
       scopedWindow &&
@@ -1749,6 +1752,7 @@ export function killswitchPassesPolicy(
       return false
     }
   }
+  if (sawUnknownWindow) return !failClosedOnUnknownQuota(storage)
   return true
 }
 

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -1760,9 +1760,11 @@ export function killswitchPassesPolicy(
  * Find the earliest reset time across all accounts' quota windows.
  * Returns seconds from `now` until that reset, or 300 as a fallback.
  *
- * When `scopedModelId` is provided, the matched scoped window's `resetsAt`
- * is also considered so the retry hint reflects the weekly reset for a
- * scoped-driven block.
+ * When `scopedModelId` is provided, ONLY the matched scoped window's
+ * `resetsAt` is considered — the 5h/7d resets are intentionally ignored
+ * so the retry hint reflects the weekly reset, not the sooner 5h reset
+ * (which would cause a retry-storm against a block that won't clear for
+ * days). With `scopedModelId` undefined, the 5h/7d behavior is unchanged.
  */
 export function killswitchRetryAfterSeconds(
   mainQuota: OAuthQuotaSnapshot | undefined,
@@ -1773,14 +1775,6 @@ export function killswitchRetryAfterSeconds(
   const resetTimes: number[] = []
   const allQuotas = [mainQuota, ...fallbackAccounts.map((a) => a.quota)]
   for (const quota of allQuotas) {
-    for (const key of ['five_hour', 'seven_day'] as const) {
-      const resetStr = quota?.[key]?.resetsAt
-      if (!resetStr) continue
-      const resetTime = Date.parse(resetStr)
-      if (Number.isFinite(resetTime) && resetTime > now) {
-        resetTimes.push(resetTime)
-      }
-    }
     if (scopedModelId) {
       const scopedWindow = getScopedQuotaWindowForModel(quota, scopedModelId)
       const resetStr = scopedWindow?.resetsAt
@@ -1788,6 +1782,15 @@ export function killswitchRetryAfterSeconds(
       const resetTime = Date.parse(resetStr)
       if (Number.isFinite(resetTime) && resetTime > now) {
         resetTimes.push(resetTime)
+      }
+    } else {
+      for (const key of ['five_hour', 'seven_day'] as const) {
+        const resetStr = quota?.[key]?.resetsAt
+        if (!resetStr) continue
+        const resetTime = Date.parse(resetStr)
+        if (Number.isFinite(resetTime) && resetTime > now) {
+          resetTimes.push(resetTime)
+        }
       }
     }
   }

--- a/packages/core/src/killswitch.ts
+++ b/packages/core/src/killswitch.ts
@@ -1,5 +1,8 @@
 import type { KillswitchConfig, KillswitchThresholds } from './accounts.ts'
-import { DEFAULT_KILLSWITCH_THRESHOLDS as DEFAULT_THRESHOLDS } from './accounts.ts'
+import {
+  DEFAULT_KILLSWITCH_THRESHOLDS as DEFAULT_THRESHOLDS,
+  normalizeKillswitchThresholds,
+} from './accounts.ts'
 
 export const KILLSWITCH_COMMAND_NAME = 'claude-killswitch'
 
@@ -7,7 +10,15 @@ export type KillswitchCommandAction =
   | { type: 'status' }
   | { type: 'on' }
   | { type: 'off' }
-  | { type: 'set'; entries: Array<{ account: string; fh: number; sd: number }> }
+  | {
+      type: 'set'
+      entries: Array<{
+        account: string
+        fh: number
+        sd: number
+        scoped?: number
+      }>
+    }
   | { type: 'usage' }
 
 export function parseKillswitchCommandAction(
@@ -19,17 +30,33 @@ export function parseKillswitchCommandAction(
   if (parts.length === 1 && parts[0] === 'off') return { type: 'off' }
 
   if (parts[0] === 'set') {
-    const entries: Array<{ account: string; fh: number; sd: number }> = []
+    const entries: Array<{
+      account: string
+      fh: number
+      sd: number
+      scoped?: number
+    }> = []
     for (let i = 1; i < parts.length; i++) {
-      const match = parts[i]?.match(/^([^:]+):(\d+),(\d+)$/)
+      const match = parts[i]?.match(/^([^:]+):(\d+),(\d+)(?:,(\d+))?$/)
       if (!match) return { type: 'usage' }
-      const [, account, fhStr, sdStr] = match as RegExpMatchArray &
-        [string, string, string, string]
-      entries.push({
+      const [, account, fhStr, sdStr, scopedStr] = match as RegExpMatchArray &
+        [string, string, string, string, string | undefined]
+      const scoped =
+        typeof scopedStr === 'string' && scopedStr.length > 0
+          ? Number.parseInt(scopedStr, 10)
+          : undefined
+      const entry: {
+        account: string
+        fh: number
+        sd: number
+        scoped?: number
+      } = {
         account,
         fh: Number.parseInt(fhStr, 10),
         sd: Number.parseInt(sdStr, 10),
-      })
+      }
+      if (scoped !== undefined) entry.scoped = scoped
+      entries.push(entry)
     }
     if (entries.length === 0) return { type: 'usage' }
     return { type: 'set', entries }
@@ -51,19 +78,21 @@ function buildStatusTable(
 
   if (enabled) {
     lines.push('')
-    lines.push('| Account | 5h threshold | 1w threshold |')
-    lines.push('| ------- | ------------ | ------------ |')
+    lines.push('| Account | 5h threshold | 1w threshold | Scoped |')
+    lines.push('| ------- | ------------ | ------------ | ------ |')
 
-    const mainT = config.main ?? {}
-    const fh = mainT.five_hour ?? mainT['5h'] ?? DEFAULT_THRESHOLDS.five_hour
-    const sd = mainT.seven_day ?? mainT['1w'] ?? DEFAULT_THRESHOLDS.seven_day
-    lines.push(`| main | \u2265 ${fh}% | \u2265 ${sd}% |`)
+    const mainT = normalizeKillswitchThresholds(config.main)
+    lines.push(
+      `| main | \u2265 ${mainT.five_hour}% | \u2265 ${mainT.seven_day}% | \u2264 ${mainT.scoped}% |`,
+    )
 
     for (const id of accountIds) {
-      const t = config.accounts?.[id] ?? config.main ?? {}
-      const afh = t.five_hour ?? t['5h'] ?? DEFAULT_THRESHOLDS.five_hour
-      const asd = t.seven_day ?? t['1w'] ?? DEFAULT_THRESHOLDS.seven_day
-      lines.push(`| ${id} | \u2265 ${afh}% | \u2265 ${asd}% |`)
+      const t = normalizeKillswitchThresholds(
+        config.accounts?.[id] ?? config.main,
+      )
+      lines.push(
+        `| ${id} | \u2265 ${t.five_hour}% | \u2265 ${t.seven_day}% | \u2264 ${t.scoped}% |`,
+      )
     }
   }
 
@@ -78,6 +107,7 @@ const USAGE_TEXT = [
   `/${KILLSWITCH_COMMAND_NAME} on           — enable with current or default thresholds`,
   `/${KILLSWITCH_COMMAND_NAME} off          — disable`,
   `/${KILLSWITCH_COMMAND_NAME} set all:5,10 — set all accounts to 5h≥5%, 1w≥10%`,
+  `/${KILLSWITCH_COMMAND_NAME} set main:3,8,0 — set 5h≥3%, 1w≥8%, scoped≤0%`,
   `/${KILLSWITCH_COMMAND_NAME} set main:3,8 work-alt:5,10 — per-account`,
   '```',
 ].join('\n')
@@ -130,6 +160,7 @@ export function executeKillswitchCommand(input: {
         five_hour: entry.fh,
         seven_day: entry.sd,
       }
+      if (entry.scoped !== undefined) thresholds.scoped = entry.scoped
       if (entry.account === 'main') {
         updated.main = thresholds
       } else if (entry.account === 'all') {

--- a/packages/core/src/tests/killswitch.test.ts
+++ b/packages/core/src/tests/killswitch.test.ts
@@ -571,4 +571,104 @@ describe('killswitchRetryAfterSeconds — scoped resetsAt', () => {
     expect(seconds).toBeGreaterThanOrEqual(359)
     expect(seconds).toBeLessThanOrEqual(361)
   })
+
+  // Regression for FINDING 1: when a scopedModelId is provided, the 5h/7d
+  // resetsAt must NOT also be collected. Otherwise the 5h reset (hours away)
+  // always beats the weekly scoped reset (days away) in Math.min, and the
+  // client retries the request hours before the actual weekly block clears.
+  test('scoped branch REPLACES 5h/7d, not adds to it (FINDING 1)', () => {
+    const now = Date.now()
+    const twoHours = 2 * 60 * 60 * 1000
+    const twoDays = 2 * 24 * 60 * 60 * 1000
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 95,
+        remainingPercent: 5,
+        resetsAt: new Date(now + twoHours).toISOString(),
+        checkedAt: now,
+      },
+      seven_day: {
+        usedPercent: 95,
+        remainingPercent: 5,
+        resetsAt: new Date(now + twoHours).toISOString(),
+        checkedAt: now,
+      },
+      scoped: [
+        scopeWindow(
+          0,
+          { name: 'Claude Fable 5', id: 'claude-fable-5' },
+          { resetsAt: new Date(now + twoDays).toISOString() },
+        ),
+      ],
+    }
+    const seconds = killswitchRetryAfterSeconds(
+      mainQuota,
+      [],
+      now,
+      'claude-fable-5',
+    )
+    // Expected: ~2 days + 60s buffer. The 5h/7d reset (~2h) must be ignored
+    // because the block is scoped-driven.
+    const expected = Math.ceil(twoDays / 1000) + 60
+    expect(seconds).toBeGreaterThanOrEqual(expected - 2)
+    expect(seconds).toBeLessThanOrEqual(expected + 2)
+  })
+
+  test('scoped branch: matched scoped window in FALLBACK is the only source (FINDING 1 fallback case)', () => {
+    const now = Date.now()
+    const twoHours = 2 * 60 * 60 * 1000
+    const twoDays = 2 * 24 * 60 * 60 * 1000
+    // main has NO scoped window, but 5h resetsAt in 2h. A fallback carries
+    // a Fable window that resets in 2 days. The 5h reset on the fallback
+    // must be ignored too — the branch is scoped REPLACEMENT, per-quota.
+    const mainQuota: OAuthQuotaSnapshot = {}
+    const fallbacks = [
+      {
+        quota: {
+          five_hour: {
+            usedPercent: 95,
+            remainingPercent: 5,
+            resetsAt: new Date(now + twoHours).toISOString(),
+            checkedAt: now,
+          },
+          scoped: [
+            scopeWindow(
+              0,
+              { name: 'Claude Fable 5', id: 'claude-fable-5' },
+              { resetsAt: new Date(now + twoDays).toISOString() },
+            ),
+          ],
+        },
+      },
+    ]
+    const seconds = killswitchRetryAfterSeconds(
+      mainQuota,
+      fallbacks,
+      now,
+      'claude-fable-5',
+    )
+    const expected = Math.ceil(twoDays / 1000) + 60
+    expect(seconds).toBeGreaterThanOrEqual(expected - 2)
+    expect(seconds).toBeLessThanOrEqual(expected + 2)
+  })
+
+  test('scoped branch: no matched scoped window in any quota → 300 fallback (FINDING 1 empty)', () => {
+    const now = Date.now()
+    // main has a 5h reset but NO scoped window for the requested model.
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 95,
+        remainingPercent: 5,
+        resetsAt: new Date(now + 7_200_000).toISOString(),
+        checkedAt: now,
+      },
+    }
+    const seconds = killswitchRetryAfterSeconds(
+      mainQuota,
+      [],
+      now,
+      'claude-fable-5',
+    )
+    expect(seconds).toBe(300)
+  })
 })

--- a/packages/core/src/tests/killswitch.test.ts
+++ b/packages/core/src/tests/killswitch.test.ts
@@ -1,0 +1,493 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  type AccountScopedQuotaWindow,
+  type AccountStorage,
+  DEFAULT_KILLSWITCH_THRESHOLDS,
+  getKillswitchThresholdsForAccount,
+  killswitchPassesPolicy,
+  killswitchRetryAfterSeconds,
+  normalizeKillswitchThresholds,
+  type OAuthQuotaSnapshot,
+} from '../accounts.ts'
+import {
+  executeKillswitchCommand,
+  parseKillswitchCommandAction,
+} from '../killswitch.ts'
+
+const baseStorage = (): AccountStorage => ({
+  version: 1,
+  main: { type: 'opencode', provider: 'anthropic' },
+  fallbackOn: [401, 403, 429],
+  quota: {
+    enabled: true,
+    checkIntervalMinutes: 5,
+    minimumRemaining: { five_hour: 10, seven_day: 20 },
+    failClosedOnUnknownQuota: true,
+  },
+  accounts: [],
+})
+
+const scopeWindow = (
+  remainingPercent: number,
+  model: { name: string; id?: string },
+  overrides: Partial<AccountScopedQuotaWindow> = {},
+): AccountScopedQuotaWindow => ({
+  usedPercent: 100 - remainingPercent,
+  remainingPercent,
+  checkedAt: Date.now(),
+  id: 'claude-weekly-scoped-fable',
+  title: `${model.name} only`,
+  modelName: model.name,
+  ...(model.id && { modelId: model.id }),
+  ...overrides,
+})
+
+const healthy5h7d = (): Pick<
+  OAuthQuotaSnapshot,
+  'five_hour' | 'seven_day'
+> => ({
+  five_hour: {
+    usedPercent: 50,
+    remainingPercent: 50,
+    checkedAt: Date.now(),
+  },
+  seven_day: {
+    usedPercent: 20,
+    remainingPercent: 80,
+    checkedAt: Date.now(),
+  },
+})
+
+// ---------------------------------------------------------------------------
+// DEFAULT_KILLSWITCH_THRESHOLDS / normalizeKillswitchThresholds
+// ---------------------------------------------------------------------------
+describe('scoped killswitch — defaults + normalization', () => {
+  test('DEFAULT_KILLSWITCH_THRESHOLDS.scoped is 0', () => {
+    expect(DEFAULT_KILLSWITCH_THRESHOLDS.scoped).toBe(0)
+  })
+
+  test('normalizeKillswitchThresholds resolves scoped to default 0 when absent', () => {
+    const t = normalizeKillswitchThresholds({ five_hour: 5, seven_day: 10 })
+    expect(t.scoped).toBe(0)
+  })
+
+  test('normalizeKillswitchThresholds preserves an explicit scoped value', () => {
+    const t = normalizeKillswitchThresholds({
+      five_hour: 5,
+      seven_day: 10,
+      scoped: 20,
+    })
+    expect(t.scoped).toBe(20)
+  })
+
+  test('normalizeKillswitchThresholds falls back to default for non-finite scoped', () => {
+    const t = normalizeKillswitchThresholds({
+      five_hour: 5,
+      seven_day: 10,
+      scoped: Number.NaN,
+    })
+    expect(t.scoped).toBe(0)
+
+    const inf = normalizeKillswitchThresholds({
+      five_hour: 5,
+      seven_day: 10,
+      scoped: Number.POSITIVE_INFINITY,
+    })
+    expect(inf.scoped).toBe(0)
+  })
+
+  test('getKillswitchThresholdsForAccount carries scoped', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 20 },
+    }
+    expect(getKillswitchThresholdsForAccount(storage).scoped).toBe(20)
+    expect(getKillswitchThresholdsForAccount(storage, 'work-alt').scoped).toBe(
+      20,
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// killswitchPassesPolicy — model-scoped additive behavior
+// ---------------------------------------------------------------------------
+describe('killswitchPassesPolicy — scoped model dimension', () => {
+  test('modelId absent: byte-identical to pre-change (no scoped evaluation)', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 100 },
+    }
+    const quota: OAuthQuotaSnapshot = {
+      ...healthy5h7d(),
+      // a fully exhausted scoped window is present, but no modelId is provided
+      // → the killswitch must NOT touch it (regression lock for the additive
+      //   semantics).
+      scoped: [
+        scopeWindow(0, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    }
+    expect(killswitchPassesPolicy(quota, storage)).toBe(true)
+  })
+
+  test('matching model + scoped window at/below threshold → blocks', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    const quota: OAuthQuotaSnapshot = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(0, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    }
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-fable-5'),
+    ).toBe(false)
+  })
+
+  test('NON-matching model + scoped-exhausted window → account stays live (the model-scoped proof)', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    const quota: OAuthQuotaSnapshot = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(0, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    }
+    // Sonnet — not in the Fable scope — must pass even though Fable is exhausted.
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-sonnet-5'),
+    ).toBe(true)
+  })
+
+  test('matching model + scoped window ABOVE threshold → passes', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    const quota: OAuthQuotaSnapshot = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(50, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    }
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-fable-5'),
+    ).toBe(true)
+  })
+
+  test('5h/7d below threshold blocks regardless of scoped state', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 10, seven_day: 10, scoped: 0 },
+    }
+    const quota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 95,
+        remainingPercent: 5,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 20,
+        remainingPercent: 80,
+        checkedAt: Date.now(),
+      },
+      // Fable has plenty of headroom — must still block via 5h.
+      scoped: [
+        scopeWindow(80, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    }
+    expect(killswitchPassesPolicy(quota, storage)).toBe(false)
+  })
+
+  test('default scoped 0: blocks at remainingPercent <= 0 only (inclusive)', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10 },
+    }
+    const remainingOne = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(1, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    } as OAuthQuotaSnapshot
+    // 1% remaining — above the default 0 → pass
+    expect(
+      killswitchPassesPolicy(
+        remainingOne,
+        storage,
+        undefined,
+        'claude-fable-5',
+      ),
+    ).toBe(true)
+
+    const exactlyZero = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(0, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    } as OAuthQuotaSnapshot
+    // 0% remaining — must block (inclusive boundary)
+    expect(
+      killswitchPassesPolicy(exactlyZero, storage, undefined, 'claude-fable-5'),
+    ).toBe(false)
+  })
+
+  test('raised scoped threshold (20) blocks at <= 20', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 20 },
+    }
+    const quota21 = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(21, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    } as OAuthQuotaSnapshot
+    expect(
+      killswitchPassesPolicy(quota21, storage, undefined, 'claude-fable-5'),
+    ).toBe(true)
+
+    const quota20 = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(20, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    } as OAuthQuotaSnapshot
+    expect(
+      killswitchPassesPolicy(quota20, storage, undefined, 'claude-fable-5'),
+    ).toBe(false)
+
+    const quota5 = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(5, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    } as OAuthQuotaSnapshot
+    expect(
+      killswitchPassesPolicy(quota5, storage, undefined, 'claude-fable-5'),
+    ).toBe(false)
+  })
+
+  test('non-finite scoped remainingPercent → not blocked', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    const quota = {
+      ...healthy5h7d(),
+      scoped: [
+        {
+          usedPercent: 0,
+          remainingPercent: Number.NaN,
+          checkedAt: Date.now(),
+          id: 'claude-weekly-scoped-fable',
+          title: 'Claude Fable 5 only',
+          modelName: 'Claude Fable 5',
+          modelId: 'claude-fable-5',
+        },
+      ],
+    } as OAuthQuotaSnapshot
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-fable-5'),
+    ).toBe(true)
+  })
+
+  test('generic: a non-Fable display_name scoped window behaves identically (no hardcoded string)', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    // Pretend the future carve-out has a different display name; the keying
+    // in getScopedQuotaWindowForModel is via the `fable`/`mythos` substring
+    // (or future model keys), so we use a key that the matcher recognises.
+    const quota: OAuthQuotaSnapshot = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(0, { name: 'Claude Mythos 5', id: 'claude-mythos-5' }),
+      ],
+    }
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-mythos-5'),
+    ).toBe(false)
+    // Sonnet still untouched
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-sonnet-5'),
+    ).toBe(true)
+  })
+
+  test('a model with no matching scoped window is unaffected by the scoped check', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    const quota = healthy5h7d() // no `scoped` array
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-fable-5'),
+    ).toBe(true)
+  })
+
+  test('killswitch disabled → scoped check never runs', () => {
+    const storage = baseStorage()
+    // killswitch NOT enabled; even with a present scoped window and a model
+    // that would otherwise match, the function must short-circuit to true.
+    const quota: OAuthQuotaSnapshot = {
+      ...healthy5h7d(),
+      scoped: [
+        scopeWindow(0, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    }
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-fable-5'),
+    ).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseKillswitchCommandAction / executeKillswitchCommand — scoped column
+// ---------------------------------------------------------------------------
+describe('parseKillswitchCommandAction — scoped three-number form', () => {
+  test('two-number form still parses (backward compatibility)', () => {
+    expect(parseKillswitchCommandAction('set main:3,8')).toEqual({
+      type: 'set',
+      entries: [{ account: 'main', fh: 3, sd: 8, scoped: undefined }],
+    })
+  })
+
+  test('three-number form parses fh/sd/scoped', () => {
+    expect(parseKillswitchCommandAction('set main:80,10,0')).toEqual({
+      type: 'set',
+      entries: [{ account: 'main', fh: 80, sd: 10, scoped: 0 }],
+    })
+  })
+
+  test('three-number form with non-zero scoped threshold', () => {
+    expect(parseKillswitchCommandAction('set all:80,10,20')).toEqual({
+      type: 'set',
+      entries: [{ account: 'all', fh: 80, sd: 10, scoped: 20 }],
+    })
+  })
+
+  test('mixed: one entry with scoped, one without', () => {
+    expect(
+      parseKillswitchCommandAction('set main:80,10,0 work-alt:5,10'),
+    ).toEqual({
+      type: 'set',
+      entries: [
+        { account: 'main', fh: 80, sd: 10, scoped: 0 },
+        { account: 'work-alt', fh: 5, sd: 10, scoped: undefined },
+      ],
+    })
+  })
+
+  test('per-account scoped threshold round-trips through the command', () => {
+    const result = executeKillswitchCommand({
+      argumentsText: 'set main:5,10 work-alt:80,10,15',
+      config: { enabled: true, main: { five_hour: 5, seven_day: 10 } },
+      accountIds: ['work-alt'],
+    })
+    expect(result.updatedConfig?.accounts?.['work-alt']?.scoped).toBe(15)
+    // main did not specify a scoped threshold in this command, so it should
+    // fall back to the default (0) on normalization, not retain an arbitrary
+    // value. The command itself only writes what was parsed.
+    expect(result.updatedConfig?.main?.scoped).toBeUndefined()
+  })
+
+  test('status table renders the Scoped column when enabled', () => {
+    const result = executeKillswitchCommand({
+      argumentsText: 'set main:5,10,20 work-alt:80,10,15',
+      config: { enabled: false },
+      accountIds: ['work-alt'],
+    })
+    expect(result.text).toContain('Scoped')
+    expect(result.text).toContain('main')
+    expect(result.text).toContain('work-alt')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// killswitchRetryAfterSeconds — scoped window resetsAt
+// ---------------------------------------------------------------------------
+describe('killswitchRetryAfterSeconds — scoped resetsAt', () => {
+  test('considers the matched scoped window resetsAt when present', () => {
+    const now = Date.now()
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 50,
+        remainingPercent: 50,
+        checkedAt: now,
+      },
+    }
+    // A Fable window 3 minutes out — should be the earliest reset.
+    const fallbacks = [
+      {
+        quota: {
+          five_hour: {
+            usedPercent: 50,
+            remainingPercent: 50,
+            resetsAt: new Date(now + 600_000).toISOString(), // 10 min
+            checkedAt: now,
+          },
+          scoped: [
+            scopeWindow(
+              0,
+              { name: 'Claude Fable 5', id: 'claude-fable-5' },
+              {
+                resetsAt: new Date(now + 180_000).toISOString(), // 3 min
+              },
+            ),
+          ],
+        },
+      },
+    ]
+    const seconds = killswitchRetryAfterSeconds(
+      mainQuota,
+      fallbacks,
+      now,
+      'claude-fable-5',
+    )
+    // 180s until reset + 60s buffer
+    expect(seconds).toBeGreaterThanOrEqual(239)
+    expect(seconds).toBeLessThanOrEqual(241)
+  })
+
+  test('omitting scoped resetsAt is backward-compatible', () => {
+    const now = Date.now()
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 50,
+        remainingPercent: 50,
+        checkedAt: now,
+      },
+    }
+    const fallbacks = [
+      {
+        quota: {
+          five_hour: {
+            usedPercent: 50,
+            remainingPercent: 50,
+            resetsAt: new Date(now + 300_000).toISOString(),
+            checkedAt: now,
+          },
+        },
+      },
+    ]
+    const seconds = killswitchRetryAfterSeconds(mainQuota, fallbacks, now)
+    expect(seconds).toBeGreaterThanOrEqual(359)
+    expect(seconds).toBeLessThanOrEqual(361)
+  })
+})

--- a/packages/core/src/tests/killswitch.test.ts
+++ b/packages/core/src/tests/killswitch.test.ts
@@ -355,6 +355,87 @@ describe('killswitchPassesPolicy — scoped model dimension', () => {
       killswitchPassesPolicy(quota, storage, undefined, 'claude-fable-5'),
     ).toBe(true)
   })
+
+  // Regression for MUST-1: when 5h/7d is missing/non-finite AND
+  // failClosedOnUnknownQuota=false, the function must STILL evaluate the
+  // scoped check — an exhausted scoped window is its own block reason,
+  // independent of the unknown 5h/7d fail-closed decision.
+  test('scoped check runs even when 5h/7d is unknown and fail-OPEN (MUST-1)', () => {
+    const storage = baseStorage()
+    storage.quota = { ...storage.quota, failClosedOnUnknownQuota: false }
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    // Both 5h/7d absent → sawUnknownWindow=true. With fail-OPEN the old
+    // code would short-circuit to true and skip the scoped check.
+    const quota: OAuthQuotaSnapshot = {
+      scoped: [
+        scopeWindow(0, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    }
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-fable-5'),
+    ).toBe(false)
+  })
+
+  test('scoped check runs when one 5h/7d window is non-finite + fail-OPEN (MUST-1 variant)', () => {
+    const storage = baseStorage()
+    storage.quota = { ...storage.quota, failClosedOnUnknownQuota: false }
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    // five_hour present + non-finite (sawUnknownWindow=true), seven_day absent.
+    const quota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 0,
+        remainingPercent: Number.NaN,
+        checkedAt: Date.now(),
+      },
+      scoped: [
+        scopeWindow(0, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    }
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-fable-5'),
+    ).toBe(false)
+  })
+
+  test('healthy scoped window with unknown 5h/7d + fail-OPEN still passes (MUST-1 complement)', () => {
+    const storage = baseStorage()
+    storage.quota = { ...storage.quota, failClosedOnUnknownQuota: false }
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    // Unknown 5h/7d, but the Fable window is HEALTHY (above threshold).
+    // The scoped check passes, then the unknown-5h/7d fail-OPEN decision
+    // also passes. Final: true.
+    const quota: OAuthQuotaSnapshot = {
+      scoped: [
+        scopeWindow(50, { name: 'Claude Fable 5', id: 'claude-fable-5' }),
+      ],
+    }
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-fable-5'),
+    ).toBe(true)
+  })
+
+  test('absent scoped window with unknown 5h/7d + fail-OPEN still passes (MUST-1 complement)', () => {
+    const storage = baseStorage()
+    storage.quota = { ...storage.quota, failClosedOnUnknownQuota: false }
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    // No scoped array at all (Sonnet-style: no carve-out). The scoped check
+    // doesn't fire, then the unknown-5h/7d fail-OPEN decision passes.
+    const quota: OAuthQuotaSnapshot = {}
+    expect(
+      killswitchPassesPolicy(quota, storage, undefined, 'claude-sonnet-5'),
+    ).toBe(true)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -48,6 +48,7 @@ import {
   getQuotaNextRefreshAt,
   getRelayConfig,
   getRoutingMode,
+  getScopedQuotaWindowForModel,
   hashRefreshToken,
   isApiKeyAccount,
   isCache1hEnabled,
@@ -152,6 +153,25 @@ const CONCURRENT_MAIN_REFRESH_POLL_BASE_MS = 200
 const MIN_MAIN_REFRESH_BEFORE_EXPIRY_MINUTES = 240
 const DEFAULT_MAIN_REFRESH_BEFORE_EXPIRY_MINUTES =
   MIN_MAIN_REFRESH_BEFORE_EXPIRY_MINUTES
+
+/**
+ * Format the user-facing 429 message for a killswitch block. When the block
+ * is scoped-driven (the request's model matches a scoped window that is at
+ * or below the killswitch threshold), the message names the model so the
+ * operator can distinguish a per-model weekly block from a whole-account
+ * kill. Otherwise the generic account-level message is used.
+ */
+export function formatKillswitchBlockMessage(input: {
+  retryAfterSeconds: number
+  modelName?: string
+}): string {
+  const minutes = Math.floor(input.retryAfterSeconds / 60)
+  const seconds = input.retryAfterSeconds % 60
+  const retryHint = `Retry in ${minutes}m ${seconds}s.`
+  return input.modelName
+    ? `${input.modelName} weekly limit reached, no routable accounts. ${retryHint}`
+    : `Killswitch: no routable accounts. ${retryHint}`
+}
 
 type NotificationRequest = {
   path: { id: string }
@@ -2558,6 +2578,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                     getFallbackQuota(account),
                     storageArg,
                     account.id,
+                    options.modelId,
                   )
                 : true,
             )
@@ -2731,7 +2752,12 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                   ? // Prefer the fresh QuotaManager cache (updated by the eager
                     // killswitch refresh) over the request-start storage snapshot,
                     // matching the other killswitch fallback filters.
-                    killswitchPassesPolicy(getFallbackQuota(a), storage, a.id)
+                    killswitchPassesPolicy(
+                      getFallbackQuota(a),
+                      storage,
+                      a.id,
+                      modelId,
+                    )
                   : true,
               )
               if (accounts.length < before) {
@@ -3133,7 +3159,14 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                 // refresh failed on the first request) killswitchPassesPolicy
                 // returns false under failClosedOnUnknownQuota, so the killswitch
                 // must still block / reroute instead of falling through to main.
-                !killswitchPassesPolicy(mainQuota, storage)
+                // accountId stays undefined for main; the optional trailing
+                // modelId adds the per-model scoped check.
+                !killswitchPassesPolicy(
+                  mainQuota,
+                  storage,
+                  undefined,
+                  requestModelId,
+                )
               ) {
                 // Main is killswitch-killed. Decide where to route from the SAME
                 // set routing will actually use — usable fallbacks that also
@@ -3197,17 +3230,29 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                       a.enabled !== false && isOAuthAccount(a),
                   )
                   .map((a) => ({ ...a, quota: getFallbackQuota(a) }))
+                // Detect a scoped-driven block: the request's model matches a
+                // scoped window on main that is at/below the killswitch
+                // threshold. The message names the model so the operator can
+                // tell a per-model weekly block from a whole-account kill.
+                const scopedWindow = requestModelId
+                  ? getScopedQuotaWindowForModel(mainQuota, requestModelId)
+                  : undefined
                 const retryAfter = killswitchRetryAfterSeconds(
                   mainQuota,
                   fallbackAccounts,
                   now,
+                  scopedWindow ? requestModelId : undefined,
                 )
+                const message = formatKillswitchBlockMessage({
+                  retryAfterSeconds: retryAfter,
+                  modelName: scopedWindow?.modelName,
+                })
                 return new Response(
                   JSON.stringify({
                     type: 'error',
                     error: {
                       type: 'rate_limit_error',
-                      message: `Killswitch: no routable accounts. Retry in ${Math.floor(retryAfter / 60)}m ${retryAfter % 60}s.`,
+                      message,
                     },
                   }),
                   {

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -181,6 +181,12 @@ export function formatKillswitchBlockMessage(input: {
  * actually at or below the per-account scoped threshold. A Fable request
  * with a healthy Fable window is therefore correctly classified as
  * account-level (the 5h/7d breach killed the account, not the Fable quota).
+ *
+ * Priority: account-level 5h/7d always wins. `killswitchPassesPolicy` called
+ * WITHOUT a modelId evaluates only 5h/7d; if it returns false, 5h/7d drove
+ * the block, so this is account-level regardless of the scoped window's
+ * state. Only when 5h/7d pass AND the matched scoped window is at/below the
+ * scoped threshold do we call it scoped-driven.
  */
 export function resolveScopedDrivenBlock(input: {
   mainQuota: OAuthQuotaSnapshot | undefined
@@ -190,6 +196,10 @@ export function resolveScopedDrivenBlock(input: {
   | { isScopedDriven: true; modelName: string; modelId: string }
   | { isScopedDriven: false } {
   if (!input.requestModelId) return { isScopedDriven: false }
+  if (!killswitchPassesPolicy(input.mainQuota, input.storage)) {
+    // 5h/7d already killed the account — account-level, not scoped-driven.
+    return { isScopedDriven: false }
+  }
   const matchedWindow = getScopedQuotaWindowForModel(
     input.mainQuota,
     input.requestModelId,

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -43,6 +43,7 @@ import {
   getCache1hPersistentMode,
   getCacheKeepWindow,
   getKillswitchConfig,
+  getKillswitchThresholdsForAccount,
   getPersistedLogLevel,
   getPersistedMainQuota,
   getQuotaNextRefreshAt,
@@ -171,6 +172,41 @@ export function formatKillswitchBlockMessage(input: {
   return input.modelName
     ? `${input.modelName} weekly limit reached, no routable accounts. ${retryHint}`
     : `Killswitch: no routable accounts. ${retryHint}`
+}
+
+/**
+ * Decide whether a killswitch block is scoped-driven (a per-model weekly
+ * block) versus a whole-account 5h/7d-driven block. A block is scoped-driven
+ * only when the request's model matches a scoped window AND that window is
+ * actually at or below the per-account scoped threshold. A Fable request
+ * with a healthy Fable window is therefore correctly classified as
+ * account-level (the 5h/7d breach killed the account, not the Fable quota).
+ */
+export function resolveScopedDrivenBlock(input: {
+  mainQuota: OAuthQuotaSnapshot | undefined
+  requestModelId: string | undefined
+  storage: AccountStorage | null
+}):
+  | { isScopedDriven: true; modelName: string; modelId: string }
+  | { isScopedDriven: false } {
+  if (!input.requestModelId) return { isScopedDriven: false }
+  const matchedWindow = getScopedQuotaWindowForModel(
+    input.mainQuota,
+    input.requestModelId,
+  )
+  if (!matchedWindow) return { isScopedDriven: false }
+  if (!Number.isFinite(matchedWindow.remainingPercent)) {
+    return { isScopedDriven: false }
+  }
+  const thresholds = getKillswitchThresholdsForAccount(input.storage)
+  if (matchedWindow.remainingPercent <= thresholds.scoped) {
+    return {
+      isScopedDriven: true,
+      modelName: matchedWindow.modelName,
+      modelId: input.requestModelId,
+    }
+  }
+  return { isScopedDriven: false }
 }
 
 type NotificationRequest = {
@@ -3230,22 +3266,24 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                       a.enabled !== false && isOAuthAccount(a),
                   )
                   .map((a) => ({ ...a, quota: getFallbackQuota(a) }))
-                // Detect a scoped-driven block: the request's model matches a
-                // scoped window on main that is at/below the killswitch
-                // threshold. The message names the model so the operator can
-                // tell a per-model weekly block from a whole-account kill.
-                const scopedWindow = requestModelId
-                  ? getScopedQuotaWindowForModel(mainQuota, requestModelId)
-                  : undefined
+                // Decide whether the block is scoped-driven (request's
+                // model matches a scoped window that is at/below the scoped
+                // threshold) vs a whole-account 5h/7d-driven block. A
+                // healthy Fable window + 5h/7d breach is NOT scoped-driven.
+                const scoped = resolveScopedDrivenBlock({
+                  mainQuota,
+                  requestModelId,
+                  storage,
+                })
                 const retryAfter = killswitchRetryAfterSeconds(
                   mainQuota,
                   fallbackAccounts,
                   now,
-                  scopedWindow ? requestModelId : undefined,
+                  scoped.isScopedDriven ? scoped.modelId : undefined,
                 )
                 const message = formatKillswitchBlockMessage({
                   retryAfterSeconds: retryAfter,
-                  modelName: scopedWindow?.modelName,
+                  ...(scoped.isScopedDriven && { modelName: scoped.modelName }),
                 })
                 return new Response(
                   JSON.stringify({

--- a/packages/opencode/src/tests/killswitch.test.ts
+++ b/packages/opencode/src/tests/killswitch.test.ts
@@ -17,6 +17,8 @@ import {
   setKillswitchPersistent,
 } from '@cortexkit/anthropic-auth-core'
 
+import { formatKillswitchBlockMessage } from '../index.ts'
+
 let tempDir: string
 let accountPath: string
 
@@ -533,5 +535,44 @@ describe('getQuotaRefreshEveryNRequests', () => {
 
     storage.quota = { ...storage.quota!, refreshEveryNRequests: Infinity }
     expect(getQuotaRefreshEveryNRequests(storage)).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatKillswitchBlockMessage — scope-aware 429 message
+// ---------------------------------------------------------------------------
+describe('formatKillswitchBlockMessage', () => {
+  test('scoped-driven: names the model + weekly phrasing', () => {
+    const message = formatKillswitchBlockMessage({
+      retryAfterSeconds: 300,
+      modelName: 'Claude Fable 5',
+    })
+    expect(message).toContain('Claude Fable 5')
+    expect(message).toContain('weekly limit reached')
+    expect(message).toContain('5m 0s')
+    expect(message).not.toContain('Killswitch: no routable accounts')
+  })
+
+  test('account-level: generic phrasing when no modelName', () => {
+    const message = formatKillswitchBlockMessage({
+      retryAfterSeconds: 300,
+    })
+    expect(message).toContain('Killswitch: no routable accounts')
+    expect(message).toContain('5m 0s')
+  })
+
+  test('scoped: modelName is generic (e.g. Mythos), no hardcoded Fable string', () => {
+    const message = formatKillswitchBlockMessage({
+      retryAfterSeconds: 60,
+      modelName: 'Claude Mythos 5',
+    })
+    expect(message).toContain('Claude Mythos 5')
+    expect(message).not.toContain('Fable')
+  })
+
+  test('retry hint formatting — minutes and seconds', () => {
+    const message = formatKillswitchBlockMessage({ retryAfterSeconds: 754 })
+    // 754s = 12m 34s
+    expect(message).toContain('12m 34s')
   })
 })

--- a/packages/opencode/src/tests/killswitch.test.ts
+++ b/packages/opencode/src/tests/killswitch.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
+  type AccountScopedQuotaWindow,
   type AccountStorage,
   executeKillswitchCommand,
   getKillswitchConfig,
@@ -12,12 +13,16 @@ import {
   killswitchPassesPolicy,
   killswitchRetryAfterSeconds,
   loadAccounts,
+  type OAuthQuotaSnapshot,
   parseKillswitchCommandAction,
   saveAccounts,
   setKillswitchPersistent,
 } from '@cortexkit/anthropic-auth-core'
 
-import { formatKillswitchBlockMessage } from '../index.ts'
+import {
+  formatKillswitchBlockMessage,
+  resolveScopedDrivenBlock,
+} from '../index.ts'
 
 let tempDir: string
 let accountPath: string
@@ -574,5 +579,206 @@ describe('formatKillswitchBlockMessage', () => {
     const message = formatKillswitchBlockMessage({ retryAfterSeconds: 754 })
     // 754s = 12m 34s
     expect(message).toContain('12m 34s')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveScopedDrivenBlock — must-2: a healthy scoped window must NOT be
+// treated as scoped-driven; the 5h/7d block must keep the generic message
+// even when the request's model happens to match a scoped carve-out.
+// ---------------------------------------------------------------------------
+describe('resolveScopedDrivenBlock', () => {
+  const fableWindow = (remaining: number): AccountScopedQuotaWindow => ({
+    id: 'claude-weekly-scoped-fable',
+    title: 'Claude Fable 5 only',
+    modelName: 'Claude Fable 5',
+    modelId: 'claude-fable-5',
+    usedPercent: 100 - remaining,
+    remainingPercent: remaining,
+    checkedAt: Date.now(),
+  })
+
+  const killswitchStorage = (scoped: number): AccountStorage => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped },
+    }
+    return storage
+  }
+
+  test('5h/7d-driven block + HEALTHY Fable window → NOT scoped-driven (MUST-2)', () => {
+    // Main quota is exhausted on 5h/7d (killswitch will fire), but the
+    // Fable window is at 100% remaining — well above the scoped threshold.
+    // The current (buggy) code names Fable; the fix must produce a generic
+    // account-level message because the block is 5h/7d-driven, not
+    // scoped-driven.
+    const storage = killswitchStorage(0)
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 95,
+        remainingPercent: 5,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 90,
+        remainingPercent: 10,
+        checkedAt: Date.now(),
+      },
+      scoped: [fableWindow(100)], // perfectly healthy
+    }
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: 'claude-fable-5',
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(false)
+  })
+
+  test('EXHAUSTED Fable window at/below scoped threshold → IS scoped-driven (MUST-2 proof)', () => {
+    const storage = killswitchStorage(0)
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 95,
+        remainingPercent: 5,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 90,
+        remainingPercent: 10,
+        checkedAt: Date.now(),
+      },
+      scoped: [fableWindow(0)], // exhausted
+    }
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: 'claude-fable-5',
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(true)
+    if (result.isScopedDriven) {
+      expect(result.modelName).toBe('Claude Fable 5')
+      expect(result.modelId).toBe('claude-fable-5')
+    }
+  })
+
+  test('raised scoped threshold (20) marks a 20% Fable window as scoped-driven (MUST-2 boundary)', () => {
+    const storage = killswitchStorage(20)
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 50,
+        remainingPercent: 50,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 50,
+        remainingPercent: 50,
+        checkedAt: Date.now(),
+      },
+      scoped: [fableWindow(20)],
+    }
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: 'claude-fable-5',
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(true)
+  })
+
+  test('same 20% threshold + 21% remaining Fable window → NOT scoped-driven', () => {
+    const storage = killswitchStorage(20)
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 50,
+        remainingPercent: 50,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 50,
+        remainingPercent: 50,
+        checkedAt: Date.now(),
+      },
+      scoped: [fableWindow(21)],
+    }
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: 'claude-fable-5',
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(false)
+  })
+
+  test('Sonnet request: no matching scoped window → NOT scoped-driven', () => {
+    const storage = killswitchStorage(0)
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 95,
+        remainingPercent: 5,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 90,
+        remainingPercent: 10,
+        checkedAt: Date.now(),
+      },
+      scoped: [fableWindow(0)],
+    }
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: 'claude-sonnet-5',
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(false)
+  })
+
+  test('no requestModelId → NOT scoped-driven', () => {
+    const storage = killswitchStorage(0)
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 95,
+        remainingPercent: 5,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 90,
+        remainingPercent: 10,
+        checkedAt: Date.now(),
+      },
+      scoped: [fableWindow(0)],
+    }
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: undefined,
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(false)
+  })
+
+  test('non-finite remainingPercent on a matched window → NOT scoped-driven', () => {
+    const storage = killswitchStorage(0)
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 95,
+        remainingPercent: 5,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 90,
+        remainingPercent: 10,
+        checkedAt: Date.now(),
+      },
+      scoped: [
+        {
+          ...fableWindow(0),
+          remainingPercent: Number.NaN,
+        },
+      ],
+    }
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: 'claude-fable-5',
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(false)
   })
 })

--- a/packages/opencode/src/tests/killswitch.test.ts
+++ b/packages/opencode/src/tests/killswitch.test.ts
@@ -608,21 +608,20 @@ describe('resolveScopedDrivenBlock', () => {
   }
 
   test('5h/7d-driven block + HEALTHY Fable window → NOT scoped-driven (MUST-2)', () => {
-    // Main quota is exhausted on 5h/7d (killswitch will fire), but the
-    // Fable window is at 100% remaining — well above the scoped threshold.
-    // The current (buggy) code names Fable; the fix must produce a generic
-    // account-level message because the block is 5h/7d-driven, not
-    // scoped-driven.
+    // Main quota is exhausted on 5h/7d (remaining below the strict-`<`
+    // thresholds of 5/10, so the killswitch genuinely fires), but the Fable
+    // window is at 100% remaining — well above the scoped threshold. The block
+    // must be classified account-level (generic message), not scoped-driven.
     const storage = killswitchStorage(0)
     const mainQuota: OAuthQuotaSnapshot = {
       five_hour: {
-        usedPercent: 95,
-        remainingPercent: 5,
+        usedPercent: 96,
+        remainingPercent: 4,
         checkedAt: Date.now(),
       },
       seven_day: {
-        usedPercent: 90,
-        remainingPercent: 10,
+        usedPercent: 91,
+        remainingPercent: 9,
         checkedAt: Date.now(),
       },
       scoped: [fableWindow(100)], // perfectly healthy

--- a/packages/opencode/src/tests/killswitch.test.ts
+++ b/packages/opencode/src/tests/killswitch.test.ts
@@ -781,4 +781,104 @@ describe('resolveScopedDrivenBlock', () => {
     })
     expect(result.isScopedDriven).toBe(false)
   })
+
+  // Regression for FINDING 2: when BOTH 5h/7d AND the Fable window are
+  // exhausted, the real block reason is account-level (5h/7d), yet the
+  // old code only checked the scoped window and reported scoped-driven.
+  // That misleads the operator (saying "Fable weekly limit" when the
+  // account is dead for ALL models) and misroutes the retry-after to
+  // the weekly window. Account-level 5h/7d must take priority.
+  test('BOTH 5h/7d AND Fable exhausted → NOT scoped-driven (FINDING 2)', () => {
+    // 5h threshold 10, 5h remaining 4 → 4 < 10, BLOCKED
+    // 7d threshold 10, 7d remaining 4 → 4 < 10, BLOCKED
+    // scoped threshold 0, Fable remaining 0 → 0 <= 0, BLOCKED
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 10, seven_day: 10, scoped: 0 },
+    }
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 96,
+        remainingPercent: 4,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 96,
+        remainingPercent: 4,
+        checkedAt: Date.now(),
+      },
+      scoped: [fableWindow(0)],
+    }
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: 'claude-fable-5',
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(false)
+  })
+
+  test('BOTH 5h/7d AND Fable exhausted — Sonnet request → NOT scoped-driven (FINDING 2 Sonnet variant)', () => {
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 10, seven_day: 10, scoped: 0 },
+    }
+    const mainQuota: OAuthQuotaSnapshot = {
+      five_hour: {
+        usedPercent: 96,
+        remainingPercent: 4,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 96,
+        remainingPercent: 4,
+        checkedAt: Date.now(),
+      },
+      scoped: [fableWindow(0)],
+    }
+    // Sonnet has no matching scoped window, so the 5h/7d guard short-
+    // circuits. Important: result is still NOT scoped-driven.
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: 'claude-sonnet-5',
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(false)
+  })
+
+  test('HEALTHY 5h/7d + EXHAUSTED Fable → still IS scoped-driven (FINDING 2 regression lock)', () => {
+    // This is the MUST-2 proof test, restated as a regression lock for
+    // FINDING 2: the 5h/7d guard must not over-trigger and turn a
+    // genuine scoped-driven block into account-level.
+    const storage = baseStorage()
+    storage.killswitch = {
+      enabled: true,
+      main: { five_hour: 5, seven_day: 10, scoped: 0 },
+    }
+    const mainQuota: OAuthQuotaSnapshot = {
+      // 5h/7d HEALTHY — they must pass the no-modelId policy check.
+      five_hour: {
+        usedPercent: 10,
+        remainingPercent: 90,
+        checkedAt: Date.now(),
+      },
+      seven_day: {
+        usedPercent: 20,
+        remainingPercent: 80,
+        checkedAt: Date.now(),
+      },
+      scoped: [fableWindow(0)],
+    }
+    const result = resolveScopedDrivenBlock({
+      mainQuota,
+      requestModelId: 'claude-fable-5',
+      storage,
+    })
+    expect(result.isScopedDriven).toBe(true)
+    if (result.isScopedDriven) {
+      expect(result.modelName).toBe('Claude Fable 5')
+      expect(result.modelId).toBe('claude-fable-5')
+    }
+  })
 })


### PR DESCRIPTION
## What

Adds a third, model-scoped dimension to the per-account killswitch: a `scoped` threshold that hard-limits traffic to a weekly scoped quota carve-out (the `weekly_scoped` "Fable only" window) **without killing the account for other models**.

When the killswitch is enabled and a request's model matches a scoped window at/below the `scoped` threshold, the request reroutes to a scoped-eligible fallback and hard-blocks with a 429 if none qualify — while Sonnet/Opus traffic on the same account continues normally. Additive to the existing `five_hour`/`seven_day` checks; generic over any scoped window (not Fable-hardcoded).

## Changes

- **`killswitchPassesPolicy(quota, storage, accountId?, modelId?)`** — new optional `modelId`. When present and a scoped window matches it, the window's `remainingPercent` is checked against the per-account `scoped` threshold. When absent, behavior is unchanged. The scoped check runs **before** the unknown-5h/7d fail-open return, so an exhausted scoped window blocks independently of missing 5h/7d windows.
- **Comparison is `<=` (inclusive)** for scoped — deliberately distinct from the strict `<` on 5h/7d — so the default threshold `0` fires at true exhaustion (matching `quotaSnapshotModelScopeIsExhausted`'s `<= 0`).
- **Config** — `KillswitchThresholds` gains an optional `scoped` key (default `0`); `normalizeKillswitchThresholds` resolves it with the same finite-guard/default pattern. Backward-compatible: existing two-value configs read `scoped` as the default.
- **Command** — `/claude-killswitch set main:80,10,0` accepts an optional third number (fh, sd, scoped). Two-number form parses identically to before. Status table gains a Scoped column.
- **Enforcement** — `modelId` is threaded into the three routing-path call sites (main killswitch gate + both fallback filters), leaving the sidebar/status callers model-free so account-level killed state is unchanged.
- **Block message** — a scoped-driven terminal 429 names the model (`"<Model> weekly limit reached, …"`) and `killswitchRetryAfterSeconds` honors the scoped window's weekly `resetsAt`. A 5h/7d-driven block keeps the account-level message (classified by the same `<= scoped threshold` check that drives the block, so message and reason never disagree).

Opencode-only, consistent with the existing killswitch (Pi has no killswitch enforcement).

## Verification

- `bun run typecheck` — clean (all packages)
- `bun run lint` — clean
- `bun test`: core 34/0, opencode 770/0, pi 47/0
- New tests cover: model-scoped isolation (same quota, non-matching model → account stays live), the `<=` boundary at the `0` default and a raised threshold, `modelId`-absent regression lock, the unknown-window × fail-open × scoped-exhausted interaction, block-message attribution (5h/7d block with a healthy scoped window → generic message; exhausted scoped window → model-named), and config round-trip for the two- and three-value forms.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785836709&installation_id=135454708&pr_number=109&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F109&signature=bc4b17c81390edf45a8cf0544060ec41c769517994d45582667475e714008a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-model `scoped` killswitch threshold to enforce weekly model carve-outs (e.g., Fable) without killing the account for other models. Routing, CLI, retry hints, and 429 messages are scope-aware with correct attribution and weekly reset timing; tests lock the priority rules.

- **New Features**
  - Add `scoped` threshold (default 0); inclusive `<=`; evaluated when a request includes `modelId`; additive to 5h/7d.
  - Thread `modelId` through the main gate and fallback filters; exhausted scoped windows reroute to scoped-eligible fallbacks or 429.
  - Update retry hints to accept a `scopedModelId` and use only the matched weekly reset; extend `/claude-killswitch set` to accept a third number (fh, sd, scoped); status table shows a Scoped column; thresholds normalized; block messages name the model for scoped-driven blocks.

- **Bug Fixes**
  - Run the scoped check before the unknown 5h/7d fail-open decision (MUST-1).
  - Correct 429 attribution: only label a block as model-scoped when the matched scoped window is at/below the `scoped` threshold and 5h/7d did not already kill the account (MUST-2, FINDING 2).
  - Fix retry-after for scoped blocks: when `scopedModelId` is provided, consider only the matched scoped window’s `resetsAt` so the hint reflects the weekly reset (FINDING 1).
  - Strengthen the MUST-2 test to actually trigger account-level blocks by setting 5h/7d remaining below the strict `<` thresholds (ensures the priority guard is exercised).

<sup>Written for commit 660e47dbc49699c957ed82ca36d3b8be8a9d380e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `scoped` third dimension to the per-account killswitch, enabling model-specific weekly quota enforcement (e.g., Fable carve-outs) without blocking the account for other models. The change threads `modelId` through the main killswitch gate and both fallback filters, and introduces scope-aware block-message attribution and retry-after hints.

- **`killswitchPassesPolicy`** gains an optional `modelId`; when present and a scoped window matches at/below the `scoped` threshold, the request is blocked independently of 5h/7d — using `<=` (inclusive) so the default `0` fires at true exhaustion.
- **`resolveScopedDrivenBlock`** distinguishes a scoped-driven block from a 5h/7d-driven one by re-running policy without `modelId`; if 5h/7d already killed the account, the block is classified as account-level regardless of the scoped window's state (addressing the previous FINDING 2).
- **`killswitchRetryAfterSeconds`** now takes a `scopedModelId` and, when provided, collects only the matched scoped window's weekly `resetsAt` — ignoring the 5h reset that would otherwise produce a misleadingly short retry hint (addressing the previous FINDING 1).
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the two previously flagged issues (retry-after dominated by 5h/7d resets; misclassification when both 5h/7d and scoped are simultaneously exhausted) are both resolved in this revision, with regression-lock tests co-located alongside each fix.

The scoped check is correctly ordered before the unknown-window fail-open branch, the resolveScopedDrivenBlock priority logic (5h/7d wins over scoped when both are exhausted) matches the stated invariant and is directly verified, and the retry-after split (scoped-only vs 5h/7d) prevents the retry-storm scenario. The change is backward-compatible: existing two-value configs read scoped as 0 on normalization, and callers that omit modelId see identical behavior to before.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/accounts.ts | Adds scoped to KillswitchThresholds, DEFAULT_KILLSWITCH_THRESHOLDS, and normalizeKillswitchThresholds; threads optional modelId into killswitchPassesPolicy with correct ordering (before the unknown-window fail-open branch); splits killswitchRetryAfterSeconds into scoped-only vs 5h/7d paths — all sound. |
| packages/core/src/killswitch.ts | Extends the command parser regex to accept an optional third number, updates the set-entry type, and adds a Scoped column to the status table via normalizeKillswitchThresholds — backward-compatible and clean. |
| packages/opencode/src/index.ts | Introduces resolveScopedDrivenBlock and formatKillswitchBlockMessage; threads modelId into the main gate, getRoutableFallbackAccounts, and the second fallback filter; correctly conditions retry-after and block message on isScopedDriven — logic is consistent with the policy functions. |
| packages/core/src/tests/killswitch.test.ts | New test file with 34 cases covering defaults, normalization, per-model isolation, boundary conditions (<=), MUST-1 fail-open ordering, FINDING 1 retry-after branching, and config round-trips — comprehensive. |
| packages/opencode/src/tests/killswitch.test.ts | Adds formatKillswitchBlockMessage and resolveScopedDrivenBlock tests covering MUST-2 (5h/7d priority), FINDING 2 regression lock, and message attribution; thoroughly exercises the correct block-attribution logic. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request with modelId] --> B{killswitch enabled?}
    B -- No --> Z[Pass through to main]
    B -- Yes --> C[killswitchPassesPolicy
mainQuota, storage, undefined, modelId]
    C --> D{5h/7d window
below threshold?}
    D -- Yes return false --> E[Account-level kill]
    D -- No check scoped --> F{modelId provided
and scoped window
matches model?}
    F -- No scoped window --> G{sawUnknownWindow?}
    F -- Window at/below
scoped threshold --> E
    F -- Window above
scoped threshold --> G
    G -- failClosed=true --> E
    G -- failClosed=false --> Z
    E --> H[getRoutableFallbackAccounts
filtered by modelId scoped check]
    H --> I{survivingFallbacks > 0?}
    I -- Yes --> J[Route to fallback]
    I -- No --> K[resolveScopedDrivenBlock
check 5h/7d WITHOUT modelId]
    K --> L{5h/7d passes
without modelId?}
    L -- No account-level --> M[Generic 429 message
retryAfter from 5h/7d resets]
    L -- Yes + scoped window
at/below threshold --> N[Scoped-driven 429
model-named message
retryAfter from weekly resetsAt]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Request with modelId] --> B{killswitch enabled?}
    B -- No --> Z[Pass through to main]
    B -- Yes --> C[killswitchPassesPolicy
mainQuota, storage, undefined, modelId]
    C --> D{5h/7d window
below threshold?}
    D -- Yes return false --> E[Account-level kill]
    D -- No check scoped --> F{modelId provided
and scoped window
matches model?}
    F -- No scoped window --> G{sawUnknownWindow?}
    F -- Window at/below
scoped threshold --> E
    F -- Window above
scoped threshold --> G
    G -- failClosed=true --> E
    G -- failClosed=false --> Z
    E --> H[getRoutableFallbackAccounts
filtered by modelId scoped check]
    H --> I{survivingFallbacks > 0?}
    I -- Yes --> J[Route to fallback]
    I -- No --> K[resolveScopedDrivenBlock
check 5h/7d WITHOUT modelId]
    K --> L{5h/7d passes
without modelId?}
    L -- No account-level --> M[Generic 429 message
retryAfter from 5h/7d resets]
    L -- Yes + scoped window
at/below threshold --> N[Scoped-driven 429
model-named message
retryAfter from weekly resetsAt]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/opencode/src/index.ts`, line 886-911 ([link](https://github.com/cortexkit/anthropic-auth/blob/5209727bfbcf6c97574be472d19cb2a6ac20e924/packages/opencode/src/index.ts#L886-L911)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`resolveScopedDrivenBlock` misclassifies when 5h/7d and scoped are both exhausted**

   `resolveScopedDrivenBlock` checks only whether the scoped window is at/below threshold — it does not verify that 5h/7d windows are themselves healthy. When 5h/7d exhaustion (e.g. `remainingPercent: 4` vs a threshold of `5`) caused `killswitchPassesPolicy` to return `false`, a simultaneously exhausted scoped window still produces `{ isScopedDriven: true }`. The caller then emits `"<Model> weekly limit reached, no routable accounts"`, misleading operators into thinking Sonnet requests on the same account would succeed — when in reality the account is blocked for all models due to the 5h/7d breach.

   The fix is to confirm that no 5h/7d window is independently below its threshold before declaring the block scoped-driven: if any finite 5h/7d window is `< thresholds[key]`, return `{ isScopedDriven: false }` immediately so the generic account-level message is used instead.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["test(killswitch): make MUST-2 5h/7d prem..."](https://github.com/cortexkit/anthropic-auth/commit/660e47dbc49699c957ed82ca36d3b8be8a9d380e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41893911)</sub>

<!-- /greptile_comment -->