### PR TITLE
Clean up e2e temp dirs and cap dump directory size

### DIFF
--- a/packages/core/src/dump.ts
+++ b/packages/core/src/dump.ts
@@ -1,9 +1,16 @@
-import { createHash } from 'node:crypto'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { createHash, randomBytes } from 'node:crypto'
+import {
+  lstat,
+  mkdir,
+  readdir,
+  rename,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { extractBillingHeaderCCH } from './cch.ts'
-import { isSecretKey, relayLog } from './logger.ts'
+import { isSecretKey, logger, relayLog } from './logger.ts'
 
 type DumpHeaders = ConstructorParameters<typeof Headers>[0]
 
@@ -16,10 +23,27 @@ const DUMP_USAGE_TITLE = '## Claude Dump Usage'
 const DUMP_USAGE =
   'Usage: `/claude-dump`, `/claude-dump on`, or `/claude-dump off`.'
 const DUMP_DIR_ENV = 'OPENCODE_ANTHROPIC_AUTH_DUMP_DIR'
+const DUMP_MAX_BYTES_ENV = 'OPENCODE_ANTHROPIC_AUTH_DUMP_MAX_BYTES'
 const DEFAULT_DUMP_DIR = join(tmpdir(), 'opencode-anthropic-auth-dumps')
+const DEFAULT_DUMP_MAX_BYTES = 512 * 1024 * 1024
+const DUMP_SWEEP_INTERVAL_MS = 5 * 60 * 1000
+const DUMP_SWEEP_NEWNESS_FLOOR_MS = 60 * 1000
+const DUMP_PARTIAL_STALE_MS = 10 * 60 * 1000
+const DUMP_ARTIFACT_SUFFIX_PATTERN = /\.(body|meta|relay|request)\.json$/
+// Earlier builds emitted five-digit counters; current counters grow without truncation.
+const DUMP_ARTIFACT_ID_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z-\d{5,}-(.+)$/
+const DUMP_SEGMENT_PATTERN = '[a-zA-Z0-9._-]'
+const DIRECT_DUMP_PATTERN = new RegExp(
+  `^${DUMP_SEGMENT_PATTERN}{1,80}-direct(?:-${DUMP_SEGMENT_PATTERN}{1,80})?$`,
+)
+const RELAY_DUMP_PATTERN = new RegExp(
+  `^${DUMP_SEGMENT_PATTERN}{1,80}-(?:http|websocket)-p[12]-(?:full_sync|patch)$`,
+)
 
 let dumpEnabled = false
 let nextDumpId = 0
+let lastDumpSweepAt = 0
 
 const DIRECT_DUMP_PREVIOUS_BODY_LIMIT = 100
 const directDumpPreviousBodies = new Map<string, string>()
@@ -41,11 +65,165 @@ export function setDumpEnabled(enabled: boolean) {
 export function resetDumpState() {
   dumpEnabled = false
   nextDumpId = 0
+  lastDumpSweepAt = 0
   directDumpPreviousBodies.clear()
 }
 
 export function getDumpDirectory() {
   return process.env[DUMP_DIR_ENV] || DEFAULT_DUMP_DIR
+}
+
+function getDumpMaxBytes() {
+  const configured = Number(process.env[DUMP_MAX_BYTES_ENV])
+  return Number.isFinite(configured) && configured >= 0
+    ? Math.floor(configured)
+    : DEFAULT_DUMP_MAX_BYTES
+}
+
+function isConfiguredDumpDirectory(path: string) {
+  return resolve(path) === resolve(getDumpDirectory())
+}
+
+function isDumpArtifactFileName(name: string) {
+  const stem = name.replace(DUMP_ARTIFACT_SUFFIX_PATTERN, '')
+  if (stem === name) return false
+  const match = DUMP_ARTIFACT_ID_PATTERN.exec(stem)
+  const requestPath = match?.[1]
+  if (!requestPath) return false
+  return (
+    DIRECT_DUMP_PATTERN.test(requestPath) ||
+    RELAY_DUMP_PATTERN.test(requestPath)
+  )
+}
+
+function isDumpPartialFileName(name: string) {
+  if (!name.endsWith('.partial')) return false
+  const partialStem = name.slice(0, -8)
+  if (isDumpArtifactFileName(partialStem)) return true
+  const separator = partialStem.lastIndexOf('.')
+  if (separator < 0) return false
+  const nonce = partialStem.slice(separator + 1)
+  return (
+    /^[a-f0-9]{24}$/.test(nonce) &&
+    isDumpArtifactFileName(partialStem.slice(0, separator))
+  )
+}
+
+export async function writeDumpFile(path: string, contents: string) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const nonce = randomBytes(12).toString('hex')
+    const partialPath = `${path}.${nonce}.partial`
+    let created = false
+    try {
+      await writeFile(partialPath, contents, { encoding: 'utf8', flag: 'wx' })
+      created = true
+      await rename(partialPath, path)
+      return true
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') continue
+      if (created) await unlink(partialPath).catch(() => {})
+      throw error
+    }
+  }
+  return false
+}
+
+/**
+ * Caps completed dump artifacts in the configured directory. A zero-byte cap
+ * disables sweeping. Custom directories may contain unrelated files: only
+ * recognized final artifact names and stale partials are eligible. Symlinks,
+ * fresh partial writes, and files younger than the newness floor remain
+ * protected.
+ */
+export async function sweepDumpDirectory(options: {
+  dumpDir?: string
+  maxBytes?: number
+  protectedPaths?: readonly string[]
+  now?: number
+  minAgeMs?: number
+  partialStaleMs?: number
+}) {
+  const dumpDir = options.dumpDir ?? getDumpDirectory()
+  const maxBytes = options.maxBytes ?? getDumpMaxBytes()
+  const now = options.now ?? Date.now()
+  const minAgeMs = options.minAgeMs ?? DUMP_SWEEP_NEWNESS_FLOOR_MS
+  const partialStaleMs = options.partialStaleMs ?? DUMP_PARTIAL_STALE_MS
+  const emptyResult = { removed: 0, freedBytes: 0 }
+  if (!isConfiguredDumpDirectory(dumpDir) || maxBytes <= 0) return emptyResult
+
+  try {
+    const dumpDirStats = await lstat(dumpDir)
+    if (dumpDirStats.isSymbolicLink()) return emptyResult
+    const protectedPaths = new Set(
+      (options.protectedPaths ?? []).map((path) => resolve(path)),
+    )
+    const entries = await readdir(dumpDir, { withFileTypes: true })
+    const files: {
+      path: string
+      size: number
+      mtimeMs: number
+      partial: boolean
+    }[] = []
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (!entry.isFile()) return
+        const partial = isDumpPartialFileName(entry.name)
+        if (!partial && !isDumpArtifactFileName(entry.name)) return
+        const path = join(dumpDir, entry.name)
+        try {
+          const stats = await lstat(path)
+          if (!stats.isFile() || stats.isSymbolicLink()) return
+          files.push({
+            path,
+            size: stats.size,
+            mtimeMs: stats.mtimeMs,
+            partial,
+          })
+        } catch {
+          // Files can disappear while concurrent dump requests finish.
+        }
+      }),
+    )
+
+    let totalBytes = files.reduce((total, file) => total + file.size, 0)
+    files.sort(
+      (left, right) =>
+        left.mtimeMs - right.mtimeMs || left.path.localeCompare(right.path),
+    )
+
+    let removed = 0
+    let freedBytes = 0
+    for (const file of files) {
+      if (protectedPaths.has(resolve(file.path))) continue
+      const ageMs = now - file.mtimeMs
+      const stalePartial = file.partial && ageMs >= partialStaleMs
+      if (!stalePartial && totalBytes <= maxBytes) continue
+      if (file.partial ? !stalePartial : ageMs < minAgeMs) continue
+      try {
+        await unlink(file.path)
+        totalBytes -= file.size
+        freedBytes += file.size
+        removed += 1
+      } catch {
+        // Dump cleanup is best-effort and must not affect request handling.
+      }
+    }
+
+    if (removed > 0) {
+      logger.debug('dump', 'removed old dump files', { removed, freedBytes })
+    }
+    return { removed, freedBytes }
+  } catch {
+    return emptyResult
+  }
+}
+
+function scheduleDumpSweep(dumpDir: string, protectedPaths: readonly string[]) {
+  const now = Date.now()
+  if (now - lastDumpSweepAt < DUMP_SWEEP_INTERVAL_MS) return
+  lastDumpSweepAt = now
+  void sweepDumpDirectory({ dumpDir, protectedPaths }).catch(() => {})
 }
 
 export function parseDumpCommandAction(
@@ -298,7 +476,7 @@ async function dumpRequest(input: {
   if (!dumpEnabled) return
   nextDumpId += 1
   const affinity = input.affinity?.trim() || 'session-unknown'
-  const id = `${new Date().toISOString().replace(/[:.]/g, '-')}-${String(nextDumpId).padStart(5, '0')}-${dumpFileSessionSegment(affinity)}-${dumpRequestSegment(input)}`
+  const id = `${new Date().toISOString().replace(/[:.]/g, '-')}-${String(nextDumpId).padStart(6, '0')}-${dumpFileSessionSegment(affinity)}-${dumpRequestSegment(input)}`
   const dumpDir = getDumpDirectory()
   const prefix = join(dumpDir, id)
   const files: {
@@ -334,27 +512,22 @@ async function dumpRequest(input: {
     }
 
     const writes = [
-      writeFile(files.body, input.bodyText, 'utf8'),
-      writeFile(
-        files.metadata,
-        `${JSON.stringify(metadata, null, 2)}\n`,
-        'utf8',
-      ),
+      writeDumpFile(files.body, input.bodyText),
+      writeDumpFile(files.metadata, `${JSON.stringify(metadata, null, 2)}\n`),
     ]
 
     if (input.payload !== undefined && files.relay) {
       writes.push(
-        writeFile(
+        writeDumpFile(
           files.relay,
           `${JSON.stringify(redactForDump(input.payload), null, 2)}\n`,
-          'utf8',
         ),
       )
     }
 
     if (input.request !== undefined && files.request) {
       writes.push(
-        writeFile(
+        writeDumpFile(
           files.request,
           `${JSON.stringify(
             redactForDump({
@@ -364,12 +537,12 @@ async function dumpRequest(input: {
             null,
             2,
           )}\n`,
-          'utf8',
         ),
       )
     }
 
     await Promise.all(writes)
+    scheduleDumpSweep(dumpDir, Object.values(files))
 
     relayLog(
       `dumped request id=${id} session=${shortAffinity(affinity)} body=${files.body} meta=${files.metadata}`,

--- a/packages/core/src/tests/dump.test.ts
+++ b/packages/core/src/tests/dump.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  symlink,
+  unlink,
+  utimes,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { sweepDumpDirectory, writeDumpFile } from '../dump'
+
+const dumpDirs: string[] = []
+const dumpLinks: string[] = []
+const originalDumpMaxBytes = process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_MAX_BYTES
+const originalDumpDir = process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR
+
+function dumpArtifactName(
+  id: number,
+  kind: 'body' | 'meta' | 'relay' | 'request' = 'body',
+) {
+  return `2026-07-17T12-00-00-000Z-${String(id).padStart(6, '0')}-session-direct.${kind}.json`
+}
+
+afterEach(async () => {
+  if (originalDumpMaxBytes === undefined) {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_MAX_BYTES
+  } else {
+    process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_MAX_BYTES = originalDumpMaxBytes
+  }
+  if (originalDumpDir === undefined) {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR
+  } else {
+    process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR = originalDumpDir
+  }
+  await Promise.all(
+    dumpLinks.splice(0).map((path) => unlink(path).catch(() => {})),
+  )
+  await Promise.all(
+    dumpDirs
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  )
+})
+
+test('dump sweep deletes oldest files until the directory is under its cap', async () => {
+  const dumpDir = await mkdtemp(
+    join(tmpdir(), 'opencode-anthropic-auth-dumps-test-'),
+  )
+  dumpDirs.push(dumpDir)
+  process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR = dumpDir
+  const oldFile = join(dumpDir, dumpArtifactName(1))
+  const middleFile = join(dumpDir, dumpArtifactName(2, 'meta'))
+  const newestFile = join(dumpDir, dumpArtifactName(3, 'request'))
+  await mkdir(dumpDir, { recursive: true })
+  await Promise.all([
+    writeFile(oldFile, '12345678'),
+    writeFile(middleFile, '12345678'),
+    writeFile(newestFile, '12345678'),
+  ])
+  await utimes(oldFile, new Date(1_000), new Date(1_000))
+  await utimes(middleFile, new Date(2_000), new Date(2_000))
+  await utimes(newestFile, new Date(3_000), new Date(3_000))
+
+  const result = await sweepDumpDirectory({
+    dumpDir,
+    maxBytes: 12,
+    protectedPaths: [newestFile],
+  })
+
+  expect(result).toEqual({ removed: 2, freedBytes: 16 })
+  expect(await readdir(dumpDir)).toEqual([dumpArtifactName(3, 'request')])
+})
+
+test('sweeps artifacts whose request counter has grown to seven digits', async () => {
+  const dumpDir = await mkdtemp(
+    join(tmpdir(), 'opencode-anthropic-auth-dumps-test-'),
+  )
+  dumpDirs.push(dumpDir)
+  process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR = dumpDir
+  const artifact = join(
+    dumpDir,
+    '2026-07-17T12-00-00-000Z-1000000-session-direct.body.json',
+  )
+  await writeFile(artifact, '12345678')
+  await utimes(artifact, new Date(1_000), new Date(1_000))
+
+  expect(await sweepDumpDirectory({ dumpDir, maxBytes: 1 })).toEqual({
+    removed: 1,
+    freedBytes: 8,
+  })
+  expect(await readdir(dumpDir)).toEqual([])
+})
+
+describe('dump sweep safety guard', () => {
+  test('refuses a configured symlinked dump directory without deleting target files', async () => {
+    const targetDir = await mkdtemp(join(tmpdir(), 'target-dir-secret-'))
+    dumpDirs.push(targetDir)
+    const secretFile = join(targetDir, 'secret.txt')
+    await writeFile(secretFile, 'do not delete me')
+    const dumpDir = join(
+      tmpdir(),
+      `opencode-anthropic-auth-dumps-link-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    dumpLinks.push(dumpDir)
+    await symlink(targetDir, dumpDir)
+    process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR = dumpDir
+
+    expect(await sweepDumpDirectory({ maxBytes: 1 })).toEqual({
+      removed: 0,
+      freedBytes: 0,
+    })
+    expect(await readdir(targetDir)).toEqual(['secret.txt'])
+  })
+
+  test('refuses a directory that is not configured for dumps', async () => {
+    const dumpDir = await mkdtemp(join(tmpdir(), 'unrelated-dumps-test-'))
+    dumpDirs.push(dumpDir)
+    await writeFile(join(dumpDir, 'old.json'), '12345678')
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR
+
+    expect(await sweepDumpDirectory({ dumpDir, maxBytes: 1 })).toEqual({
+      removed: 0,
+      freedBytes: 0,
+    })
+    expect(await readdir(dumpDir)).toEqual(['old.json'])
+  })
+})
+
+test('enforces the cap in a configured custom dump directory', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'custom-dump-root-'))
+  dumpDirs.push(root)
+  const dumpDir = join(root, 'dumps')
+  await mkdir(dumpDir)
+  const oldDump = join(dumpDir, dumpArtifactName(1))
+  const newDump = join(dumpDir, dumpArtifactName(2, 'meta'))
+  const unrelatedFile = join(dumpDir, 'system.log')
+  await Promise.all([
+    writeFile(oldDump, '12345678'),
+    writeFile(newDump, '12345678'),
+    writeFile(unrelatedFile, 'unrelated file must survive'),
+  ])
+  await utimes(oldDump, new Date(1_000), new Date(1_000))
+  await utimes(newDump, new Date(2_000), new Date(2_000))
+  await utimes(unrelatedFile, new Date(500), new Date(500))
+  process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR = dumpDir
+
+  expect(await sweepDumpDirectory({ maxBytes: 8 })).toEqual({
+    removed: 1,
+    freedBytes: 8,
+  })
+  expect((await readdir(dumpDir)).sort()).toEqual(
+    [dumpArtifactName(2, 'meta'), 'system.log'].sort(),
+  )
+})
+
+test('disables dump sweeping when the configured cap is zero', async () => {
+  const dumpDir = await mkdtemp(
+    join(tmpdir(), 'opencode-anthropic-auth-dumps-test-'),
+  )
+  dumpDirs.push(dumpDir)
+  process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR = dumpDir
+  const oldFile = join(dumpDir, dumpArtifactName(1))
+  await writeFile(oldFile, '12345678')
+  await utimes(oldFile, new Date(1_000), new Date(1_000))
+  process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_MAX_BYTES = '0'
+
+  expect(await sweepDumpDirectory({ dumpDir })).toEqual({
+    removed: 0,
+    freedBytes: 0,
+  })
+  expect(await readdir(dumpDir)).toEqual([dumpArtifactName(1)])
+})
+
+test('preserves files younger than the sweep newness floor', async () => {
+  const dumpDir = await mkdtemp(
+    join(tmpdir(), 'opencode-anthropic-auth-dumps-test-'),
+  )
+  dumpDirs.push(dumpDir)
+  process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR = dumpDir
+  const recentFile = join(dumpDir, dumpArtifactName(1))
+  const now = new Date('2026-07-17T12:00:00.000Z')
+  await writeFile(recentFile, '12345678')
+  await utimes(recentFile, now, now)
+
+  expect(
+    await sweepDumpDirectory({
+      dumpDir,
+      maxBytes: 1,
+      now: now.getTime(),
+    }),
+  ).toEqual({ removed: 0, freedBytes: 0 })
+  expect(await readdir(dumpDir)).toEqual([dumpArtifactName(1)])
+})
+
+test('preserves fresh partials and reclaims stale partials even under the cap', async () => {
+  const dumpDir = await mkdtemp(
+    join(tmpdir(), 'opencode-anthropic-auth-dumps-test-'),
+  )
+  dumpDirs.push(dumpDir)
+  process.env.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR = dumpDir
+  const now = new Date('2026-07-17T12:00:00.000Z')
+  const freshPartial = join(dumpDir, `${dumpArtifactName(1)}.partial`)
+  const stalePartial = join(
+    dumpDir,
+    `${dumpArtifactName(2)}.0123456789abcdef01234567.partial`,
+  )
+  await Promise.all([
+    writeFile(freshPartial, '12345678'),
+    writeFile(stalePartial, '12345678'),
+  ])
+  await utimes(freshPartial, now, now)
+  await utimes(
+    stalePartial,
+    new Date(now.getTime() - 11 * 60 * 1000),
+    new Date(now.getTime() - 11 * 60 * 1000),
+  )
+
+  expect(
+    await sweepDumpDirectory({
+      dumpDir,
+      maxBytes: 100,
+      now: now.getTime(),
+    }),
+  ).toEqual({
+    removed: 1,
+    freedBytes: 8,
+  })
+  expect(await readdir(dumpDir)).toEqual([`${dumpArtifactName(1)}.partial`])
+})
+
+test('does not follow a pre-planted predictable partial symlink', async () => {
+  const dumpDir = await mkdtemp(
+    join(tmpdir(), 'opencode-anthropic-auth-dumps-test-'),
+  )
+  const targetDir = await mkdtemp(join(tmpdir(), 'dump-partial-target-'))
+  dumpDirs.push(dumpDir, targetDir)
+  const targetFile = join(targetDir, 'target.txt')
+  const finalFile = join(dumpDir, dumpArtifactName(1))
+  await writeFile(targetFile, 'do not overwrite')
+  await symlink(targetFile, `${finalFile}.partial`)
+
+  await writeDumpFile(finalFile, 'safe dump content')
+
+  expect(await readFile(targetFile, 'utf8')).toBe('do not overwrite')
+  expect(await readFile(finalFile, 'utf8')).toBe('safe dump content')
+  expect((await lstat(finalFile)).isSymbolicLink()).toBe(false)
+})

--- a/packages/e2e-tests/src/harness.ts
+++ b/packages/e2e-tests/src/harness.ts
@@ -25,6 +25,7 @@ type SdkClient = {
 export type E2EHarnessOptions = {
   relay?: 'websocket'
   hybridCache?: boolean
+  childTmpDir?: string
 }
 
 export class E2EHarness {
@@ -66,6 +67,7 @@ export class E2EHarness {
       anthropicBaseURL: baseURL,
       relay: relayConfig,
       hybridCache: options.hybridCache,
+      childTmpDir: options.childTmpDir,
     })
     const sdk = await import('@opencode-ai/sdk')
     const client = sdk.createOpencodeClient({

--- a/packages/e2e-tests/src/opencode-runner.ts
+++ b/packages/e2e-tests/src/opencode-runner.ts
@@ -1,18 +1,163 @@
 /// <reference types="bun-types" />
 
 import { type ChildProcess, spawn } from 'node:child_process'
-import { mkdirSync, realpathSync, writeFileSync } from 'node:fs'
+import { randomBytes } from 'node:crypto'
+import {
+  type Dirent,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import {
+  lstat,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 
 const REPO_ROOT = resolve(import.meta.dir, '../../..')
 const PLUGIN_ENTRY = join(REPO_ROOT, 'packages/opencode/src/index.ts')
+const E2E_TEMP_PREFIX = 'anthropic-auth-e2e-'
+const DEFAULT_STALE_AGE_MS = 24 * 60 * 60 * 1000
+const RUN_PID_FILE = 'run.pid'
+const activeRunDirs = new Set<string>()
 
 export type IsolatedEnv = {
+  tempDir: string
   configDir: string
   dataDir: string
   cacheDir: string
   workdir: string
+}
+
+function isExpectedE2ETempDir(path: string, root: string) {
+  const resolvedPath = resolve(path)
+  const resolvedRoot = resolve(root)
+  return (
+    dirname(resolvedPath) === resolvedRoot &&
+    basename(resolvedPath).startsWith(E2E_TEMP_PREFIX)
+  )
+}
+
+async function isSafeE2ETempDir(path: string, root: string) {
+  if (!isExpectedE2ETempDir(path, root)) return false
+  try {
+    const stats = await lstat(path)
+    return stats.isDirectory() && !stats.isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+export async function removeE2ETempDir(
+  path: string,
+  options: { root?: string; keep?: boolean } = {},
+) {
+  if (options.keep) return false
+  const root = options.root ?? tmpdir()
+  if (!(await isSafeE2ETempDir(path, root))) return false
+  activeRunDirs.delete(resolve(path))
+
+  try {
+    await rm(path, { recursive: true, force: true })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function sweepStaleE2ETempDirs(
+  options: { root?: string; now?: number; maxAgeMs?: number } = {},
+) {
+  const root = options.root ?? tmpdir()
+  const now = options.now ?? Date.now()
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_STALE_AGE_MS
+
+  let entries: Dirent[]
+  try {
+    entries = await readdir(root, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.name.startsWith(E2E_TEMP_PREFIX) || !entry.isDirectory())
+        return
+      const path = join(root, entry.name)
+      try {
+        const stats = await lstat(path)
+        if (stats.isSymbolicLink() || now - stats.mtimeMs <= maxAgeMs) return
+        if (await hasLiveRunOwner(path)) return
+        await removeE2ETempDir(path, { root })
+      } catch {
+        // A crashed-run sweep must not prevent a new harness from starting.
+      }
+    }),
+  )
+}
+
+async function hasLiveRunOwner(path: string) {
+  if (activeRunDirs.has(resolve(path))) return true
+  try {
+    const value = await readFile(join(path, RUN_PID_FILE), 'utf8')
+    const pid = Number(value.trim())
+    if (!Number.isInteger(pid) || pid <= 0) return false
+    if (pid === process.pid) return activeRunDirs.has(resolve(path))
+    try {
+      process.kill(pid, 0)
+      return true
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code === 'EPERM'
+    }
+  } catch {
+    return false
+  }
+}
+
+async function handoffRunPid(tempDir: string, root: string, childPid: number) {
+  const runPidPath = join(tempDir, RUN_PID_FILE)
+  if (
+    resolve(dirname(runPidPath)) !== resolve(tempDir) ||
+    !(await isSafeE2ETempDir(tempDir, root))
+  ) {
+    return false
+  }
+
+  try {
+    const stats = await lstat(runPidPath)
+    if (!stats.isFile() || stats.isSymbolicLink()) return false
+  } catch {
+    return false
+  }
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const temporaryPath = join(
+      tempDir,
+      `.${RUN_PID_FILE}.${randomBytes(12).toString('hex')}.tmp`,
+    )
+    let created = false
+    try {
+      await writeFile(temporaryPath, String(childPid), {
+        encoding: 'utf8',
+        flag: 'wx',
+      })
+      created = true
+      await rename(temporaryPath, runPidPath)
+      return true
+    } catch (error) {
+      if (created) await unlink(temporaryPath).catch(() => {})
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') continue
+      return false
+    }
+  }
+  return false
 }
 
 export type SpawnedOpencode = {
@@ -33,6 +178,8 @@ export type SpawnOptions = {
     transport: 'websocket' | 'http'
   }
   port?: number
+  beforeSpawn?: (env: IsolatedEnv) => void
+  childTmpDir?: string
 }
 
 async function pickFreePort() {
@@ -43,21 +190,31 @@ async function pickFreePort() {
   return port
 }
 
-function createIsolatedEnv(): IsolatedEnv {
+export function createIsolatedEnv(root = tmpdir()): IsolatedEnv {
   const base = join(
-    tmpdir(),
-    `anthropic-auth-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    root,
+    `${E2E_TEMP_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2)}`,
   )
   const env = {
+    tempDir: base,
     configDir: join(base, 'config'),
     dataDir: join(base, 'data'),
     cacheDir: join(base, 'cache'),
     workdir: join(base, 'work'),
   }
-  for (const dir of Object.values(env)) mkdirSync(dir, { recursive: true })
-  env.workdir = realpathSync(env.workdir)
-  writeFileSync(join(env.workdir, 'sample.txt'), 'hello from sample file\n')
-  return env
+  try {
+    for (const dir of Object.values(env)) mkdirSync(dir, { recursive: true })
+    writeFileSync(join(base, RUN_PID_FILE), String(process.pid))
+    env.workdir = realpathSync(env.workdir)
+    writeFileSync(join(env.workdir, 'sample.txt'), 'hello from sample file\n')
+    activeRunDirs.add(resolve(base))
+    return env
+  } catch (error) {
+    if (isExpectedE2ETempDir(base, root)) {
+      rmSync(base, { recursive: true, force: true })
+    }
+    throw error
+  }
 }
 
 function writeConfigs(env: IsolatedEnv, options: SpawnOptions) {
@@ -143,84 +300,178 @@ async function waitForReady(
   throw new Error(`opencode serve did not become ready: ${String(lastError)}`)
 }
 
+export async function terminateChildProcess(
+  child: ChildProcess,
+  options: { termTimeoutMs?: number; killExitTimeoutMs?: number } = {},
+) {
+  if (child.exitCode !== null || child.signalCode !== null) return true
+  return new Promise<boolean>((resolve) => {
+    let termTimer: ReturnType<typeof setTimeout> | undefined
+    let killExitTimer: ReturnType<typeof setTimeout> | undefined
+    let settled = false
+    const finish = (exitConfirmed: boolean) => {
+      if (settled) return
+      settled = true
+      if (termTimer) clearTimeout(termTimer)
+      if (killExitTimer) clearTimeout(killExitTimer)
+      child.off('exit', onExit)
+      resolve(exitConfirmed)
+    }
+    const onExit = () => finish(true)
+    child.once('exit', onExit)
+    termTimer = setTimeout(() => {
+      killExitTimer = setTimeout(() => {
+        console.warn(
+          'opencode child did not exit after SIGKILL; leaving temp dir for stale cleanup',
+        )
+        finish(false)
+      }, options.killExitTimeoutMs ?? 2000)
+      child.kill('SIGKILL')
+    }, options.termTimeoutMs ?? 3000)
+    child.kill('SIGTERM')
+  })
+}
+
+export async function cleanupE2ERun(options: {
+  child?: ChildProcess
+  tempDir: string
+  root?: string
+  keep?: boolean
+  terminationOptions?: { termTimeoutMs?: number; killExitTimeoutMs?: number }
+}) {
+  const exitConfirmed = options.child
+    ? await terminateChildProcess(options.child, options.terminationOptions)
+    : true
+  if (!exitConfirmed) {
+    const childPid = options.child?.pid
+    if (
+      typeof childPid === 'number' &&
+      Number.isInteger(childPid) &&
+      childPid > 0
+    ) {
+      const root = options.root ?? tmpdir()
+      if (await handoffRunPid(options.tempDir, root, childPid)) {
+        activeRunDirs.delete(resolve(options.tempDir))
+      }
+    }
+    return false
+  }
+  activeRunDirs.delete(resolve(options.tempDir))
+  return removeE2ETempDir(options.tempDir, {
+    root: options.root,
+    keep: options.keep,
+  })
+}
+
 export async function spawnOpencode(
   options: SpawnOptions,
 ): Promise<SpawnedOpencode> {
+  await sweepStaleE2ETempDirs()
   const env = createIsolatedEnv()
-  const port = options.port ?? (await pickFreePort())
-  writeConfigs(env, options)
-
-  const childEnv: Record<string, string> = {}
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value == null) continue
-    if (key === 'OPENCODE_SERVER_PASSWORD') continue
-    if (key === 'OPENCODE_SERVER_USERNAME') continue
-    if (key === 'NODE_ENV') continue
-    childEnv[key] = value
-  }
-  childEnv.OPENCODE_CONFIG_DIR = env.configDir
-  childEnv.OPENCODE_ANTHROPIC_AUTH_FILE = join(
-    env.configDir,
-    'anthropic-auth.json',
-  )
-  childEnv.XDG_CONFIG_HOME = env.configDir
-  childEnv.XDG_DATA_HOME = env.dataDir
-  childEnv.XDG_CACHE_HOME = env.cacheDir
-  childEnv.OPENCODE_AUTH_CONTENT = JSON.stringify({
-    anthropic: {
-      type: 'oauth',
-      access: 'test-access-token',
-      refresh: 'test-refresh-token',
-      expires: Date.now() + 60 * 60 * 1000,
-    },
-  })
-  childEnv.ANTHROPIC_BASE_URL = options.anthropicBaseURL
-  childEnv.ANTHROPIC_API_KEY = 'test-key-not-real'
-
-  const child: ChildProcess = spawn(
-    'opencode',
-    ['serve', '--port', String(port), '--hostname', '127.0.0.1'],
-    { cwd: env.workdir, env: childEnv, stdio: ['ignore', 'pipe', 'pipe'] },
-  )
-
+  let child: ChildProcess | undefined
+  let spawnError: Error | undefined
   let stdout = ''
   let stderr = ''
-  child.stdout?.on('data', (chunk: Buffer) => {
-    stdout += chunk.toString()
-  })
-  child.stderr?.on('data', (chunk: Buffer) => {
-    stderr += chunk.toString()
-  })
-
-  const url = `http://127.0.0.1:${port}`
   try {
-    await waitForReady(url, () => ({ stdout, stderr }))
+    options.beforeSpawn?.(env)
+    const port = options.port ?? (await pickFreePort())
+    writeConfigs(env, options)
+
+    const childEnv: Record<string, string> = {}
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value == null) continue
+      if (key === 'OPENCODE_SERVER_PASSWORD') continue
+      if (key === 'OPENCODE_SERVER_USERNAME') continue
+      if (key === 'NODE_ENV') continue
+      childEnv[key] = value
+    }
+    childEnv.OPENCODE_CONFIG_DIR = env.configDir
+    childEnv.OPENCODE_ANTHROPIC_AUTH_FILE = join(
+      env.configDir,
+      'anthropic-auth.json',
+    )
+    childEnv.OPENCODE_ANTHROPIC_AUTH_STATE_FILE = join(
+      env.configDir,
+      'anthropic-auth-state.json',
+    )
+    childEnv.OPENCODE_ANTHROPIC_AUTH_SIDEBAR_STATE_FILE = join(
+      env.configDir,
+      'sidebar-state.json',
+    )
+    childEnv.OPENCODE_ANTHROPIC_AUTH_RPC_DIR = join(env.tempDir, 'rpc')
+    childEnv.OPENCODE_ANTHROPIC_AUTH_DUMP_DIR = join(env.tempDir, 'dumps')
+    childEnv.OPENCODE_ANTHROPIC_AUTH_LOG_FILE = join(
+      env.tempDir,
+      'opencode-anthropic-auth.log',
+    )
+    childEnv.XDG_CONFIG_HOME = env.configDir
+    childEnv.XDG_DATA_HOME = env.dataDir
+    childEnv.XDG_CACHE_HOME = env.cacheDir
+    if (options.childTmpDir) {
+      // Cover all platform temp-dir aliases: POSIX reads TMPDIR; Windows
+      // resolves TEMP/TMP first, so leaving them inherited would let the
+      // child escape the fake temp root there.
+      childEnv.TMPDIR = options.childTmpDir
+      childEnv.TEMP = options.childTmpDir
+      childEnv.TMP = options.childTmpDir
+    }
+    childEnv.OPENCODE_AUTH_CONTENT = JSON.stringify({
+      anthropic: {
+        type: 'oauth',
+        access: 'test-access-token',
+        refresh: 'test-refresh-token',
+        expires: Date.now() + 60 * 60 * 1000,
+      },
+    })
+    childEnv.ANTHROPIC_BASE_URL = options.anthropicBaseURL
+    childEnv.ANTHROPIC_API_KEY = 'test-key-not-real'
+
+    child = spawn(
+      'opencode',
+      ['serve', '--port', String(port), '--hostname', '127.0.0.1'],
+      { cwd: env.workdir, env: childEnv, stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    const spawnFailure = new Promise<never>((_, reject) => {
+      child?.once('error', (error) => {
+        spawnError = error
+        reject(error)
+      })
+    })
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const url = `http://127.0.0.1:${port}`
+    await Promise.race([
+      waitForReady(url, () => ({ stdout, stderr })),
+      spawnFailure,
+    ])
+    return {
+      url,
+      port,
+      env,
+      stdout: () => stdout,
+      stderr: () => stderr,
+      kill: async () => {
+        await cleanupE2ERun({
+          child,
+          tempDir: env.tempDir,
+          keep: process.env.ANTHROPIC_AUTH_E2E_KEEP_TMP === '1',
+        })
+      },
+    }
   } catch (error) {
-    child.kill('SIGTERM')
+    await cleanupE2ERun({
+      child: spawnError ? undefined : child,
+      tempDir: env.tempDir,
+      keep: process.env.ANTHROPIC_AUTH_E2E_KEEP_TMP === '1',
+    })
+    if (!child) throw error
     throw new Error(
       `opencode serve failed to start\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}\n${String(error)}`,
     )
-  }
-
-  return {
-    url,
-    port,
-    env,
-    stdout: () => stdout,
-    stderr: () => stderr,
-    kill: async () => {
-      if (child.exitCode !== null || child.signalCode !== null) return
-      child.kill('SIGTERM')
-      await new Promise<void>((resolve) => {
-        const timer = setTimeout(() => {
-          child.kill('SIGKILL')
-          resolve()
-        }, 3000)
-        child.once('exit', () => {
-          clearTimeout(timer)
-          resolve()
-        })
-      })
-    },
   }
 }

--- a/packages/e2e-tests/tests/tmp-hygiene.test.ts
+++ b/packages/e2e-tests/tests/tmp-hygiene.test.ts
@@ -1,0 +1,417 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import type { ChildProcess } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  rm,
+  symlink,
+  unlink,
+  utimes,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  cleanupE2ERun,
+  createIsolatedEnv,
+  removeE2ETempDir,
+  spawnOpencode,
+  sweepStaleE2ETempDirs,
+  terminateChildProcess,
+} from '../src/opencode-runner.ts'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function createRoot() {
+  const root = await mkdtemp(join(tmpdir(), 'anthropic-auth-e2e-hygiene-test-'))
+  roots.push(root)
+  return root
+}
+
+function unresponsiveChild(pid?: number) {
+  const child = new EventEmitter() as EventEmitter & {
+    exitCode: number | null
+    signalCode: NodeJS.Signals | null
+    pid?: number
+    kill: () => boolean
+  }
+  child.exitCode = null
+  child.signalCode = null
+  child.pid = pid
+  child.kill = () => true
+  return child as unknown as ChildProcess
+}
+
+describe('e2e temporary directory hygiene', () => {
+  it('removes only stale sibling run directories without following symlinks', async () => {
+    const root = await createRoot()
+    const oldDir = join(root, 'anthropic-auth-e2e-old')
+    const newDir = join(root, 'anthropic-auth-e2e-new')
+    const symlinkTarget = join(root, 'symlink-target')
+    const staleTime = new Date('2026-07-15T00:00:00.000Z')
+    const now = new Date('2026-07-17T00:00:00.000Z')
+
+    await Promise.all([
+      mkdir(oldDir),
+      mkdir(newDir),
+      mkdir(symlinkTarget),
+    ])
+    await symlink(symlinkTarget, join(root, 'anthropic-auth-e2e-link'))
+    await utimes(oldDir, staleTime, staleTime)
+    await utimes(newDir, now, now)
+
+    await sweepStaleE2ETempDirs({ root, now: now.getTime() })
+
+    expect((await readdir(root)).sort()).toEqual([
+      'anthropic-auth-e2e-link',
+      'anthropic-auth-e2e-new',
+      'symlink-target',
+    ])
+    expect((await lstat(symlinkTarget)).isDirectory()).toBe(true)
+  })
+
+  it('removes an old same-process run directory that is no longer active', async () => {
+    const root = await createRoot()
+    const orphanDir = join(root, 'anthropic-auth-e2e-orphan')
+    const staleTime = new Date('2026-07-15T00:00:00.000Z')
+    const now = new Date('2026-07-17T00:00:00.000Z')
+    await mkdir(orphanDir)
+    await writeFile(join(orphanDir, 'run.pid'), String(process.pid))
+    await utimes(orphanDir, staleTime, staleTime)
+
+    await sweepStaleE2ETempDirs({ root, now: now.getTime() })
+
+    expect(await readdir(root)).toEqual([])
+  })
+
+  it('keeps an old same-process run directory while it is active', async () => {
+    const root = await createRoot()
+    const env = createIsolatedEnv(root)
+    const staleTime = new Date('2026-07-15T00:00:00.000Z')
+    const now = new Date('2026-07-17T00:00:00.000Z')
+    await utimes(env.tempDir, staleTime, staleTime)
+
+    await sweepStaleE2ETempDirs({ root, now: now.getTime() })
+
+    expect(await readdir(root)).toEqual([env.tempDir.split('/').at(-1)])
+    await removeE2ETempDir(env.tempDir, { root })
+  })
+
+  it('removes an old run directory owned by an exited process', async () => {
+    const root = await createRoot()
+    const deadDir = join(root, 'anthropic-auth-e2e-dead')
+    const staleTime = new Date('2026-07-15T00:00:00.000Z')
+    const now = new Date('2026-07-17T00:00:00.000Z')
+    const child = Bun.spawn(['true'])
+    const deadPid = child.pid
+    await child.exited
+    await mkdir(deadDir)
+    await writeFile(join(deadDir, 'run.pid'), String(deadPid))
+    await utimes(deadDir, staleTime, staleTime)
+
+    await sweepStaleE2ETempDirs({ root, now: now.getTime() })
+
+    expect(await readdir(root)).toEqual([])
+  })
+
+  it('removes a verified run directory unless the keep escape hatch is enabled', async () => {
+    const root = await createRoot()
+    const removedDir = join(root, 'anthropic-auth-e2e-remove')
+    const keptDir = join(root, 'anthropic-auth-e2e-keep')
+    await Promise.all([mkdir(removedDir), mkdir(keptDir)])
+
+    expect(await removeE2ETempDir(removedDir, { root })).toBe(true)
+    expect(
+      await removeE2ETempDir(keptDir, { root, keep: true }),
+    ).toBe(false)
+    expect((await readdir(root)).sort()).toEqual(['anthropic-auth-e2e-keep'])
+  })
+
+  it('refuses to remove paths outside the expected prefix', async () => {
+    const root = await createRoot()
+    const unrelated = join(root, 'unrelated')
+    await mkdir(unrelated)
+
+    expect(await removeE2ETempDir(unrelated, { root })).toBe(false)
+    expect((await lstat(unrelated)).isDirectory()).toBe(true)
+  })
+
+  it('waits for a child process to exit after requesting termination', async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null
+      signalCode: NodeJS.Signals | null
+      killSignals: NodeJS.Signals[]
+      kill: (signal: NodeJS.Signals) => boolean
+    }
+    child.exitCode = null
+    child.signalCode = null
+    child.killSignals = []
+    child.kill = (signal) => {
+      child.killSignals.push(signal)
+      return true
+    }
+    let resolved = false
+
+    const termination = terminateChildProcess(child as unknown as ChildProcess).then(
+      () => {
+        resolved = true
+      },
+    )
+    await Bun.sleep(0)
+
+    expect(child.killSignals).toEqual(['SIGTERM'])
+    expect(resolved).toBe(false)
+    child.exitCode = 0
+    child.emit('exit', 0, null)
+    await termination
+    expect(resolved).toBe(true)
+  })
+
+  it('waits for exit after escalating termination to SIGKILL', async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null
+      signalCode: NodeJS.Signals | null
+      killSignals: NodeJS.Signals[]
+      kill: (signal: NodeJS.Signals) => boolean
+    }
+    child.exitCode = null
+    child.signalCode = null
+    child.killSignals = []
+    child.kill = (signal) => {
+      child.killSignals.push(signal)
+      return true
+    }
+    let resolved = false
+
+    const termination = terminateChildProcess(child as unknown as ChildProcess, {
+      termTimeoutMs: 5,
+      killExitTimeoutMs: 100,
+    }).then(() => {
+      resolved = true
+    })
+    await Bun.sleep(20)
+
+    expect(child.killSignals).toEqual(['SIGTERM', 'SIGKILL'])
+    expect(resolved).toBe(false)
+    child.signalCode = 'SIGKILL'
+    child.emit('exit', null, 'SIGKILL')
+    await termination
+    expect(resolved).toBe(true)
+  })
+
+  it('reports an unconfirmed exit after the SIGKILL fallback expires', async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null
+      signalCode: NodeJS.Signals | null
+      kill: () => boolean
+    }
+    child.exitCode = null
+    child.signalCode = null
+    child.kill = () => true
+
+    const exited = await terminateChildProcess(child as unknown as ChildProcess, {
+      termTimeoutMs: 5,
+      killExitTimeoutMs: 5,
+    })
+
+    expect(exited).toBe(false)
+  })
+
+  it('leaves the temp directory when child exit cannot be confirmed', async () => {
+    const root = await createRoot()
+    const env = createIsolatedEnv(root)
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null
+      signalCode: NodeJS.Signals | null
+      kill: () => boolean
+    }
+    child.exitCode = null
+    child.signalCode = null
+    child.kill = () => true
+
+    expect(
+      await cleanupE2ERun({
+        child: child as unknown as ChildProcess,
+        tempDir: env.tempDir,
+        root,
+        terminationOptions: { termTimeoutMs: 5, killExitTimeoutMs: 5 },
+      }),
+    ).toBe(false)
+    const staleTime = new Date('2026-07-15T00:00:00.000Z')
+    const now = new Date('2026-07-17T00:00:00.000Z')
+    await utimes(env.tempDir, staleTime, staleTime)
+
+    await sweepStaleE2ETempDirs({ root, now: now.getTime() })
+
+    expect(await readdir(root)).toEqual([env.tempDir.split('/').at(-1)])
+    await removeE2ETempDir(env.tempDir, { root })
+  })
+
+  it('reclaims an unconfirmed-exit directory after the child is dead', async () => {
+    const root = await createRoot()
+    const env = createIsolatedEnv(root)
+    const child = Bun.spawn(['true'])
+    const deadPid = child.pid
+    await child.exited
+
+    expect(
+      await cleanupE2ERun({
+        child: unresponsiveChild(deadPid),
+        tempDir: env.tempDir,
+        root,
+        terminationOptions: { termTimeoutMs: 5, killExitTimeoutMs: 5 },
+      }),
+    ).toBe(false)
+    const staleTime = new Date('2026-07-15T00:00:00.000Z')
+    const now = new Date('2026-07-17T00:00:00.000Z')
+    await utimes(env.tempDir, staleTime, staleTime)
+
+    await sweepStaleE2ETempDirs({ root, now: now.getTime() })
+
+    expect(await readdir(root)).toEqual([])
+  })
+
+  it('protects an unconfirmed-exit directory while the child is alive', async () => {
+    const root = await createRoot()
+    const env = createIsolatedEnv(root)
+    const child = Bun.spawn(['sleep', '30'])
+
+    try {
+      expect(
+        await cleanupE2ERun({
+          child: unresponsiveChild(child.pid),
+          tempDir: env.tempDir,
+          root,
+          terminationOptions: { termTimeoutMs: 5, killExitTimeoutMs: 5 },
+        }),
+      ).toBe(false)
+      const staleTime = new Date('2026-07-15T00:00:00.000Z')
+      const now = new Date('2026-07-17T00:00:00.000Z')
+      await utimes(env.tempDir, staleTime, staleTime)
+
+      await sweepStaleE2ETempDirs({ root, now: now.getTime() })
+
+      expect(await readdir(root)).toEqual([env.tempDir.split('/').at(-1)])
+    } finally {
+      child.kill()
+      await child.exited
+      await removeE2ETempDir(env.tempDir, { root })
+    }
+  })
+
+  it('refuses child pid handoff through a planted run.pid symlink', async () => {
+    const root = await createRoot()
+    const env = createIsolatedEnv(root)
+    const targetFile = join(root, 'handoff-target.txt')
+    const runPidFile = join(env.tempDir, 'run.pid')
+    await writeFile(targetFile, 'do not overwrite')
+    await unlink(runPidFile)
+    await symlink(targetFile, runPidFile)
+    const child = Bun.spawn(['true'])
+    const deadPid = child.pid
+    await child.exited
+
+    expect(
+      await cleanupE2ERun({
+        child: unresponsiveChild(deadPid),
+        tempDir: env.tempDir,
+        root,
+        terminationOptions: { termTimeoutMs: 5, killExitTimeoutMs: 5 },
+      }),
+    ).toBe(false)
+    expect(await Bun.file(targetFile).text()).toBe('do not overwrite')
+    const staleTime = new Date('2026-07-15T00:00:00.000Z')
+    const now = new Date('2026-07-17T00:00:00.000Z')
+    await utimes(env.tempDir, staleTime, staleTime)
+
+    await sweepStaleE2ETempDirs({ root, now: now.getTime() })
+
+    expect((await readdir(root)).sort()).toEqual(
+      [env.tempDir.split('/').at(-1), 'handoff-target.txt'].sort(),
+    )
+    await removeE2ETempDir(env.tempDir, { root })
+  })
+
+  it('refuses child pid handoff through a symlinked temp directory', async () => {
+    const root = await createRoot()
+    const env = createIsolatedEnv(root)
+    const externalDir = await mkdtemp(join(tmpdir(), 'e2e-pid-target-'))
+    roots.push(externalDir)
+    const externalRunPid = join(externalDir, 'run.pid')
+    await writeFile(externalRunPid, 'do not overwrite')
+    await rm(env.tempDir, { recursive: true, force: true })
+    await symlink(externalDir, env.tempDir)
+    const child = Bun.spawn(['true'])
+    const deadPid = child.pid
+    await child.exited
+
+    expect(
+      await cleanupE2ERun({
+        child: unresponsiveChild(deadPid),
+        tempDir: env.tempDir,
+        root,
+        terminationOptions: { termTimeoutMs: 5, killExitTimeoutMs: 5 },
+      }),
+    ).toBe(false)
+    expect(await Bun.file(externalRunPid).text()).toBe('do not overwrite')
+
+    await unlink(env.tempDir)
+    await mkdir(env.tempDir)
+    await writeFile(join(env.tempDir, 'run.pid'), String(process.pid))
+    const staleTime = new Date('2026-07-15T00:00:00.000Z')
+    const now = new Date('2026-07-17T00:00:00.000Z')
+    await utimes(env.tempDir, staleTime, staleTime)
+    await sweepStaleE2ETempDirs({ root, now: now.getTime() })
+
+    expect(await readdir(root)).toEqual([env.tempDir.split('/').at(-1)])
+    await removeE2ETempDir(env.tempDir, { root })
+  })
+
+  it('removes the temp directory when setup fails before spawning a child', async () => {
+    let tempDir = ''
+
+    await expect(
+      spawnOpencode({
+        anthropicBaseURL: 'http://127.0.0.1:1',
+        beforeSpawn: (env) => {
+          tempDir = env.tempDir
+          throw new Error('setup failed')
+        },
+      }),
+    ).rejects.toThrow('setup failed')
+
+    expect(tempDir).not.toBe('')
+    expect(await Bun.file(tempDir).exists()).toBe(false)
+  })
+
+  it('surfaces spawn errors and removes the temp directory', async () => {
+    const originalPath = process.env.PATH
+    let tempDir = ''
+    process.env.PATH = ''
+
+    try {
+      await expect(
+        spawnOpencode({
+          anthropicBaseURL: 'http://127.0.0.1:1',
+          beforeSpawn: (env) => {
+            tempDir = env.tempDir
+          },
+        }),
+      ).rejects.toThrow(/Executable not found|ENOENT|spawn opencode/)
+    } finally {
+      process.env.PATH = originalPath
+    }
+
+    expect(tempDir).not.toBe('')
+    expect(await Bun.file(tempDir).exists()).toBe(false)
+  })
+})

--- a/packages/e2e-tests/tests/tool-prefix.test.ts
+++ b/packages/e2e-tests/tests/tool-prefix.test.ts
@@ -1,6 +1,9 @@
 /// <reference types="bun-types" />
 
 import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { E2EHarness } from '../src/harness.ts'
 
 let harness: E2EHarness | null = null
@@ -11,6 +14,39 @@ afterEach(async () => {
 })
 
 describe('OpenCode Anthropic auth e2e', () => {
+  it('keeps sidebar state inside the isolated run directory', async () => {
+    const fakeTmpDir = await mkdtemp(join(tmpdir(), 'anthropic-auth-global-'))
+    const globalStateDir = join(fakeTmpDir, 'opencode-anthropic-auth')
+    const globalStateFile = join(globalStateDir, 'sidebar-state.json')
+    const sentinel = '{"sentinel":"operator-live-state"}\n'
+    await mkdir(globalStateDir)
+    await writeFile(globalStateFile, sentinel)
+
+    try {
+      // Only the child sees the fake TMPDIR; harness lifecycle paths stay in the real system tmpdir.
+      harness = await E2EHarness.create({ childTmpDir: fakeTmpDir })
+      expect(harness.opencode.env.tempDir.startsWith(fakeTmpDir)).toBe(false)
+      harness.script([{ type: 'text', text: 'isolation checked' }])
+      const sessionId = await harness.createSession()
+      await harness.sendPrompt(sessionId, 'verify isolated sidebar state')
+      const isolatedStateFile = join(
+        harness.opencode.env.configDir,
+        'sidebar-state.json',
+      )
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        if (await Bun.file(isolatedStateFile).exists()) break
+        await Bun.sleep(100)
+      }
+
+      expect(await Bun.file(globalStateFile).text()).toBe(sentinel)
+      expect(await Bun.file(isolatedStateFile).exists()).toBe(true)
+    } finally {
+      await harness?.dispose()
+      harness = null
+      await rm(fakeTmpDir, { recursive: true, force: true })
+    }
+  }, 90_000)
+
   it('strips mcp_ tool names even when Anthropic SSE chunks split the name field', async () => {
     harness = await E2EHarness.create()
     harness.script([


### PR DESCRIPTION
The e2e harness leaks its per-run temp dir (~131MB each). On a tmpfs `/tmp`, accumulated runs filled the disk (122 dirs = 16GB observed) until sidebar/state writes started failing with ENOSPC. The dump feature has the same unbounded-growth problem (4.2GB observed).

**e2e harness:**
- Teardown removes the run's temp dir on all exit paths, including spawn failure (the failure path now awaits child termination before removal so a still-running child can't recreate files mid-delete). `ANTHROPIC_AUTH_E2E_KEEP_TMP=1` keeps it for debugging.
- Startup sweep removes `anthropic-auth-e2e-*` dirs older than 24h (crashed runs can't accumulate). Best-effort, per-dir try/catch, skips symlinks, never touches dirs younger than the threshold.

**dump directory cap (`packages/core/src/dump.ts`):**
- After a dump write, a throttled fire-and-forget sweep keeps the dumps dir under a cap (default 512MiB, `OPENCODE_ANTHROPIC_AUTH_DUMP_MAX_BYTES` override, explicit `0` honored). Oldest-first deletion; files younger than 60s are never deleted, so in-flight writes from any concurrent request survive.
- Deletion is guarded: the sweep refuses to run if the dumps dir path is unexpected or is a symlink (`lstat`), only deletes regular files inside the dir, and uses `unlink` with success-only accounting so concurrent sweeps can't double-count freed bytes.

Tests cover teardown on failure paths, the stale sweep (old removed / young and symlinks untouched), symlinked-dumps-dir refusal, explicit zero cap, the newness floor, and oldest-first cap math. Suites green (core 42, opencode 806, e2e 8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786881908&installation_id=135454708&pr_number=131&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F131&signature=745b078578e54e7e927bc09e90680940c1cde18ecab1f5a7b7d431b947f28186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up e2e temp directories, cap the dumps directory, and fully isolate plugin runtime files per run to stop disk growth and avoid global writes. Child processes now honor a child-scoped temp override (`TMPDIR`, `TEMP`, `TMP`) so tests can verify isolation.

- **Bug Fixes**
  - E2E: Remove per-run temp dir on all exit paths; terminate child with SIGTERM → SIGKILL and wait for exit. If exit can’t be confirmed, atomically hand off the child PID to `run.pid` (temp-file + rename); refuse symlinked `run.pid` and symlinked temp dirs. Write `run.pid` for each run; on startup, sweep stale `anthropic-auth-e2e-*` dirs (>24h), skip symlinks, keep live runs, and clean up on setup or spawn failure. Escape hatch: `ANTHROPIC_AUTH_E2E_KEEP_TMP=1`.
  - Isolation: Keep plugin runtime files inside each run’s temp dir: account state, sidebar state, RPC dir, dump dir, and log file (`OPENCODE_ANTHROPIC_AUTH_{STATE_FILE,SIDEBAR_STATE_FILE,RPC_DIR,DUMP_DIR,LOG_FILE}`). The harness supports `childTmpDir` and sets all aliases (`TMPDIR`, `TEMP`, `TMP`) so the child’s tmp and the harness tmp stay separate.
  - Dumps: Write via unique-nonce `.partial` + rename (`O_EXCL`) to avoid races and symlink clobbering. After each write, run a throttled sweep that enforces a size cap (default 512MiB; `OPENCODE_ANTHROPIC_AUTH_DUMP_MAX_BYTES` override; 0 disables) in `OPENCODE_ANTHROPIC_AUTH_DUMP_DIR`. Only delete recognized artifacts (`*.{body,meta,relay,request}.json`, counters ≥7 digits), refuse symlinked/unexpected dirs, delete only regular files, evict oldest first, never remove files younger than 60s, and reclaim stale `.partial` files (>10m).

<sup>Written for commit c4d2f49694b0fdd34140adbe06d27f612cf5e483. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR cleans up e2e temp files and limits dump directory growth. The main changes are:

- Per-run e2e temp directories are removed on normal and failure paths.
- Stale e2e temp directories are swept with PID-based live-run checks.
- Dump files are written through unique partial files before rename.
- Dump directories are swept under a configurable size cap.
- Child runtime state, logs, RPC files, and dumps are routed into each run directory.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The previous cleanup and dump-cap failure paths are covered by the updated code and tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/dump.ts | Adds atomic dump writes and guarded size-cap sweeping for configured dump directories. |
| packages/core/src/tests/dump.test.ts | Adds tests for dump sweeping, custom directories, symlink refusal, cap settings, and partial-file handling. |
| packages/e2e-tests/src/opencode-runner.ts | Adds e2e temp-dir ownership tracking, stale cleanup, child termination handling, and isolated child runtime paths. |
| packages/e2e-tests/src/harness.ts | Passes the child temp-directory override into the e2e runner. |
| packages/e2e-tests/tests/tmp-hygiene.test.ts | Adds coverage for e2e temp-dir cleanup, stale-run ownership, termination fallback, and symlink guards. |
| packages/e2e-tests/tests/tool-prefix.test.ts | Adds coverage that sidebar state stays inside the isolated run directory. |

</details>

<sub>Reviews (11): Last reviewed commit: ["fix: clean up e2e temp dirs and cap dump..."](https://github.com/cortexkit/anthropic-auth/commit/c4d2f49694b0fdd34140adbe06d27f612cf5e483) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45071044)</sub>

**Context used:**

- Context used - captures/AGENTS.md ([source](https://app.greptile.com/cortexkit/github/cortexkit/anthropic-auth/-/custom-context?memory=5bff518c-95bc-4c01-a7a3-295576599e9c))
- Context used - AGENTS.md ([source](https://app.greptile.com/cortexkit/github/cortexkit/anthropic-auth/-/custom-context?memory=f5d9c3e7-5536-4afd-9d61-28fa37788920))

<!-- /greptile_comment -->