### PR TITLE
Derive boot sidebar active account from routing mode and preserve live session state

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -145,6 +145,8 @@ import type {
 import { getRpcDir } from './rpc/rpc-dir.ts'
 import { type RpcServerHandle, startRpcServer } from './rpc/rpc-server.ts'
 import {
+  getInitialSidebarRoutingTestHooks,
+  getSidebarState,
   getSidebarStateFile,
   type SidebarState,
   setSidebarState,
@@ -173,6 +175,115 @@ const CONCURRENT_MAIN_REFRESH_POLL_BASE_MS = 200
 const MIN_MAIN_REFRESH_BEFORE_EXPIRY_MINUTES = 240
 const DEFAULT_MAIN_REFRESH_BEFORE_EXPIRY_MINUTES =
   MIN_MAIN_REFRESH_BEFORE_EXPIRY_MINUTES
+const SIDEBAR_ROUTING_FRESH_MS = 10 * 60 * 1000
+
+function hasEnabledOAuthAccount(
+  storage: AccountStorage | null,
+  activeId: string,
+) {
+  return (storage?.accounts ?? []).some(
+    (account) =>
+      account.id === activeId &&
+      account.enabled !== false &&
+      isOAuthAccount(account),
+  )
+}
+
+function deriveSidebarRouting(
+  storage: AccountStorage | null,
+): Pick<SidebarState, 'activeId' | 'route'> {
+  const firstFallback = (storage?.accounts ?? []).find(
+    (account): account is OAuthAccount =>
+      account.enabled !== false && isOAuthAccount(account),
+  )
+  if (getRoutingMode(storage) === 'fallback-first' && firstFallback) {
+    return { activeId: firstFallback.id, route: 'fallback-first' }
+  }
+  return { activeId: 'main', route: 'main' }
+}
+
+function validateSidebarRouting(
+  routing: Pick<SidebarState, 'activeId' | 'route'> | undefined,
+  storage: AccountStorage | null,
+): Pick<SidebarState, 'activeId' | 'route'> {
+  if (
+    routing?.activeId === 'main' ||
+    (routing?.activeId && hasEnabledOAuthAccount(storage, routing.activeId))
+  ) {
+    return routing
+  }
+  return deriveSidebarRouting(storage)
+}
+
+function resolveLoadedSidebarRouting(
+  existing: SidebarState,
+  freshStorage: AccountStorage | null,
+  fallbackRouting?: Pick<SidebarState, 'activeId' | 'route'>,
+): Pick<SidebarState, 'activeId' | 'route'> {
+  const existingAge = Date.now() - existing.lastUpdated
+  if (
+    !existing.activeId ||
+    existingAge < 0 ||
+    existingAge > SIDEBAR_ROUTING_FRESH_MS
+  ) {
+    return validateSidebarRouting(fallbackRouting, freshStorage)
+  }
+
+  return validateSidebarRouting(existing, freshStorage)
+}
+
+async function resolveFreshSidebarRouting(
+  existing: SidebarState,
+  loadFreshStorage: () => Promise<AccountStorage | null>,
+  fallbackRouting?: Pick<SidebarState, 'activeId' | 'route'>,
+): Promise<{
+  activeId: string | undefined
+  route: string
+  freshStorage: AccountStorage | null
+}> {
+  let freshStorage: AccountStorage | null
+  try {
+    freshStorage = await loadFreshStorage()
+  } catch (error) {
+    logger.warn('sidebar', 'account storage reload failed; routing preserved', {
+      message: error instanceof Error ? error.message : String(error),
+    })
+    const preservedRouting = existing.activeId
+      ? { activeId: existing.activeId, route: existing.route }
+      : (fallbackRouting ?? { activeId: 'main', route: 'main' })
+    return { ...preservedRouting, freshStorage: null }
+  }
+
+  return {
+    ...resolveLoadedSidebarRouting(existing, freshStorage, fallbackRouting),
+    freshStorage,
+  }
+}
+
+async function resolveInitialSidebarRouting(
+  accountStoragePath: string,
+): Promise<{
+  activeId: string | undefined
+  route: string
+  freshStorage: AccountStorage | null
+}> {
+  await getInitialSidebarRoutingTestHooks()?.beforeStorageLoad?.()
+  let freshStorage: AccountStorage | null
+  try {
+    freshStorage = await loadAccounts(accountStoragePath)
+  } catch {
+    return { activeId: 'main', route: 'main', freshStorage: null }
+  } finally {
+    await getInitialSidebarRoutingTestHooks()?.afterStorageLoad?.()
+  }
+
+  await getInitialSidebarRoutingTestHooks()?.beforeSidebarRead?.()
+  const existing = await getSidebarState()
+  return {
+    ...resolveLoadedSidebarRouting(existing, freshStorage),
+    freshStorage,
+  }
+}
 
 /**
  * Format the user-facing 429 message for a killswitch block. When the block
@@ -906,16 +1017,18 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
     NonNullable<SidebarState['fableRecoveries']>[number]
   >()
 
-  function writeSidebarState(
+  interface SidebarStateInput {
+    activeId?: string
+    route: string
+    mainAccessToken?: string
+    mainRefreshToken?: string
+    routingAuthoritative?: boolean
+  }
+
+  function buildSidebarState(
     storage: Awaited<ReturnType<typeof loadAccounts>>,
-    options: {
-      activeId?: string
-      route: string
-      mainAccessToken?: string
-      mainRefreshToken?: string
-    },
-  ) {
-    lastSidebarRouting = { activeId: options.activeId, route: options.route }
+    options: SidebarStateInput,
+  ): SidebarState {
     quotaManager.updateStorage(storage)
     quotaManager.seedMainFromStorage(storage, options.mainAccessToken)
     quotaManager.seedFallbacksFromAccounts(
@@ -924,7 +1037,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
     const mainEntry = quotaManager.getMain(options.mainAccessToken)
     const lastApiError = quotaManager.getLastApiError()
     const mainRefreshError = storage?.refresh?.mainLastRefreshError
-    const state: SidebarState = {
+    return {
       main: {
         quota: mainEntry?.quota ?? null,
         quotaBackedOff: quotaManager.isBackedOff(),
@@ -995,7 +1108,43 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
           : undefined,
       lastUpdated: Date.now(),
     }
-    return setSidebarState(state, sidebarStateFile).catch((error) =>
+  }
+
+  function writeSidebarState(
+    storage: Awaited<ReturnType<typeof loadAccounts>>,
+    options: SidebarStateInput,
+  ) {
+    const routingAuthoritative = options.routingAuthoritative !== false
+    if (routingAuthoritative) {
+      lastSidebarRouting = { activeId: options.activeId, route: options.route }
+    }
+    const state = buildSidebarState(storage, options)
+    return setSidebarState(state, sidebarStateFile, {
+      routingAuthoritative,
+      resolvePreservedRouting: routingAuthoritative
+        ? undefined
+        : async (current) => {
+            const preservedRouting = await resolveFreshSidebarRouting(
+              current,
+              () => loadAccounts(accountStoragePath),
+              { activeId: state.activeId, route: state.route },
+            )
+            return {
+              activeId: preservedRouting.activeId,
+              route: preservedRouting.route,
+              state: buildSidebarState(preservedRouting.freshStorage, {
+                ...options,
+                activeId: preservedRouting.activeId,
+                route: preservedRouting.route,
+              }),
+            }
+          },
+      onRoutingResolved: routingAuthoritative
+        ? undefined
+        : (routing) => {
+            lastSidebarRouting = routing
+          },
+    }).catch((error) =>
       logger.warn('sidebar', 'state write failed', {
         error: error instanceof Error ? error.message : String(error),
       }),
@@ -1023,6 +1172,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       route: lastSidebarRouting.route,
       mainAccessToken: access,
       mainRefreshToken: refresh,
+      routingAuthoritative: false,
     })
   }
 
@@ -1172,6 +1322,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
           route: lastSidebarRouting.route,
           mainAccessToken: auth.access,
           mainRefreshToken: auth.refresh,
+          routingAuthoritative: false,
         })
       } catch {
         // auth not yet available — sidebar will refresh on next request
@@ -1202,6 +1353,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       route: lastSidebarRouting.route,
       mainAccessToken: auth.access,
       mainRefreshToken: auth.refresh,
+      routingAuthoritative: false,
     })
 
     if (!desktopText || isTuiConnected(notice.sessionId)) return
@@ -1231,6 +1383,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
       route: lastSidebarRouting.route,
       mainAccessToken: auth.access,
       mainRefreshToken: auth.refresh,
+      routingAuthoritative: false,
     })
   }
 
@@ -1584,6 +1737,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
             route: lastSidebarRouting.route,
             mainAccessToken: auth.access,
             mainRefreshToken: auth.refresh,
+            routingAuthoritative: false,
           })
         } catch {
           // auth not yet available — sidebar will refresh on next request
@@ -1941,10 +2095,11 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
           ? await latestGetAuth().catch(() => undefined)
           : undefined
         writeSidebarState(cmdStorage, {
-          activeId: 'main',
-          route: 'main',
+          activeId: lastSidebarRouting.activeId,
+          route: lastSidebarRouting.route,
           mainAccessToken: cmdAuth?.access,
           mainRefreshToken: cmdAuth?.refresh,
+          routingAuthoritative: false,
         })
       }
       if (isTuiConnected(input.sessionID)) {
@@ -2360,11 +2515,14 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
           quotaManager.seedFallbacksFromAccounts(
             (initialStorage?.accounts ?? []).filter(isOAuthAccount),
           )
-          writeSidebarState(initialStorage, {
-            activeId: 'main',
-            route: 'main',
+          const initialSidebarRouting =
+            await resolveInitialSidebarRouting(accountStoragePath)
+          await writeSidebarState(initialSidebarRouting.freshStorage, {
+            activeId: initialSidebarRouting.activeId,
+            route: initialSidebarRouting.route,
             mainAccessToken: auth.access,
             mainRefreshToken: auth.refresh,
+            routingAuthoritative: false,
           })
 
           function isReplayableRequest(

--- a/packages/opencode/src/sidebar-state.ts
+++ b/packages/opencode/src/sidebar-state.ts
@@ -56,9 +56,20 @@ export interface SidebarState {
   lastUpdated: number
 }
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import {
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  rmdir,
+  stat,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { logger } from '@cortexkit/anthropic-auth-core'
 
 const STATE_FILE_ENV = 'OPENCODE_ANTHROPIC_AUTH_SIDEBAR_STATE_FILE'
 const DEFAULT_STATE_DIR = join(tmpdir(), 'opencode-anthropic-auth')
@@ -238,23 +249,329 @@ export function normalizeSidebarState(raw: unknown): SidebarState {
 
 let writeChain: Promise<void> = Promise.resolve()
 
-export async function getSidebarState(): Promise<SidebarState> {
+// Wait through ordinary contention while staying below the 2s stale-eviction window.
+const SIDEBAR_LOCK_BUDGET_MS = 1_000
+const SIDEBAR_LOCK_STALE_MS = 2_000
+const SIDEBAR_LOCK_RETRY_MIN_MS = 5
+const SIDEBAR_LOCK_RETRY_MAX_MS = 15
+
+interface SidebarStateWriteTestHooks {
+  afterMergeRead?: (stateFile: string) => void | Promise<void>
+  beforeRename?: (stateFile: string, tempFile: string) => void | Promise<void>
+  afterRename?: (stateFile: string) => void | Promise<void>
+  afterStaleLockStat?: (lockDir: string) => void | Promise<void>
+  onStaleLockClaimed?: (lockDir: string) => void | Promise<void>
+  onLockAcquired?: (lockDir: string) => void | Promise<void>
+  beforeReleaseDirectoryRemoval?: (lockDir: string) => void | Promise<void>
+  lockBudgetMs?: number
+  lockRetryMinMs?: number
+  lockRetryMaxMs?: number
+}
+
+let sidebarStateWriteTestHooks: SidebarStateWriteTestHooks | null = null
+
+export function __setSidebarStateWriteTestHooks(
+  hooks: SidebarStateWriteTestHooks | null,
+): void {
+  sidebarStateWriteTestHooks = hooks
+}
+
+// Boot-routing test hooks live here rather than in index.ts: the plugin entry
+// module must export nothing beyond the plugin factory — opencode's plugin
+// loader treats extra entry-point exports as plugin candidates and fails to
+// load the plugin (same incident class as the removed
+// __setBootProfileHydrationForTest export).
+export interface InitialSidebarRoutingTestHooks {
+  beforeSidebarRead?: () => void | Promise<void>
+  beforeStorageLoad?: () => void | Promise<void>
+  afterStorageLoad?: () => void | Promise<void>
+}
+
+let initialSidebarRoutingTestHooks: InitialSidebarRoutingTestHooks | null = null
+
+export function __setInitialSidebarRoutingTestHooks(
+  hooks: InitialSidebarRoutingTestHooks | null,
+): void {
+  initialSidebarRoutingTestHooks = hooks
+}
+
+export function getInitialSidebarRoutingTestHooks(): InitialSidebarRoutingTestHooks | null {
+  return initialSidebarRoutingTestHooks
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function acquireSidebarStateLock(stateFile: string): Promise<{
+  release: () => Promise<void>
+  ownsLock: () => Promise<boolean>
+} | null> {
+  const lockDir = `${stateFile}.lock`
+  const budgetMs =
+    sidebarStateWriteTestHooks?.lockBudgetMs ?? SIDEBAR_LOCK_BUDGET_MS
+  const retryMinMs =
+    sidebarStateWriteTestHooks?.lockRetryMinMs ?? SIDEBAR_LOCK_RETRY_MIN_MS
+  const retryMaxMs =
+    sidebarStateWriteTestHooks?.lockRetryMaxMs ?? SIDEBAR_LOCK_RETRY_MAX_MS
+  const deadline = Date.now() + budgetMs
+
+  while (true) {
+    try {
+      await mkdir(lockDir)
+      const ownerId = randomUUID()
+      const ownerFile = join(lockDir, ownerId)
+      await writeFile(ownerFile, '', {
+        encoding: 'utf8',
+        mode: 0o600,
+        flag: 'wx',
+      })
+      await sidebarStateWriteTestHooks?.onLockAcquired?.(lockDir)
+      return {
+        ownsLock: async () => {
+          try {
+            await stat(ownerFile)
+            return true
+          } catch {
+            return false
+          }
+        },
+        release: async () => {
+          // Unlinking this acquisition's unique file makes the filesystem reject
+          // a stale release after eviction handed the path to a successor.
+          try {
+            await unlink(ownerFile)
+          } catch {
+            return
+          }
+          await sidebarStateWriteTestHooks?.beforeReleaseDirectoryRemoval?.(
+            lockDir,
+          )
+          await rmdir(lockDir).catch(() => {})
+        },
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        logger.trace('sidebar', 'state lock unavailable; write skipped', {
+          stateFile,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return null
+      }
+    }
+
+    try {
+      const lockStat = await stat(lockDir)
+      if (Date.now() - lockStat.mtimeMs > SIDEBAR_LOCK_STALE_MS) {
+        await sidebarStateWriteTestHooks?.afterStaleLockStat?.(lockDir)
+        const evictedLockDir = `${lockDir}.evict-${process.pid}-${randomUUID()}`
+        try {
+          await rename(lockDir, evictedLockDir)
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
+          throw error
+        }
+        await sidebarStateWriteTestHooks?.onStaleLockClaimed?.(lockDir)
+        await rm(evictedLockDir, { recursive: true, force: true }).catch(
+          () => {},
+        )
+        continue
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
+      logger.trace('sidebar', 'state lock inspection failed; write skipped', {
+        stateFile,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return null
+    }
+
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) {
+      logger.warn('sidebar', 'lock budget exhausted, write skipped', {
+        stateFile,
+        budgetMs,
+      })
+      return null
+    }
+    const jitterMs =
+      retryMinMs + Math.floor(Math.random() * (retryMaxMs - retryMinMs + 1))
+    await sleep(Math.min(jitterMs, remainingMs))
+  }
+}
+
+export async function __acquireSidebarStateLockForTest(
+  stateFile: string,
+): Promise<(() => Promise<void>) | null> {
+  return (await acquireSidebarStateLock(stateFile))?.release ?? null
+}
+
+async function writeSidebarStateAtomic(
+  stateFile: string,
+  state: SidebarState,
+  ownsLock: () => Promise<boolean>,
+): Promise<'written' | 'lock-lost-before-rename' | 'lock-lost-after-rename'> {
+  const tempFile = `${stateFile}.${process.pid}.${randomUUID()}.tmp`
+  await writeFile(tempFile, JSON.stringify(state), {
+    encoding: 'utf8',
+    mode: 0o600,
+  })
   try {
-    const raw = await readFile(getSidebarStateFile(), 'utf8')
+    if (!(await ownsLock())) {
+      logger.trace('sidebar', 'state lock lost before rename; write aborted', {
+        stateFile,
+      })
+      await rm(tempFile, { force: true }).catch(() => {})
+      return 'lock-lost-before-rename'
+    }
+    await sidebarStateWriteTestHooks?.beforeRename?.(stateFile, tempFile)
+    // No production await separates this ownership fence from rename. A process
+    // freeze between the adjacent syscalls remains possible, so rename is also
+    // fenced from the other side below.
+    if (!(await ownsLock())) {
+      logger.trace('sidebar', 'state lock lost before rename; write aborted', {
+        stateFile,
+      })
+      await rm(tempFile, { force: true }).catch(() => {})
+      return 'lock-lost-before-rename'
+    }
+    await rename(tempFile, stateFile)
+    await sidebarStateWriteTestHooks?.afterRename?.(stateFile)
+    if (!(await ownsLock())) return 'lock-lost-after-rename'
+    return 'written'
+  } catch (error) {
+    await rm(tempFile, { force: true }).catch(() => {})
+    throw error
+  }
+}
+
+async function readSidebarState(stateFile: string): Promise<SidebarState> {
+  try {
+    const raw = await readFile(stateFile, 'utf8')
     return normalizeSidebarState(JSON.parse(raw))
   } catch {
     return DEFAULT_SIDEBAR_STATE
   }
 }
 
+export async function getSidebarState(): Promise<SidebarState> {
+  return readSidebarState(getSidebarStateFile())
+}
+
+export interface SidebarStateWriteOptions {
+  routingAuthoritative?: boolean
+  resolvePreservedRouting?: (current: SidebarState) =>
+    | (Pick<SidebarState, 'activeId' | 'route'> & {
+        state?: SidebarState
+      })
+    | undefined
+    | Promise<
+        | (Pick<SidebarState, 'activeId' | 'route'> & {
+            state?: SidebarState
+          })
+        | undefined
+      >
+  onRoutingResolved?: (
+    routing: Pick<SidebarState, 'activeId' | 'route'>,
+  ) => void
+}
+
 export async function setSidebarState(
   state: SidebarState,
   stateFile = getSidebarStateFile(),
+  options: SidebarStateWriteOptions = {},
 ): Promise<void> {
   writeChain = writeChain
     .then(async () => {
       await mkdir(dirname(stateFile), { recursive: true })
-      await writeFile(stateFile, JSON.stringify(state), 'utf8')
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const repairingPostRenameLoss = attempt === 1
+        const lock = await acquireSidebarStateLock(stateFile)
+        // Sidebar frames are display-only and refresh within seconds; dropping one
+        // is safer than clobbering routing state that may stay authoritative until
+        // another process handles its next request.
+        if (!lock) {
+          if (repairingPostRenameLoss) {
+            logger.warn(
+              'sidebar',
+              'post-rename repair lock unavailable; write skipped',
+              { stateFile },
+            )
+          }
+          return
+        }
+
+        let stateToWrite = state
+        let result:
+          | 'written'
+          | 'lock-lost-before-rename'
+          | 'lock-lost-after-rename'
+        try {
+          if (options.routingAuthoritative === false) {
+            const current = await readSidebarState(stateFile)
+            const preservedRouting =
+              await options.resolvePreservedRouting?.(current)
+            if (preservedRouting) {
+              const preservedState = preservedRouting.state ?? state
+              stateToWrite = {
+                ...preservedState,
+                activeId: preservedRouting.activeId,
+                route: preservedRouting.route,
+                lastUpdated: Math.max(
+                  preservedState.lastUpdated,
+                  current.lastUpdated,
+                ),
+              }
+            }
+            await sidebarStateWriteTestHooks?.afterMergeRead?.(stateFile)
+          } else if (repairingPostRenameLoss) {
+            const current = await readSidebarState(stateFile)
+            // A successor owns its fresh account/quota and recovery snapshots;
+            // this routing frame may only republish its decision and shared UI state.
+            stateToWrite = {
+              ...current,
+              activeId: state.activeId,
+              route: state.route,
+              relay: state.relay,
+              fastMode: state.fastMode,
+              cacheKeep: state.cacheKeep,
+              lastUpdated: Math.max(current.lastUpdated, state.lastUpdated),
+            }
+          }
+          result = await writeSidebarStateAtomic(
+            stateFile,
+            stateToWrite,
+            lock.ownsLock,
+          )
+        } finally {
+          await lock.release()
+        }
+
+        if (result === 'lock-lost-after-rename') {
+          if (repairingPostRenameLoss) {
+            logger.warn(
+              'sidebar',
+              'post-rename repair lost lock; write skipped',
+              { stateFile },
+            )
+            return
+          }
+          logger.warn(
+            'sidebar',
+            'state lock lost after rename; repairing write',
+            {
+              stateFile,
+            },
+          )
+          continue
+        }
+        if (result === 'lock-lost-before-rename') return
+        options.onRoutingResolved?.({
+          activeId: stateToWrite.activeId,
+          route: stateToWrite.route,
+        })
+        return
+      }
     })
     .catch(() => {
       // Best-effort — sidebar is non-critical

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -23,9 +23,13 @@ import {
   resetNotificationsForTest,
 } from '../rpc/notifications'
 import {
+  __setInitialSidebarRoutingTestHooks,
+  __setSidebarStateWriteTestHooks,
   drainSidebarWrites,
   getSidebarState,
   getSidebarStateFile,
+  resolveActiveAccount,
+  setSidebarState,
 } from '../sidebar-state'
 
 /** Extract the URL string from a fetch input (string, URL, or Request). */
@@ -164,6 +168,19 @@ async function waitForSidebarState(
   }
   const state = await getSidebarState()
   throw new Error(`Sidebar state did not match: ${JSON.stringify(state)}`)
+}
+
+async function seedSidebarRouting(
+  activeId: string,
+  route: string,
+  lastUpdated: number,
+) {
+  await setSidebarState({
+    ...(await getSidebarState()),
+    activeId,
+    route,
+    lastUpdated,
+  })
 }
 
 async function waitForMockCall(fn: { mock?: { calls: unknown[] } }) {
@@ -589,6 +606,8 @@ describe('auth.loader', () => {
     resetDumpState()
     resetFastModeState()
     resetNotificationsForTest()
+    __setInitialSidebarRoutingTestHooks(null)
+    __setSidebarStateWriteTestHooks(null)
     await useTempAccountFile(createFallbackStorage({ accounts: [] }))
   })
 
@@ -600,6 +619,8 @@ describe('auth.loader', () => {
     Math.random = originalRandom
     Date.now = originalDateNow
     resetNotificationsForTest()
+    __setInitialSidebarRoutingTestHooks(null)
+    __setSidebarStateWriteTestHooks(null)
     await drainSidebarWrites()
     restoreProcessTestFiles()
     if (tempConfigDir) {
@@ -631,6 +652,680 @@ describe('auth.loader', () => {
     )
     expect(result.apiKey).toBe('')
     expect(result.fetch).toBeFunction()
+  })
+
+  test('boot seeds fallback-first sidebar routing from the first enabled OAuth fallback', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({ routing: { mode: 'fallback-first' } }),
+    )
+
+    const plugin = await getPlugin()
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('fallback-1')
+    expect(state.route).toBe('fallback-first')
+  })
+
+  test('boot preserves fresh sidebar routing from another live session', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({
+        accounts: [
+          {
+            id: 'work-alt',
+            type: 'oauth',
+            access: 'work-access',
+            refresh: 'work-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+    )
+    await seedSidebarRouting('work-alt', 'fallback-first', Date.now())
+
+    const plugin = await getPlugin()
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('work-alt')
+    expect(state.route).toBe('fallback-first')
+  })
+
+  test('boot re-reads sidebar routing written after plugin creation', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({
+        accounts: [
+          {
+            id: 'work-alt',
+            type: 'oauth',
+            access: 'work-access',
+            refresh: 'work-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+    )
+
+    const plugin = await getPlugin()
+    await seedSidebarRouting('work-alt', 'fallback-first', Date.now())
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('work-alt')
+    expect(state.route).toBe('fallback-first')
+  })
+
+  test('boot reads preserved routing after its asynchronous storage load', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({
+        accounts: [
+          {
+            id: 'work-alt',
+            type: 'oauth',
+            access: 'work-access',
+            refresh: 'work-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+    )
+
+    let sequence = 0
+    let sidebarReadAt = 0
+    let storageLoadedAt = 0
+    let storageLoadStarted!: () => void
+    const storageLoadPaused = new Promise<void>((resolve) => {
+      storageLoadStarted = resolve
+    })
+    let resumeStorageLoad!: () => void
+    const storageLoadResumed = new Promise<void>((resolve) => {
+      resumeStorageLoad = resolve
+    })
+    __setInitialSidebarRoutingTestHooks({
+      beforeSidebarRead: () => {
+        sidebarReadAt = ++sequence
+      },
+      beforeStorageLoad: async () => {
+        storageLoadStarted()
+        await storageLoadResumed
+      },
+      afterStorageLoad: () => {
+        storageLoadedAt = ++sequence
+      },
+    })
+
+    const plugin = await getPlugin()
+    const loaderResult = plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await storageLoadPaused
+    await seedSidebarRouting('work-alt', 'fallback-first', Date.now())
+    resumeStorageLoad()
+    await loaderResult
+    await drainSidebarWrites()
+
+    expect(storageLoadedAt).toBeLessThan(sidebarReadAt)
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('work-alt')
+    expect(state.route).toBe('fallback-first')
+  })
+
+  test('boot write preserves routing written after its initial resolution', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({
+        accounts: [
+          {
+            id: 'work-alt',
+            type: 'oauth',
+            access: 'work-access',
+            refresh: 'work-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+    )
+    const foreignUpdatedAt = Date.now()
+    const resolvedByBoot = {
+      ...(await getSidebarState()),
+      activeId: 'main',
+      route: 'main',
+      lastUpdated: foreignUpdatedAt - 1000,
+    }
+    await seedSidebarRouting('work-alt', 'fallback-first', foreignUpdatedAt)
+
+    await setSidebarState(resolvedByBoot, getSidebarStateFile(), {
+      routingAuthoritative: false,
+      resolvePreservedRouting: (current) =>
+        current.activeId === 'work-alt'
+          ? { activeId: current.activeId, route: current.route }
+          : undefined,
+    })
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('work-alt')
+    expect(state.route).toBe('fallback-first')
+    expect(state.lastUpdated).toBe(foreignUpdatedAt)
+  })
+
+  test('boot preserves fresh routing for an account added after plugin creation', async () => {
+    const capturedStorage = createFallbackStorage({
+      accounts: [],
+      routing: { mode: 'fallback-first' },
+    })
+    expect(
+      capturedStorage.accounts.some((account) => account.id === 'work-2'),
+    ).toBe(false)
+    await useTempAccountFile(capturedStorage)
+    const plugin = await getPlugin()
+    await saveAccounts(
+      createFallbackStorage({
+        routing: { mode: 'fallback-first' },
+        accounts: [
+          {
+            id: 'work-2',
+            type: 'oauth',
+            access: 'work-2-access',
+            refresh: 'work-2-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+    )
+    expect(
+      (await loadAccounts())?.accounts.some(
+        (account) => account.id === 'work-2',
+      ),
+    ).toBe(true)
+    await seedSidebarRouting('work-2', 'fallback-first', Date.now())
+
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('work-2')
+    expect(state.route).toBe('fallback-first')
+    expect(state.fallbacks.map((account) => account.id)).toContain('work-2')
+    expect(resolveActiveAccount(state).id).toBe('work-2')
+  })
+
+  test('stale main routing write carries forward accounts added after plugin creation', async () => {
+    const capturedStorage = createFallbackStorage({ accounts: [] })
+    await useTempAccountFile(capturedStorage)
+    const plugin = await getPlugin()
+    await saveAccounts(
+      createFallbackStorage({
+        accounts: [
+          {
+            id: 'work-fresh',
+            type: 'oauth',
+            access: 'work-fresh-access',
+            refresh: 'work-fresh-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+    )
+    await seedSidebarRouting('main', 'main', Date.now())
+
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('main')
+    expect(state.route).toBe('main')
+    expect(state.fallbacks.map((account) => account.id)).toContain('work-fresh')
+  })
+
+  test('stale writer does not resurrect a deleted active account', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({
+        routing: { mode: 'fallback-first' },
+        accounts: [
+          {
+            id: 'work-deleted',
+            type: 'oauth',
+            access: 'work-deleted-access',
+            refresh: 'work-deleted-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+    )
+    const plugin = await getPlugin()
+    // v1.16.0's mergeAccountsForSave unions existing+incoming accounts, so a
+    // deletion must be declared explicitly via removedAccountIds — a plain
+    // save without the account no longer removes it.
+    await saveAccounts(
+      createFallbackStorage({
+        routing: { mode: 'fallback-first' },
+        accounts: [
+          {
+            id: 'work-current',
+            type: 'oauth',
+            access: 'work-current-access',
+            refresh: 'work-current-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+      undefined,
+      { removedAccountIds: ['work-deleted'] },
+    )
+    await seedSidebarRouting('work-deleted', 'fallback-first', Date.now())
+
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('work-current')
+    expect(state.route).toBe('fallback-first')
+    expect(state.fallbacks.map((account) => account.id)).toEqual([
+      'work-current',
+    ])
+  })
+
+  test('boot ignores stale sidebar routing and derives fallback-first routing', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({ routing: { mode: 'fallback-first' } }),
+    )
+    await seedSidebarRouting('main', 'main', Date.now() - 11 * 60 * 1000)
+
+    const plugin = await getPlugin()
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('fallback-1')
+    expect(state.route).toBe('fallback-first')
+  })
+
+  test('boot ignores fresh sidebar routing for an unknown account', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({ routing: { mode: 'fallback-first' } }),
+    )
+    await seedSidebarRouting('removed-account', 'fallback-first', Date.now())
+
+    const plugin = await getPlugin()
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('fallback-1')
+    expect(state.route).toBe('fallback-first')
+  })
+
+  test('boot keeps main-first sidebar routing on main', async () => {
+    await useTempAccountFile(createFallbackStorage())
+
+    const plugin = await getPlugin()
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('main')
+    expect(state.route).toBe('main')
+  })
+
+  async function runQuotaRefreshWithFailedStorageReload(
+    clearExistingRouting: boolean,
+  ) {
+    await useTempAccountFile(
+      createFallbackStorage({ routing: { mode: 'fallback-first' } }),
+    )
+    globalThis.fetch = mock((input: string | URL | Request) => {
+      if (extractUrl(input).includes('/api/oauth/usage')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              five_hour: { utilization: 0.25 },
+              seven_day: { utilization: 0.3 },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await drainSidebarWrites()
+    if (clearExistingRouting) {
+      const current = await getSidebarState()
+      await setSidebarState({
+        ...current,
+        activeId: undefined,
+        route: 'main',
+        lastUpdated: Date.now(),
+      })
+    } else {
+      await seedSidebarRouting('fallback-1', 'fallback-first', Date.now())
+    }
+
+    let signalBlocked!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      signalBlocked = resolve
+    })
+    let releaseWrite!: () => void
+    const released = new Promise<void>((resolve) => {
+      releaseWrite = resolve
+    })
+    let shouldBlock = true
+    __setSidebarStateWriteTestHooks({
+      beforeRename: async () => {
+        if (!shouldBlock) return
+        shouldBlock = false
+        signalBlocked()
+        await released
+      },
+    })
+
+    const blockingWrite = setSidebarState(await getSidebarState())
+    await blocked
+    try {
+      await expectHandledCommandResponse(
+        plugin['command.execute.before']({
+          command: 'claude-quota',
+          arguments: '',
+          sessionID: 'session-1',
+        }),
+      )
+      const accountFile = process.env.OPENCODE_ANTHROPIC_AUTH_FILE
+      if (!accountFile) throw new Error('Expected isolated account file')
+      await rm(accountFile)
+      await mkdir(accountFile)
+    } finally {
+      releaseWrite()
+    }
+    await blockingWrite
+    await drainSidebarWrites()
+    __setSidebarStateWriteTestHooks(null)
+    return getSidebarState()
+  }
+
+  test('quota refresh preserves existing fallback routing when storage reload fails', async () => {
+    const state = await runQuotaRefreshWithFailedStorageReload(false)
+    expect(state.activeId).toBe('fallback-1')
+    expect(state.route).toBe('fallback-first')
+  })
+
+  test('quota refresh uses supplied routing when storage reload fails without existing routing', async () => {
+    const state = await runQuotaRefreshWithFailedStorageReload(true)
+    expect(state.activeId).toBe('fallback-1')
+    expect(state.route).toBe('fallback-first')
+  })
+
+  test('/claude-quota preserves the last sidebar routing decision', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({ routing: { mode: 'fallback-first' } }),
+    )
+    globalThis.fetch = mock((input: string | URL | Request) => {
+      if (extractUrl(input).includes('/api/oauth/usage')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              five_hour: { utilization: 0.25 },
+              seven_day: { utilization: 0.3 },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+
+    await expectHandledCommandResponse(
+      plugin['command.execute.before']({
+        command: 'claude-quota',
+        arguments: '',
+        sessionID: 'session-1',
+      }),
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('fallback-1')
+    expect(state.route).toBe('fallback-first')
+  })
+
+  test('/claude-quota preserves fresher routing from another session', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({
+        routing: { mode: 'fallback-first' },
+        accounts: [
+          {
+            id: 'fallback-a',
+            type: 'oauth',
+            access: 'fallback-a-access',
+            refresh: 'fallback-a-refresh',
+            expires: Date.now() + 100000,
+          },
+          {
+            id: 'fallback-b',
+            type: 'oauth',
+            access: 'fallback-b-access',
+            refresh: 'fallback-b-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+    )
+    globalThis.fetch = mock((input: string | URL | Request) => {
+      if (extractUrl(input).includes('/api/oauth/usage')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              five_hour: { utilization: 0.25 },
+              seven_day: { utilization: 0.3 },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await seedSidebarRouting('fallback-b', 'fallback-first', Date.now())
+
+    await expectHandledCommandResponse(
+      plugin['command.execute.before']({
+        command: 'claude-quota',
+        arguments: '',
+        sessionID: 'session-1',
+      }),
+    )
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('fallback-b')
+    expect(state.route).toBe('fallback-first')
+
+    await seedSidebarRouting(
+      'fallback-b',
+      'fallback-first',
+      Date.now() - 11 * 60 * 1000,
+    )
+    await expectHandledCommandResponse(
+      plugin['command.execute.before']({
+        command: 'claude-quota',
+        arguments: '',
+        sessionID: 'session-1',
+      }),
+    )
+    await drainSidebarWrites()
+
+    const stateAfterStaleFile = await getSidebarState()
+    expect(stateAfterStaleFile.activeId).toBe('fallback-b')
+    expect(stateAfterStaleFile.route).toBe('fallback-first')
+  })
+
+  test('real routing decisions overwrite fresh routing from another session', async () => {
+    await useTempAccountFile(
+      createFallbackStorage({
+        quota: { enabled: false },
+        accounts: [
+          {
+            id: 'work-alt',
+            type: 'oauth',
+            access: 'work-access',
+            refresh: 'work-refresh',
+            expires: Date.now() + 100000,
+          },
+        ],
+      }),
+    )
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response('{}', { status: 200 })),
+    ) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    await seedSidebarRouting('work-alt', 'fallback-first', Date.now())
+
+    await result.fetch(MESSAGES_URL, {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'claude-opus-4-8',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    })
+    await drainSidebarWrites()
+
+    const state = await getSidebarState()
+    expect(state.activeId).toBe('main')
+    expect(state.route).toBe('main')
   })
 
   test('dumps direct Anthropic requests when relay is disabled', async () => {
@@ -4364,8 +5059,13 @@ describe('auth.loader', () => {
       })
 
       expect(second).toBe('message-2')
-      // Background quota refresh involves file-lock I/O; wait for it to fire.
-      await new Promise((r) => setTimeout(r, 50))
+      // Background quota refresh involves file-lock I/O; poll until it fires
+      // instead of sleeping a fixed interval (flaky under CI load). Date.now
+      // is mocked here, so the deadline uses the real clock.
+      const refreshDeadline = originalDateNow() + 5000
+      while (quotaCalls < 2 && originalDateNow() < refreshDeadline) {
+        await new Promise((r) => setTimeout(r, 10))
+      }
       expect(quotaCalls).toBe(2)
       expect(messageCalls).toBe(2)
     } finally {

--- a/packages/opencode/src/tests/sidebar-state.test.ts
+++ b/packages/opencode/src/tests/sidebar-state.test.ts
@@ -1,11 +1,23 @@
 import { afterAll, describe, expect, test } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  __acquireSidebarStateLockForTest,
+  __setSidebarStateWriteTestHooks,
   type AccountQuota,
   computeQuotaPacing,
   DEFAULT_SIDEBAR_STATE,
+  drainSidebarWrites,
   FIVE_HOUR_MS,
   getCollapsedQuotaSummary,
   getFableRecoverySummary,
@@ -14,7 +26,25 @@ import {
   resolveActiveAccount,
   SEVEN_DAY_MS,
   type SidebarState,
+  setSidebarState,
 } from '../sidebar-state'
+
+function sidebarTestPath(name: string): string {
+  return join(
+    tmpdir(),
+    `opencode-auth-sidebar-${name}-${process.pid}-${randomUUID()}`,
+    'sidebar-state.json',
+  )
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
 
 const quota = (used: number): AccountQuota => ({
   five_hour: { usedPercent: used, remainingPercent: 100 - used },
@@ -776,5 +806,554 @@ describe('getSidebarState malformed file round-trip', () => {
     await writeFile(testFile, JSON.stringify(valid))
     const state = await getSidebarState()
     expect(state).toEqual(valid)
+  })
+})
+
+describe('setSidebarState cross-process writes', () => {
+  test('does not clobber a successor after losing the lock before rename', async () => {
+    const stateFile = sidebarTestPath('lost-before-rename')
+    const stateDir = join(stateFile, '..')
+    const lockDir = `${stateFile}.lock`
+    const initial = make({
+      activeId: 'initial-routing',
+      route: 'initial-route',
+      lastUpdated: 100,
+    })
+    const successor = make({
+      activeId: 'successor-routing',
+      route: 'successor-route',
+      lastUpdated: 300,
+    })
+    const staleWriter = make({ fastMode: true, lastUpdated: 200 })
+    await mkdir(stateDir, { recursive: true })
+    await writeFile(stateFile, JSON.stringify(initial))
+
+    let child: ReturnType<typeof Bun.spawn> | undefined
+    let paused = false
+    __setSidebarStateWriteTestHooks({
+      beforeRename: async () => {
+        if (paused) return
+        paused = true
+        const stale = new Date(Date.now() - 3_000)
+        await utimes(lockDir, stale, stale)
+        const moduleUrl = new URL('../sidebar-state.ts', import.meta.url).href
+        child = Bun.spawn([
+          process.execPath,
+          '--eval',
+          `import { setSidebarState } from ${JSON.stringify(moduleUrl)}; await setSidebarState(${JSON.stringify(successor)}, ${JSON.stringify(stateFile)})`,
+        ])
+        expect(await child.exited).toBe(0)
+      },
+    })
+
+    try {
+      await setSidebarState(staleWriter, stateFile, {
+        routingAuthoritative: false,
+        resolvePreservedRouting: (current) => ({
+          activeId: current.activeId,
+          route: current.route,
+        }),
+      })
+      const written = JSON.parse(await readFile(stateFile, 'utf8'))
+      expect(written.activeId).toBe('successor-routing')
+      expect(written.route).toBe('successor-route')
+    } finally {
+      __setSidebarStateWriteTestHooks(null)
+      child?.kill()
+      await rm(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  for (const routingAuthoritative of [true, false]) {
+    test(`repairs an ${routingAuthoritative ? 'authoritative' : 'non-authoritative'} write after losing ownership post-rename`, async () => {
+      const stateFile = sidebarTestPath(
+        `lost-after-rename-${routingAuthoritative ? 'authoritative' : 'merge'}`,
+      )
+      const stateDir = join(stateFile, '..')
+      const lockDir = `${stateFile}.lock`
+      const initial = make({
+        activeId: 'initial-routing',
+        route: 'initial-route',
+        main: { quota: quota(20) },
+        fastMode: false,
+        lastUpdated: 100,
+      })
+      const successor = make({
+        activeId: 'successor-routing',
+        route: 'successor-route',
+        main: { quota: quota(80) },
+        fastMode: false,
+        lastUpdated: 300,
+      })
+      const staleWriter = make({
+        activeId: 'writer-routing',
+        route: 'writer-route',
+        main: { quota: quota(10) },
+        fastMode: true,
+        lastUpdated: 200,
+      })
+      await mkdir(stateDir, { recursive: true })
+      await writeFile(stateFile, JSON.stringify(initial))
+
+      let child: ReturnType<typeof Bun.spawn> | undefined
+      let paused = false
+      __setSidebarStateWriteTestHooks({
+        afterRename: async () => {
+          if (paused) return
+          paused = true
+          const stale = new Date(Date.now() - 3_000)
+          await utimes(lockDir, stale, stale)
+          const moduleUrl = new URL('../sidebar-state.ts', import.meta.url).href
+          child = Bun.spawn([
+            process.execPath,
+            '--eval',
+            `import { setSidebarState } from ${JSON.stringify(moduleUrl)}; await setSidebarState(${JSON.stringify(successor)}, ${JSON.stringify(stateFile)})`,
+          ])
+          expect(await child.exited).toBe(0)
+        },
+      })
+
+      try {
+        await setSidebarState(staleWriter, stateFile, {
+          routingAuthoritative,
+          resolvePreservedRouting: routingAuthoritative
+            ? undefined
+            : (current) => ({
+                activeId: current.activeId,
+                route: current.route,
+                state: {
+                  ...staleWriter,
+                  main: current.main,
+                  fallbacks: current.fallbacks,
+                },
+              }),
+        })
+        const settled = await Promise.race([
+          drainSidebarWrites().then(() => true),
+          Bun.sleep(100).then(() => false),
+        ])
+        expect(settled).toBe(true)
+        const written = JSON.parse(await readFile(stateFile, 'utf8'))
+        expect(written.activeId).toBe(
+          routingAuthoritative ? 'writer-routing' : 'successor-routing',
+        )
+        expect(written.route).toBe(
+          routingAuthoritative ? 'writer-route' : 'successor-route',
+        )
+        expect(written.main.quota.five_hour.usedPercent).toBe(80)
+        expect(written.fastMode).toBe(true)
+      } finally {
+        __setSidebarStateWriteTestHooks(null)
+        child?.kill()
+        await rm(stateDir, { recursive: true, force: true })
+      }
+    })
+  }
+
+  for (const routingAuthoritative of [true, false]) {
+    test(`skips ${routingAuthoritative ? 'authoritative' : 'non-authoritative'} writes when the lock budget is exhausted`, async () => {
+      const stateFile = sidebarTestPath(
+        routingAuthoritative
+          ? 'lock-budget-authoritative'
+          : 'lock-budget-merge',
+      )
+      const stateDir = join(stateFile, '..')
+      const lockDir = `${stateFile}.lock`
+      const initial = make({
+        activeId: 'foreign-routing',
+        route: 'foreign-route',
+        fastMode: false,
+        lastUpdated: 300,
+      })
+      const staleWriter = make({
+        activeId: 'stale-routing',
+        route: 'stale-route',
+        fastMode: true,
+        lastUpdated: 200,
+      })
+      const originalContents = JSON.stringify(initial)
+      await mkdir(stateDir, { recursive: true })
+      await writeFile(stateFile, originalContents)
+      await mkdir(lockDir)
+      __setSidebarStateWriteTestHooks({
+        lockBudgetMs: 20,
+        lockRetryMinMs: 1,
+        lockRetryMaxMs: 1,
+      })
+
+      try {
+        await setSidebarState(staleWriter, stateFile, {
+          routingAuthoritative,
+          resolvePreservedRouting: (current) => ({
+            activeId: current.activeId,
+            route: current.route,
+          }),
+        })
+        const drained = await Promise.race([
+          drainSidebarWrites().then(() => true),
+          Bun.sleep(100).then(() => false),
+        ])
+        expect(drained).toBe(true)
+        expect(await readFile(stateFile, 'utf8')).toBe(originalContents)
+      } finally {
+        __setSidebarStateWriteTestHooks(null)
+        await rm(stateDir, { recursive: true, force: true })
+      }
+    })
+  }
+
+  test('preserves an authoritative write from another process during a non-authoritative merge', async () => {
+    const stateFile = sidebarTestPath('race')
+    const stateDir = join(stateFile, '..')
+    const initial = make({
+      activeId: 'old-routing',
+      route: 'old-route',
+      lastUpdated: 100,
+    })
+    const foreign = make({
+      activeId: 'foreign-routing',
+      route: 'foreign-route',
+      lastUpdated: 300,
+    })
+    const nonAuthoritative = make({
+      activeId: 'stale-routing',
+      route: 'stale-route',
+      lastUpdated: 200,
+    })
+    await mkdir(stateDir, { recursive: true })
+    await writeFile(stateFile, JSON.stringify(initial))
+
+    let child: ReturnType<typeof Bun.spawn> | undefined
+    __setSidebarStateWriteTestHooks({
+      afterMergeRead: async () => {
+        const moduleUrl = new URL('../sidebar-state.ts', import.meta.url).href
+        const script = `
+          import { setSidebarState } from ${JSON.stringify(moduleUrl)}
+          await setSidebarState(${JSON.stringify(foreign)}, ${JSON.stringify(stateFile)})
+        `
+        child = Bun.spawn([process.execPath, '--eval', script], {
+          stdout: 'pipe',
+          stderr: 'pipe',
+        })
+        await Promise.race([
+          child.exited,
+          new Promise((resolve) => setTimeout(resolve, 50)),
+        ])
+      },
+    })
+
+    try {
+      await setSidebarState(nonAuthoritative, stateFile, {
+        routingAuthoritative: false,
+        resolvePreservedRouting: (current) => ({
+          activeId: current.activeId,
+          route: current.route,
+        }),
+      })
+      expect(child).toBeDefined()
+      expect(await child!.exited).toBe(0)
+      const written = JSON.parse(await readFile(stateFile, 'utf8'))
+      expect(written.activeId).toBe('foreign-routing')
+      expect(written.route).toBe('foreign-route')
+    } finally {
+      __setSidebarStateWriteTestHooks(null)
+      child?.kill()
+      await rm(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  test('allows only one waiter to evict and replace a stale lock', async () => {
+    type RaceHooks = Parameters<typeof __setSidebarStateWriteTestHooks>[0] & {
+      afterStaleLockStat?: () => void | Promise<void>
+      onStaleLockClaimed?: () => void | Promise<void>
+      onLockAcquired?: () => void | Promise<void>
+    }
+    const stateFile = sidebarTestPath('stale-lock-race')
+    const stateDir = join(stateFile, '..')
+    const lockDir = `${stateFile}.lock`
+    await mkdir(lockDir, { recursive: true })
+    const stale = new Date(Date.now() - 3_000)
+    await utimes(lockDir, stale, stale)
+
+    let staleStats = 0
+    let releaseStaleStats!: () => void
+    const bothSawStale = new Promise<void>((resolve) => {
+      releaseStaleStats = resolve
+    })
+    let staleClaims = 0
+    let acquisitions = 0
+    const hooks: RaceHooks = {
+      lockBudgetMs: 30,
+      lockRetryMinMs: 1,
+      lockRetryMaxMs: 1,
+      afterStaleLockStat: async () => {
+        staleStats++
+        if (staleStats === 2) releaseStaleStats()
+        await bothSawStale
+      },
+      onStaleLockClaimed: () => {
+        staleClaims++
+      },
+      onLockAcquired: () => {
+        acquisitions++
+      },
+    }
+    ;(__setSidebarStateWriteTestHooks as (hooks: RaceHooks | null) => void)(
+      hooks,
+    )
+
+    let firstRelease: (() => Promise<void>) | null = null
+    let secondRelease: (() => Promise<void>) | null = null
+    try {
+      ;[firstRelease, secondRelease] = await Promise.all([
+        __acquireSidebarStateLockForTest(stateFile),
+        __acquireSidebarStateLockForTest(stateFile),
+      ])
+      expect(staleClaims).toBe(1)
+      expect(acquisitions).toBe(1)
+      expect([firstRelease, secondRelease].filter(Boolean)).toHaveLength(1)
+    } finally {
+      await firstRelease?.()
+      await secondRelease?.()
+      __setSidebarStateWriteTestHooks(null)
+      await rm(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  test('an evicted owner cannot release its replacement lock', async () => {
+    const stateFile = sidebarTestPath('release-handoff')
+    const stateDir = join(stateFile, '..')
+    const lockDir = `${stateFile}.lock`
+    await mkdir(stateDir, { recursive: true })
+
+    const firstRelease = await __acquireSidebarStateLockForTest(stateFile)
+    expect(firstRelease).toBeFunction()
+    const stale = new Date(Date.now() - 3_000)
+    await utimes(lockDir, stale, stale)
+    const secondRelease = await __acquireSidebarStateLockForTest(stateFile)
+    expect(secondRelease).toBeFunction()
+
+    try {
+      await firstRelease?.()
+      expect(await pathExists(lockDir)).toBe(true)
+      await secondRelease?.()
+      expect(await pathExists(lockDir)).toBe(false)
+    } finally {
+      await secondRelease?.()
+      await rm(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a suspended release cannot remove a replacement lock', async () => {
+    type ReleaseHooks = Parameters<
+      typeof __setSidebarStateWriteTestHooks
+    >[0] & {
+      beforeReleaseDirectoryRemoval?: () => void | Promise<void>
+    }
+    const stateFile = sidebarTestPath('release-three-writer-handoff')
+    const stateDir = join(stateFile, '..')
+    const lockDir = `${stateFile}.lock`
+    await mkdir(stateDir, { recursive: true })
+
+    let releasePaused!: () => void
+    const paused = new Promise<void>((resolve) => {
+      releasePaused = resolve
+    })
+    let resumeRelease!: () => void
+    const resumed = new Promise<void>((resolve) => {
+      resumeRelease = resolve
+    })
+    const hooks: ReleaseHooks = {
+      beforeReleaseDirectoryRemoval: async () => {
+        releasePaused()
+        await resumed
+      },
+    }
+    ;(__setSidebarStateWriteTestHooks as (hooks: ReleaseHooks | null) => void)(
+      hooks,
+    )
+
+    let firstRelease: (() => Promise<void>) | null = null
+    let secondRelease: (() => Promise<void>) | null = null
+    let thirdRelease: (() => Promise<void>) | null = null
+    try {
+      firstRelease = await __acquireSidebarStateLockForTest(stateFile)
+      expect(firstRelease).toBeFunction()
+      const firstReleaseResult = firstRelease!()
+      const didPause = await Promise.race([
+        paused.then(() => true),
+        Bun.sleep(20).then(() => false),
+      ])
+      expect(didPause).toBe(true)
+      if (!didPause) {
+        resumeRelease()
+        await firstReleaseResult
+        return
+      }
+
+      const stale = new Date(Date.now() - 3_000)
+      await utimes(lockDir, stale, stale)
+      secondRelease = await __acquireSidebarStateLockForTest(stateFile)
+      expect(secondRelease).toBeFunction()
+      resumeRelease()
+      await firstReleaseResult
+
+      ;(
+        __setSidebarStateWriteTestHooks as (hooks: ReleaseHooks | null) => void
+      )({
+        lockBudgetMs: 20,
+        lockRetryMinMs: 5,
+        lockRetryMaxMs: 5,
+      })
+      thirdRelease = await __acquireSidebarStateLockForTest(stateFile)
+      expect(thirdRelease).toBeNull()
+      expect(await pathExists(lockDir)).toBe(true)
+    } finally {
+      resumeRelease()
+      await thirdRelease?.()
+      await secondRelease?.()
+      __setSidebarStateWriteTestHooks(null)
+      await rm(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  test('release removes the lock owned by its acquisition token', async () => {
+    const stateFile = sidebarTestPath('release-owned')
+    const stateDir = join(stateFile, '..')
+    const lockDir = `${stateFile}.lock`
+    await mkdir(stateDir, { recursive: true })
+    const release = await __acquireSidebarStateLockForTest(stateFile)
+
+    try {
+      expect(release).toBeFunction()
+      const ownerFiles = await readdir(lockDir)
+      expect(ownerFiles).toHaveLength(1)
+      expect(ownerFiles[0]).not.toBe('owner')
+      await release?.()
+      expect(await pathExists(lockDir)).toBe(false)
+    } finally {
+      await rm(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  test('release leaves the lock untouched when its owner file is missing', async () => {
+    const stateFile = sidebarTestPath('release-missing-owner')
+    const stateDir = join(stateFile, '..')
+    const lockDir = `${stateFile}.lock`
+    await mkdir(stateDir, { recursive: true })
+    const release = await __acquireSidebarStateLockForTest(stateFile)
+    expect(release).toBeFunction()
+    const [ownerFile] = await readdir(lockDir)
+    expect(ownerFile).toBeDefined()
+    await rm(join(lockDir, ownerFile!), { force: true })
+
+    try {
+      await release?.()
+      expect(await pathExists(lockDir)).toBe(true)
+    } finally {
+      await rm(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  test('evicts a stale lock and writes the state', async () => {
+    const stateFile = sidebarTestPath('stale-lock')
+    const stateDir = join(stateFile, '..')
+    const lockDir = `${stateFile}.lock`
+    await mkdir(lockDir, { recursive: true })
+    const stale = new Date(Date.now() - 3_000)
+    await utimes(lockDir, stale, stale)
+
+    try {
+      await setSidebarState(
+        make({ activeId: 'fresh', route: 'fresh' }),
+        stateFile,
+      )
+      const written = JSON.parse(await readFile(stateFile, 'utf8'))
+      expect(written.activeId).toBe('fresh')
+      expect(await readdir(stateDir)).not.toContain('sidebar-state.json.lock')
+    } finally {
+      await rm(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  test('keeps the visible file complete until an atomic rename publishes the new state', async () => {
+    const stateFile = sidebarTestPath('atomic')
+    const stateDir = join(stateFile, '..')
+    const initial = make({ activeId: 'initial', route: 'initial' })
+    const next = make({ activeId: 'next', route: 'next' })
+    await mkdir(stateDir, { recursive: true })
+    await writeFile(stateFile, JSON.stringify(initial))
+
+    let enteredRename!: () => void
+    const renameReady = new Promise<void>((resolve) => {
+      enteredRename = resolve
+    })
+    let releaseRename!: () => void
+    const renameReleased = new Promise<void>((resolve) => {
+      releaseRename = resolve
+    })
+    __setSidebarStateWriteTestHooks({
+      beforeRename: async () => {
+        enteredRename()
+        await renameReleased
+      },
+    })
+
+    try {
+      const write = setSidebarState(next, stateFile)
+      await renameReady
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const visible = JSON.parse(await readFile(stateFile, 'utf8'))
+        expect(visible.activeId).toBe('initial')
+      }
+      const tempName = (await readdir(stateDir)).find((name) =>
+        name.endsWith('.tmp'),
+      )
+      expect(tempName).toBeDefined()
+      const tempContents = await readFile(join(stateDir, tempName!), 'utf8')
+      expect(() => JSON.parse(tempContents)).not.toThrow()
+      releaseRename()
+      await write
+      const visible = JSON.parse(await readFile(stateFile, 'utf8'))
+      expect(visible.activeId).toBe('next')
+    } finally {
+      releaseRename()
+      __setSidebarStateWriteTestHooks(null)
+      await rm(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  test('aborts a write after its lock is evicted before rename', async () => {
+    const stateFile = sidebarTestPath('lost-before-rename')
+    const stateDir = join(stateFile, '..')
+    const lockDir = `${stateFile}.lock`
+    const initial = make({ activeId: 'initial', route: 'initial' })
+    const staleWriter = make({ activeId: 'stale-writer', route: 'stale' })
+    const replacement = make({ activeId: 'replacement', route: 'replacement' })
+    await mkdir(stateDir, { recursive: true })
+    await writeFile(stateFile, JSON.stringify(initial))
+
+    const replacementLock: {
+      release: (() => Promise<void>) | null
+    } = { release: null }
+    __setSidebarStateWriteTestHooks({
+      beforeRename: async () => {
+        const stale = new Date(Date.now() - 3_000)
+        await utimes(lockDir, stale, stale)
+        replacementLock.release =
+          await __acquireSidebarStateLockForTest(stateFile)
+        expect(replacementLock.release).toBeFunction()
+        await writeFile(stateFile, JSON.stringify(replacement))
+      },
+    })
+
+    try {
+      await setSidebarState(staleWriter, stateFile)
+      expect(JSON.parse(await readFile(stateFile, 'utf8'))).toEqual(replacement)
+    } finally {
+      __setSidebarStateWriteTestHooks(null)
+      await replacementLock.release?.()
+      await rm(stateDir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
On boot the sidebar always showed `main` as the active account, even with `routing.mode: fallback-first` — and a freshly launched session clobbered the shared sidebar-state file's `activeId` that another live session's routing had legitimately written. The display only self-corrected after the new session's first real request.

Three contributing sites in `packages/opencode/src/index.ts`:

- the auth-loader boot seed hardcoded `activeId: 'main', route: 'main'`
- the in-process `lastSidebarRouting` default also started at `'main'`, so background quota refreshes kept re-writing it
- one command path hardcoded the same values, so running a `/claude-*` command reset the displayed active account

## Fix

New `resolveInitialSidebarRouting(storage)` used to seed both the boot write and `lastSidebarRouting`:

1. If the existing sidebar file has a fresh `activeId` (recent `lastUpdated`, id still present among enabled accounts), preserve it — that's another live session's routing decision.
2. Otherwise derive from the routing mode: `fallback-first` with at least one enabled OAuth fallback → that fallback, else `main`.

The command path now reuses `lastSidebarRouting` (the pattern the mutation-refresh path already used). Real routing decisions keep overwriting `lastSidebarRouting` exactly as before.

## Verification

Six red-first tests: fallback-first boot derives the fallback; a fresh cross-session `activeId` is preserved; stale or invalid file state falls back to derivation; `/claude-quota` no longer resets the active account; main-first boot unchanged. Full suite: core 37 / opencode 812 / pi 48, typecheck + biome clean, repo-root `bun run test` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786824974&installation_id=135454708&pr_number=128&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F128&signature=7954fc99db2b9a507c04324c8c71a1cb7c1551b1b2ada28652550ca0936293fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the sidebar’s active account on boot from routing mode and preserves a live session’s selection across boots and display-only refreshes. Cross-process writes are serialized and atomic to prevent clobbering.

- **Bug Fixes**
  - Boot resolves routing after loading accounts, then reads the sidebar: preserve a fresh (≤10m) valid `activeId`; otherwise derive from routing (`fallback-first` → first enabled OAuth, else `main`). Ignores stale/unknown ids and keeps existing routing if storage reload fails.
  - Display-only writes (boot, quota refresh, notice, command) are non‑authoritative: re-read the file and fresh accounts, keep newer routing, carry forward latest quota/accounts, and update in‑process `lastSidebarRouting` when preserved. Real routing decisions stay authoritative; commands now reuse `lastSidebarRouting`.
  - Cross-process writes use a per-file directory lock with owner tokens and jittered retries; stale locks are evicted via atomic rename. Writes use temp files and atomic rename with ownership checks before/after; on post-rename loss, one bounded repair republishes routing/UI fields into the successor’s fresh state. Skips when lock budget is exhausted; never writes unlocked.

<sup>Written for commit d6d3de6960e7ffedcc04dcfabf0acb210a1e5a84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR keeps sidebar routing aligned with the current routing mode and live session state. The main changes are:

- Derive boot routing from fresh account storage.
- Preserve fresh, valid routing from another session.
- Reconcile display-only writes under a cross-process lock.
- Publish sidebar state atomically and handle lock loss.
- Add tests for boot, refresh, command, and concurrency paths.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated boot and display-only paths preserve current shared routing.
- Lock ownership and publication races have focused tests.
- No blocking issues were found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/opencode/src/index.ts | Derives and validates sidebar routing, preserves routing on reload failure, and marks display-only writes as non-authoritative. |
| packages/opencode/src/sidebar-state.ts | Adds cross-process locking, atomic state publication, ownership checks, and bounded lock-loss repair. |
| packages/opencode/src/tests/index.test.ts | Covers boot derivation, cross-session preservation, invalid state, reload failures, commands, and authoritative routing. |
| packages/opencode/src/tests/sidebar-state.test.ts | Covers lock contention, stale eviction, ownership handoff, skipped writes, atomic publication, and lock-loss races. |

</details>

<sub>Reviews (17): Last reviewed commit: ["fix(opencode): derive boot sidebar activ..."](https://github.com/cortexkit/anthropic-auth/commit/d6d3de6960e7ffedcc04dcfabf0acb210a1e5a84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44908608)</sub>

**Context used:**

- Context used - captures/AGENTS.md ([source](https://app.greptile.com/cortexkit/github/cortexkit/anthropic-auth/-/custom-context?memory=5bff518c-95bc-4c01-a7a3-295576599e9c))
- Context used - AGENTS.md ([source](https://app.greptile.com/cortexkit/github/cortexkit/anthropic-auth/-/custom-context?memory=f5d9c3e7-5536-4afd-9d61-28fa37788920))

<!-- /greptile_comment -->