### PR TITLE
fix(opencode): keep client-side content-filter recovery armed in server fallback mode

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -4143,27 +4143,25 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                 incomingHeaders.get('x-session-affinity') ||
                 incomingHeaders.get('x-opencode-session')
               const requestModel = parseRequestModel(init?.body)
-              const serverFallbackModel =
-                fallbackMode === 'server' &&
-                isRecoverableRefusalModel(requestModel)
-                  ? requestModel
-                  : undefined
               let fablePlan = fableFallbackManager.plan(sessionId, init?.body)
-              if (
-                fallbackMode === 'legacy' &&
-                fablePlan &&
-                !fablePlan.downgraded
-              ) {
+              if (fablePlan && !fablePlan.downgraded) {
                 const finalWarm = recoveryWarmChains.get(fablePlan.recoveryKey)
                 if (finalWarm) {
                   await finalWarm
                   fablePlan = fableFallbackManager.plan(sessionId, init?.body)
                 }
               }
+              const serverFallbackModel =
+                fallbackMode === 'server' &&
+                isRecoverableRefusalModel(
+                  fablePlan?.effectiveModel ?? requestModel,
+                )
+                  ? (fablePlan?.effectiveModel ?? requestModel)
+                  : undefined
               const fableRequest: FableRequestContext | undefined = fablePlan
                 ? { plan: fablePlan }
                 : undefined
-              if (fallbackMode === 'legacy' && fablePlan?.downgraded) {
+              if (fablePlan?.downgraded) {
                 init = { ...init, body: fablePlan.bodyText }
               }
 
@@ -4178,9 +4176,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                 createStrippedStream(response, {
                   perf: (stage, data) => trace.mark(stage, data),
                   contentFilterModel: fablePlan?.requestedModel,
-                  ...(fallbackMode === 'legacy' &&
-                  !fablePlan?.downgraded &&
-                  fablePlan
+                  ...(!fablePlan?.downgraded && fablePlan
                     ? {
                         onContentFilter: () => {
                           if (!fableRequest?.warmTarget) {
@@ -4218,9 +4214,7 @@ export const AnthropicAuthPlugin: Plugin = async (ctx) => {
                         },
                       }
                     : {}),
-                  ...(fallbackMode === 'legacy' &&
-                  fablePlan?.downgraded &&
-                  fableRequest
+                  ...(fablePlan?.downgraded && fableRequest
                     ? {
                         onComplete: (finishReason: string) => {
                           const completed = fableFallbackManager.complete(

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -7917,6 +7917,278 @@ describe('auth.loader', () => {
     ).toBe(0)
   })
 
+  test('server mode — refusal with no server-side handoff downgrades to Opus (wedge regression)', async () => {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_FALLBACK_MODE
+    await useTempAccountFile(
+      createFallbackStorage({
+        accounts: [],
+        claudeCache: { enabled: false },
+        cacheKeep: { enabled: false },
+      }),
+    )
+    const models: string[] = []
+    let firstFable = true
+    const refusalSse = [
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_filtered"}}\n\n',
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"refusal"},"usage":{"output_tokens":0}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ].join('')
+    const successSse = [
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_ok"}}\n\n',
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ].join('')
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/api/oauth/usage')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              five_hour: { utilization: 0 },
+              seven_day: { utilization: 0 },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      if (!url.includes('/v1/messages')) {
+        return Promise.resolve(new Response('{}', { status: 200 }))
+      }
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+      if (body.max_tokens === 0) {
+        return Promise.resolve(new Response('{}', { status: 200 }))
+      }
+      models.push(String(body.model))
+      if (body.model === 'claude-fable-5' && firstFable) {
+        firstFable = false
+        return Promise.resolve(new Response(refusalSse, { status: 200 }))
+      }
+      return Promise.resolve(new Response(successSse, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    const request = {
+      method: 'POST',
+      headers: { 'x-session-affinity': 'ses_wedge' },
+      body: JSON.stringify({
+        model: 'claude-fable-5',
+        max_tokens: 128_000,
+        stream: true,
+        system: [{ type: 'text', text: 'stable system' }],
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    }
+
+    // First request hits the refusal — onContentFilter fires, stream rejects.
+    // The second request must carry the downgraded Opus model.
+    const filtered = await result.fetch(MESSAGES_URL, request)
+    await expect(filtered.text()).rejects.toThrow()
+    const second = await result.fetch(MESSAGES_URL, request)
+    await second.text()
+
+    expect(models).toEqual(['claude-fable-5', 'claude-opus-4-8'])
+  })
+
+  test('server mode — absorbed server-side fallback does NOT activate client-side downgrade', async () => {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_FALLBACK_MODE
+    await useTempAccountFile(
+      createFallbackStorage({
+        accounts: [],
+        claudeCache: { enabled: false },
+        cacheKeep: { enabled: false },
+      }),
+    )
+    const models: string[] = []
+    const frame = (event: string, data: unknown) =>
+      `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+    const fallbackSse = [
+      frame('message_start', {
+        type: 'message_start',
+        message: { id: 'msg_fallback', model: 'claude-opus-5' },
+      }),
+      frame('content_block_start', {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'fallback',
+          from: { model: 'claude-fable-5' },
+          to: { model: 'claude-opus-5' },
+        },
+      }),
+      frame('content_block_stop', { type: 'content_block_stop', index: 0 }),
+      frame('content_block_start', {
+        type: 'content_block_start',
+        index: 1,
+        content_block: { type: 'text', text: '' },
+      }),
+      frame('content_block_delta', {
+        type: 'content_block_delta',
+        index: 1,
+        delta: { type: 'text_delta', text: 'safe answer' },
+      }),
+      frame('content_block_stop', { type: 'content_block_stop', index: 1 }),
+      frame('message_delta', {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+        usage: { output_tokens: 2 },
+      }),
+      frame('message_stop', { type: 'message_stop' }),
+    ].join('')
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/api/oauth/usage')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              five_hour: { utilization: 0 },
+              seven_day: { utilization: 0 },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      if (!url.includes('/v1/messages')) {
+        return Promise.resolve(new Response('{}', { status: 200 }))
+      }
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+      if (body.max_tokens === 0) {
+        return Promise.resolve(new Response('{}', { status: 200 }))
+      }
+      models.push(String(body.model))
+      return Promise.resolve(new Response(fallbackSse, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    const request = {
+      method: 'POST',
+      headers: { 'x-session-affinity': 'ses_no_double' },
+      body: JSON.stringify({
+        model: 'claude-fable-5',
+        max_tokens: 128_000,
+        stream: true,
+        system: [{ type: 'text', text: 'stable system' }],
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    }
+
+    const first = await result.fetch(MESSAGES_URL, request)
+    await first.text()
+    const second = await result.fetch(MESSAGES_URL, request)
+    await second.text()
+
+    // Both requests stayed on Fable — no client-side downgrade triggered.
+    expect(models).toEqual(['claude-fable-5', 'claude-fable-5'])
+  })
+
+  test('server mode — downgraded Opus request does not carry server-side fallback opt-in', async () => {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_FALLBACK_MODE
+    await useTempAccountFile(
+      createFallbackStorage({
+        accounts: [],
+        claudeCache: { enabled: false },
+        cacheKeep: { enabled: false },
+      }),
+    )
+    const models: string[] = []
+    const bodies: Array<Record<string, unknown>> = []
+    let firstFable = true
+    const refusalSse = [
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_filtered"}}\n\n',
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"refusal"},"usage":{"output_tokens":0}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ].join('')
+    const successSse = [
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_ok"}}\n\n',
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ].join('')
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/api/oauth/usage')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              five_hour: { utilization: 0 },
+              seven_day: { utilization: 0 },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      if (!url.includes('/v1/messages')) {
+        return Promise.resolve(new Response('{}', { status: 200 }))
+      }
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+      if (body.max_tokens === 0) {
+        return Promise.resolve(new Response('{}', { status: 200 }))
+      }
+      models.push(String(body.model))
+      bodies.push(body)
+      if (body.model === 'claude-fable-5' && firstFable) {
+        firstFable = false
+        return Promise.resolve(new Response(refusalSse, { status: 200 }))
+      }
+      return Promise.resolve(new Response(successSse, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'main-access',
+          refresh: 'main-refresh',
+          expires: Date.now() + 100000,
+        }),
+      { models: {} },
+    )
+    const request = {
+      method: 'POST',
+      headers: { 'x-session-affinity': 'ses_no_optin' },
+      body: JSON.stringify({
+        model: 'claude-fable-5',
+        max_tokens: 128_000,
+        stream: true,
+        system: [{ type: 'text', text: 'stable system' }],
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    }
+
+    // First request hits the refusal. After the fix, onContentFilter fires
+    // causing the stream to reject with a ContentFilterError.
+    const filtered = await result.fetch(MESSAGES_URL, request)
+    await expect(filtered.text()).rejects.toThrow()
+    const opus = await result.fetch(MESSAGES_URL, request)
+    await opus.text()
+
+    expect(models).toEqual(['claude-fable-5', 'claude-opus-4-8'])
+    // The Opus request must NOT carry the server-side fallback opt-in.
+    expect(bodies[1]?.fallbacks).toBeUndefined()
+  })
+
   test('uses the sidebar instead of promptAsync when the matching TUI is connected', async () => {
     await useTempAccountFile(
       createFallbackStorage({

--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -4,6 +4,7 @@ import {
   FAST_MODE_BETA,
   OPENCODE_IDENTITY_PREFIX,
   REQUIRED_BETAS,
+  selectClaudeCodeBetas,
 } from '@cortexkit/anthropic-auth-core'
 import dedent from 'dedent'
 import {
@@ -983,6 +984,26 @@ describe('prepareFableCacheWarmSource', () => {
     const body = JSON.parse(source.bodyText)
     expect(body.model).toBe('claude-opus-5')
     expect(body.thinking).toEqual({ type: 'adaptive', display: 'summarized' })
+  })
+
+  test('strips the server-side fallback opt-in so the source-model prewarm never triggers Anthropic fallback routing', () => {
+    const source = prepareFableCacheWarmSource(
+      JSON.stringify({
+        model: 'claude-opus-4-8',
+        fallbacks: 'default',
+        speed: 'fast',
+        messages: [{ role: 'user', content: 'same input' }],
+      }),
+    )
+
+    expect(source.ok).toBe(true)
+    if (!source.ok) throw new Error(source.reason)
+    const body = JSON.parse(source.bodyText)
+    expect(body.fallbacks).toBeUndefined()
+    expect(body.speed).toBeUndefined()
+    expect(selectClaudeCodeBetas(body).split(',')).not.toContain(
+      'server-side-fallback-2026-07-01',
+    )
   })
 })
 

--- a/packages/opencode/src/transform.ts
+++ b/packages/opencode/src/transform.ts
@@ -1022,6 +1022,9 @@ export function prepareFableCacheWarmSource(
     const body = JSON.parse(bodyText) as Record<string, unknown>
     body.model = fableModel
     delete body.speed
+    // The prewarm must reach the source model (not be fallback-routed),
+    // so strip any server-side fallback opt-in inherited from the captured body.
+    delete body.fallbacks
     normalizeFableMythosRequest(body)
     normalizeOpus5Request(body)
     return { ok: true, bodyText: JSON.stringify(body) }


### PR DESCRIPTION
Server-side safety fallback and the client-side content-filter recovery are currently mutually exclusive. `fallbackMode` defaults to `server`, and the client-side recovery is gated behind `fallbackMode === 'legacy'`, so in the default configuration a refusal that Anthropic's server-side fallback does not absorb reaches the client as a fatal `ContentFilterError` with no downgrade path — and the session stays broken for every subsequent turn.

Hit live on a Fable 5 session today:

```
22:10:50  assistant  ContentFilterError "The response was blocked by the provider's content filter"
22:13:29  INFO [fable-fallback] Anthropic server-side safety fallback active … targetModel=claude-opus-4-8 handoff=true
22:17:15  assistant  ContentFilterError
```

No recovery line anywhere, and the 22:13 fallback never logged "ended". An earlier refusal in the same session (`active` → `ended` in 12s) shows the server-side path working when Anthropic does absorb the refusal — the failure is specifically the unabsorbed path. Both refusals were triggered by benign content (a documentation URL, and a malformed `curl` command).

## Change

Removes the `fallbackMode === 'legacy'` gate from the four client-side recovery sites in `index.ts` (warm-chain re-plan, downgraded-body rewrite, `onContentFilter`, `onComplete`), making server-side fallback the first line and the client-side downgrade a backstop rather than an alternative.

This does not double-recover: when server-side fallback absorbs a refusal, the stream rewriter turns it into a normal completion, so `stop_reason: "refusal"` never reaches the finish-state handler and `onContentFilter` does not fire. The backstop only engages on the path that currently dies.

`serverFallbackModel` now derives from `fablePlan?.effectiveModel ?? requestModel` (and moved below the warm-chain re-plan so the plan is final). Without this, a downgraded turn would carry a `claude-opus-4-8` body while still requesting server-side fallback for the original model.

The default mode and the `OPENCODE_ANTHROPIC_AUTH_FALLBACK_MODE` escape hatch are unchanged.

## Tests

Three tests added, all in server (default) mode:

- refusal with no server-side handoff activates the client-side downgrade — the wedge regression. Fails on `main` (both requests carry `claude-fable-5`), passes here.
- an absorbed server-side fallback does not activate the client-side downgrade — no double-recovery.
- a downgraded Opus request does not carry the server-side fallback opt-in.

## Verification

typecheck, build, lint, biome check clean. opencode 1014 / core 69 / pi 57 pass.

e2e is 25 pass / 1 fail — `tool-prefix.test.ts:301` "bridges back to a stale Opus cache after more than 20 Fable blocks", which is **pre-existing on `main`**: verified 0/3 pass on a pristine `41e9aee` checkout with no commits from this branch, and 0/3 with them. Unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788986239&installation_model_id=22398&pr_number=146&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F146&signature=33bb899e8caa04152ce6d870a0046a27caf335021d836543e1d7f44166d1bd3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps client-side content-filter recovery armed in server fallback mode so unabsorbed refusals downgrade instead of throwing a fatal `ContentFilterError`. Also prevents cache prewarm requests from opting into server-side fallback routing in `opencode`.

- **Bug Fixes**
  - Removed the `fallbackMode === 'legacy'` gate for warm-chain replan, downgraded-body rewrite, `onContentFilter`, and `onComplete`.
  - Derived `serverFallbackModel` from `fablePlan?.effectiveModel ?? requestModel` after re-plan, so downgraded `claude-opus-4-8` requests don’t opt into server-side fallback.
  - Prevented double-recovery: absorbed server fallbacks are rewritten to normal completions, so client-side handlers do not fire.
  - Defaults unchanged: `fallbackMode` remains `server`; `OPENCODE_ANTHROPIC_AUTH_FALLBACK_MODE` still works.
  - Stripped `fallbacks` opt-in from source-model cache prewarm so warm requests reach the source model and don’t trigger server-side fallback routing.

<sup>Written for commit e8ebeaeb3750bfdd69312b70572840a3bc33c0a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR keeps client-side content-filter recovery active as a backstop in server fallback mode while ensuring downgraded and prewarm requests use routing options appropriate to their effective models.
- Removes legacy-mode gating from fallback planning and recovery callbacks.
- Computes server fallback handling from the final effective request model.
- Strips server fallback opt-in from source-model cache prewarms.
- Adds regression coverage for unabsorbed refusals, absorbed server fallbacks, and downgraded requests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/opencode/src/index.ts | Enables client-side refusal recovery in server mode and aligns server fallback stream handling with the final planned request model. |
| packages/opencode/src/transform.ts | Removes the server-side fallback body opt-in when constructing source-model cache prewarm requests. |
| packages/opencode/src/tests/index.test.ts | Adds server-mode regression tests covering unabsorbed refusals, absorbed fallbacks, and downgraded request routing. |
| packages/opencode/src/tests/transform.test.ts | Verifies that cache prewarm transformation removes fallback and fast-mode opt-ins. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Plugin
    participant Anthropic
    Client->>Plugin: Fable request
    Plugin->>Anthropic: Fable request with server fallback enabled
    alt Server fallback absorbs refusal
        Anthropic-->>Plugin: Normal rewritten completion
        Plugin-->>Client: Successful response
    else Refusal remains visible
        Anthropic-->>Plugin: refusal
        Plugin->>Plugin: Activate client-side downgrade
        Plugin-->>Client: ContentFilterError for current stream
        Client->>Plugin: Next request
        Plugin->>Anthropic: Opus request without server fallback opt-in
        Anthropic-->>Plugin: Completion
        Plugin-->>Client: Successful response
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(opencode): strip server-side fallbac..."](https://github.com/cortexkit/anthropic-auth/commit/e8ebeaeb3750bfdd69312b70572840a3bc33c0a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51960820)</sub>

<!-- /greptile_comment -->