### PR TITLE
Expose Claude Sonnet 5 in Pi catalog

### DIFF
--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -2,7 +2,7 @@
 
 Pi package for CortexKit Anthropic OAuth support. It overrides Pi's built-in `anthropic` provider with a CortexKit provider extension backed by the shared `@cortexkit/anthropic-auth-core` package.
 
-The Pi provider catalog includes Claude Fable 5 (`claude-fable-5`), limited-access Claude Mythos 5 (`claude-mythos-5`), Claude Opus 4.8, Claude Opus 4.5, and Claude Sonnet 4.5. Fable/Mythos reasoning uses Anthropic adaptive thinking with `thinking.display: "summarized"` and `output_config.effort`; the package does not send rejected manual `thinking.budget_tokens` for those models.
+The Pi provider catalog includes Claude Fable 5 (`claude-fable-5`), limited-access Claude Mythos 5 (`claude-mythos-5`), Claude Opus 4.8, Claude Opus 4.5, Claude Sonnet 4.5, and Claude Sonnet 5 (`claude-sonnet-5`). Fable/Mythos reasoning uses Anthropic adaptive thinking with `thinking.display: "summarized"` and `output_config.effort`; the package does not send rejected manual `thinking.budget_tokens` for those models.
 
 This package is part of the CortexKit Anthropic Auth monorepo, which supports both OpenCode (`@cortexkit/opencode-anthropic-auth`) and Pi (`@cortexkit/pi-anthropic-auth`) through the same shared core logic.
 

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -107,6 +107,15 @@ export default function cortexKitPiAnthropicAuth(pi: ExtensionAPI) {
         contextWindow: 200_000,
         maxTokens: 64_000,
       },
+      {
+        id: 'claude-sonnet-5',
+        name: 'Claude Sonnet 5',
+        reasoning: true,
+        input: textImageInput(),
+        cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
     ],
     oauth: {
       name: 'Anthropic Claude Pro/Max (CortexKit)',

--- a/packages/pi/src/tests/index.test.ts
+++ b/packages/pi/src/tests/index.test.ts
@@ -39,6 +39,7 @@ describe('cortexKitPiAnthropicAuth provider registration', () => {
       name: 'Claude Sonnet 5',
       reasoning: true,
       input: ['text', 'image'],
+      cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
       contextWindow: 1_000_000,
       maxTokens: 128_000,
     })

--- a/packages/pi/src/tests/index.test.ts
+++ b/packages/pi/src/tests/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test'
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+
+import cortexKitPiAnthropicAuth from '../index'
+
+function mockPi() {
+  const providers = new Map<
+    string,
+    { models?: Array<Record<string, unknown>> }
+  >()
+
+  const pi = {
+    registerCommand: () => {},
+    registerProvider: (
+      name: string,
+      config: { models?: Array<Record<string, unknown>> },
+    ) => {
+      providers.set(name, config)
+    },
+  } as unknown as ExtensionAPI
+
+  return { pi, providers }
+}
+
+describe('cortexKitPiAnthropicAuth provider registration', () => {
+  test('exposes Claude Sonnet 5 in the Pi Anthropic catalog', () => {
+    const { pi, providers } = mockPi()
+
+    cortexKitPiAnthropicAuth(pi)
+
+    const anthropic = providers.get('anthropic')
+    expect(anthropic).toBeDefined()
+
+    const sonnet5 = anthropic?.models?.find(
+      (model) => model.id === 'claude-sonnet-5',
+    )
+    expect(sonnet5).toMatchObject({
+      id: 'claude-sonnet-5',
+      name: 'Claude Sonnet 5',
+      reasoning: true,
+      input: ['text', 'image'],
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add `claude-sonnet-5` to the Pi provider catalog registered by `@cortexkit/pi-anthropic-auth`
- add a Pi registration regression test so future request-shaping support cannot ship without model discoverability
- update the Pi package README catalog sentence

## Why

PR #100 added Sonnet 5 request shaping and noted that `claude-sonnet-5` is in Pi's native model catalog. The Pi package currently passes a `models` array to `pi.registerProvider('anthropic', ...)`, which replaces Pi's native Anthropic catalog, so the native Sonnet 5 entry is hidden after this extension loads.

I checked whether omitting `models` while keeping the CortexKit provider `api` would preserve native models and still route through the CortexKit transport. A local dummy provider test showed native models keep their `anthropic-messages` API and bypass the replacement `streamSimple`, so this PR uses the smaller catalog fix instead of changing the provider override architecture.

## Testing

- `bun run --cwd packages/core build && bun run --cwd packages/pi test && bun run test && bun run typecheck`
- `bunx biome check .`
- `pi --no-extensions -e packages/pi/dist/index.js --list-models claude-sonnet-5`

Local Pi output includes:

```text
provider   model              context  max-out  thinking  images
anthropic  claude-sonnet-4-5  200K     64K      yes       yes
anthropic  claude-sonnet-5    1M       128K     yes       yes
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes `claude-sonnet-5` discoverable in the Pi provider catalog. Because the extension passes an explicit `models` array to `pi.registerProvider`, Pi's native Anthropic catalog is replaced entirely, hiding any native Sonnet 5 entry — this change adds it back. The underlying request-shaping support (`isClaudeSonnet5Model`, `CLAUDE_SONNET_5_ADAPTIVE_THINKING`, `output_config` effort routing) was already wired in `convert.ts` from PR #100.

- **`packages/pi/src/index.ts`**: Adds a `claude-sonnet-5` catalog entry with a 1M-token context window, 128K max output, `reasoning: true`, and introductory pricing ($2/$10 input/output through August 31, 2026). Cache and spec values match Anthropic's published figures.
- **`packages/pi/src/tests/index.test.ts`**: New regression test that mounts a minimal `ExtensionAPI` mock, calls the extension, and asserts every field on the Sonnet 5 catalog entry — ensuring future model additions cannot silently drop discoverability.
- **`packages/pi/README.md`**: Catalog sentence updated to list Sonnet 5 alongside the existing models.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted catalog addition backed by request-shaping logic that was already in place, and a regression test validates all catalog fields.

The diff is minimal and focused: one model entry in the catalog, one README sentence, and one new test. The convert.ts layer that handles Sonnet 5 adaptive thinking and output_config routing was already merged; this PR only makes the model visible. All pricing and spec values match Anthropic's published figures.

No files require special attention. The introductory pricing expiration in packages/pi/src/index.ts (and the mirrored assertion in the test) is worth tracking for a follow-up update before September 1, 2026.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pi/src/index.ts | Adds the claude-sonnet-5 catalog entry with correct 1M-token context window, 128K max output, and introductory pricing ($2/$10); request-shaping logic (CLAUDE_SONNET_5_ADAPTIVE_THINKING, isClaudeSonnet5Model) was already present from a prior PR. |
| packages/pi/src/tests/index.test.ts | New regression test verifying claude-sonnet-5 is registered in the Pi Anthropic catalog with all expected fields including cost; uses a minimal mock of ExtensionAPI. |
| packages/pi/README.md | Catalog sentence updated to include Claude Sonnet 5; purely documentary, accurate. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Pi as Pi Agent
    participant Ext as cortexKitPiAnthropicAuth
    participant Core as @cortexkit/anthropic-auth-core
    participant API as Anthropic API

    Pi->>Ext: load extension (ExtensionAPI)
    Ext->>Pi: "registerProvider('anthropic', { models: [..., claude-sonnet-5], api, oauth, streamSimple })"
    Note over Pi: Pi catalog now includes claude-sonnet-5

    Pi->>Ext: "streamSimple(model=claude-sonnet-5, context, options)"
    Ext->>Core: isClaudeSonnet5Model(modelId) → true
    Core-->>Ext: "body.thinking = CLAUDE_SONNET_5_ADAPTIVE_THINKING"
    Core-->>Ext: "body.output_config = { effort: options.reasoning }"
    Ext->>API: POST /v1/messages (signed, with adaptive thinking)
    API-->>Ext: SSE stream
    Ext-->>Pi: AssistantMessageEventStream
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Pi as Pi Agent
    participant Ext as cortexKitPiAnthropicAuth
    participant Core as @cortexkit/anthropic-auth-core
    participant API as Anthropic API

    Pi->>Ext: load extension (ExtensionAPI)
    Ext->>Pi: "registerProvider('anthropic', { models: [..., claude-sonnet-5], api, oauth, streamSimple })"
    Note over Pi: Pi catalog now includes claude-sonnet-5

    Pi->>Ext: "streamSimple(model=claude-sonnet-5, context, options)"
    Ext->>Core: isClaudeSonnet5Model(modelId) → true
    Core-->>Ext: "body.thinking = CLAUDE_SONNET_5_ADAPTIVE_THINKING"
    Core-->>Ext: "body.output_config = { effort: options.reasoning }"
    Ext->>API: POST /v1/messages (signed, with adaptive thinking)
    API-->>Ext: SSE stream
    Ext-->>Pi: AssistantMessageEventStream
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Assert Sonnet 5 pricing in Pi catalog te..."](https://github.com/cortexkit/anthropic-auth/commit/f373d8a82cb490d78c3e936613e2b832d5303b1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42849996)</sub>

<!-- /greptile_comment -->