### PR TITLE
fix(pi): Claude Code billing rejection and missing claude-opus-5

### DIFF
--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -2,7 +2,7 @@
 
 Pi package for CortexKit Anthropic OAuth support. It overrides Pi's built-in `anthropic` provider with a CortexKit provider extension backed by the shared `@cortexkit/anthropic-auth-core` package.
 
-The Pi provider catalog includes Claude Fable 5 (`claude-fable-5`), limited-access Claude Mythos 5 (`claude-mythos-5`), Claude Opus 4.8, Claude Opus 4.5, Claude Sonnet 4.5, and Claude Sonnet 5 (`claude-sonnet-5`). Fable/Mythos reasoning uses Anthropic adaptive thinking with `thinking.display: "summarized"` and `output_config.effort`; the package does not send rejected manual `thinking.budget_tokens` for those models.
+The Pi provider catalog includes Claude Fable 5 (`claude-fable-5`), limited-access Claude Mythos 5 (`claude-mythos-5`), Claude Opus 5 (`claude-opus-5`), Claude Opus 4.8, Claude Opus 4.5, Claude Sonnet 4.5, and Claude Sonnet 5 (`claude-sonnet-5`). Fable/Mythos reasoning uses Anthropic adaptive thinking with `thinking.display: "summarized"` and `output_config.effort`; the package does not send rejected manual `thinking.budget_tokens` for those models.
 
 This package is part of the CortexKit Anthropic Auth monorepo, which supports both OpenCode (`@cortexkit/opencode-anthropic-auth`) and Pi (`@cortexkit/pi-anthropic-auth`) through the same shared core logic.
 

--- a/packages/pi/src/convert.ts
+++ b/packages/pi/src/convert.ts
@@ -403,9 +403,12 @@ export async function buildAnthropicRequest(
       firstUser.content = `${prompt}\n\n${content}`
     } else if (firstUser && Array.isArray(content)) {
       content.unshift({ type: 'text', text: prompt })
-    } else {
-      system.push({ type: 'text', text: prompt })
     }
+    // No else: with no user message, messages[] is necessarily empty
+    // (convertMessages emits only user/assistant, and trailing assistants are
+    // stripped above), so the request is already invalid. Pushing the prompt
+    // into system[] there would recreate the rejected three-entry shape for
+    // no benefit, so the prompt is dropped instead.
   }
 
   const body: AnthropicRequestBody = {

--- a/packages/pi/src/convert.ts
+++ b/packages/pi/src/convert.ts
@@ -391,7 +391,21 @@ export async function buildAnthropicRequest(
     { type: 'text', text: CLAUDE_CODE_IDENTITY },
   ]
   if (context.systemPrompt?.trim()) {
-    system.push({ type: 'text', text: sanitize(context.systemPrompt) })
+    // Anthropic validates system[] for OAuth requests using Claude Code
+    // billing. Third-party system content alongside the identity block is
+    // rejected with 400 "You're out of extra usage". Keep only the billing
+    // header and identity in system[], and relocate Pi's prompt to the first
+    // user message, where it is functionally equivalent.
+    const prompt = sanitize(context.systemPrompt)
+    const firstUser = messages.find((m) => m.role === 'user')
+    const content = firstUser?.content
+    if (firstUser && typeof content === 'string') {
+      firstUser.content = `${prompt}\n\n${content}`
+    } else if (firstUser && Array.isArray(content)) {
+      content.unshift({ type: 'text', text: prompt })
+    } else {
+      system.push({ type: 'text', text: prompt })
+    }
   }
 
   const body: AnthropicRequestBody = {

--- a/packages/pi/src/convert.ts
+++ b/packages/pi/src/convert.ts
@@ -27,6 +27,11 @@ import type {
   ToolResultMessage,
 } from '@earendil-works/pi-ai'
 
+// Anchor identifying Pi's documentation paragraph — the only part of the prompt
+// that Anthropic rejects in system[]. If pi upstream renames this heading the
+// split stops separating and the whole prompt returns to system[], which 400s.
+const PI_DOCS_ANCHOR = 'Pi documentation'
+
 const CLAUDE_CODE_TOOLS = new Map(
   [
     'Read',
@@ -391,36 +396,49 @@ export async function buildAnthropicRequest(
     { type: 'text', text: CLAUDE_CODE_IDENTITY },
   ]
   if (context.systemPrompt?.trim()) {
-    // Pi's prompt cannot sit in the top-level system[] array: two lines of its
-    // documentation paragraph (the docs/*.md enumeration and the "follow .md
+    // Pi's prompt cannot sit whole in the top-level system[] array: two lines of
+    // its documentation paragraph (the docs/*.md enumeration and the "follow .md
     // cross-references" instruction) are each independently sufficient to make
     // Anthropic reject the request with 400 "You're out of extra usage". Entry
     // count and payload size are ruled out — 2697 bytes of neutral filler in the
-    // same position is accepted. The same text is accepted inside messages[], so
-    // carry the prompt as a role: "system" message and keep system[] to the
-    // billing header and identity block.
+    // same position is accepted, and the same text is accepted inside messages[].
     //
-    // cache_control is set here rather than left to addEphemeralCacheControl,
-    // whose message-level breakpoint only fires when a message's content is an
-    // array — Pi sends plain strings, so it never fires. Without this marker the
-    // prompt sits outside the cached prefix and is reprocessed every turn.
-    const prompt = sanitize(context.systemPrompt)
-    const firstUserIndex = messages.findIndex((m) => m.role === 'user')
-    if (firstUserIndex !== -1) {
-      messages.splice(firstUserIndex + 1, 0, {
-        role: 'system',
-        content: [
-          {
-            type: 'text',
-            text: prompt,
-            cache_control: { type: 'ephemeral' },
-          },
-        ],
-      })
+    // Keep the identity, tool contract and guidelines in system[], where they
+    // carry system weight and survive context compaction, and carry only the
+    // documentation paragraph in messages[].
+    //
+    // It goes in as its own content block ahead of the user's text, not merged
+    // into it and not as a separate message. A cache prefix matches contiguously
+    // from the start of the request, so a block boundary here lets the prefix end
+    // before the user's words: a new conversation with a different first message
+    // still reads the paragraph from cache instead of re-writing ~1.1k tokens.
+    // A role: "system" message cannot be used at messages[0] — Anthropic rejects
+    // that — and placing one after the first user message puts it behind content
+    // that varies, which defeats the caching.
+    //
+    // cache_control is set explicitly because addEphemeralCacheControl's
+    // message-level breakpoint only fires for array content on the *last* user
+    // message, which is not this one after the first turn.
+    const paras = sanitize(context.systemPrompt).split(/\n\n+/)
+    const keep = paras.filter((p) => !p.includes(PI_DOCS_ANCHOR))
+    const docs = paras.filter((p) => p.includes(PI_DOCS_ANCHOR))
+    if (keep.length) {
+      system.push({ type: 'text', text: keep.join('\n\n') })
     }
-    // No else: with no user message, messages[] is necessarily empty
-    // (convertMessages emits only user/assistant, and trailing assistants are
-    // stripped above), so the request is already invalid.
+    if (docs.length) {
+      const firstUser = messages.find((m) => m.role === 'user')
+      const content = firstUser?.content
+      const docsBlock = {
+        type: 'text',
+        text: docs.join('\n\n'),
+        cache_control: { type: 'ephemeral' as const },
+      }
+      if (firstUser && typeof content === 'string') {
+        firstUser.content = [docsBlock, { type: 'text', text: content }]
+      } else if (firstUser && Array.isArray(content)) {
+        content.unshift(docsBlock)
+      }
+    }
   }
 
   const body: AnthropicRequestBody = {

--- a/packages/pi/src/convert.ts
+++ b/packages/pi/src/convert.ts
@@ -391,24 +391,36 @@ export async function buildAnthropicRequest(
     { type: 'text', text: CLAUDE_CODE_IDENTITY },
   ]
   if (context.systemPrompt?.trim()) {
-    // Anthropic validates system[] for OAuth requests using Claude Code
-    // billing. Third-party system content alongside the identity block is
-    // rejected with 400 "You're out of extra usage". Keep only the billing
-    // header and identity in system[], and relocate Pi's prompt to the first
-    // user message, where it is functionally equivalent.
+    // Pi's prompt cannot sit in the top-level system[] array: two lines of its
+    // documentation paragraph (the docs/*.md enumeration and the "follow .md
+    // cross-references" instruction) are each independently sufficient to make
+    // Anthropic reject the request with 400 "You're out of extra usage". Entry
+    // count and payload size are ruled out — 2697 bytes of neutral filler in the
+    // same position is accepted. The same text is accepted inside messages[], so
+    // carry the prompt as a role: "system" message and keep system[] to the
+    // billing header and identity block.
+    //
+    // cache_control is set here rather than left to addEphemeralCacheControl,
+    // whose message-level breakpoint only fires when a message's content is an
+    // array — Pi sends plain strings, so it never fires. Without this marker the
+    // prompt sits outside the cached prefix and is reprocessed every turn.
     const prompt = sanitize(context.systemPrompt)
-    const firstUser = messages.find((m) => m.role === 'user')
-    const content = firstUser?.content
-    if (firstUser && typeof content === 'string') {
-      firstUser.content = `${prompt}\n\n${content}`
-    } else if (firstUser && Array.isArray(content)) {
-      content.unshift({ type: 'text', text: prompt })
+    const firstUserIndex = messages.findIndex((m) => m.role === 'user')
+    if (firstUserIndex !== -1) {
+      messages.splice(firstUserIndex + 1, 0, {
+        role: 'system',
+        content: [
+          {
+            type: 'text',
+            text: prompt,
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      })
     }
     // No else: with no user message, messages[] is necessarily empty
     // (convertMessages emits only user/assistant, and trailing assistants are
-    // stripped above), so the request is already invalid. Pushing the prompt
-    // into system[] there would recreate the rejected three-entry shape for
-    // no benefit, so the prompt is dropped instead.
+    // stripped above), so the request is already invalid.
   }
 
   const body: AnthropicRequestBody = {

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -81,6 +81,15 @@ export default function cortexKitPiAnthropicAuth(pi: ExtensionAPI) {
         maxTokens: CLAUDE_FABLE_MYTHOS_5_MAX_OUTPUT_TOKENS,
       })),
       {
+        id: 'claude-opus-5',
+        name: 'Claude Opus 5',
+        reasoning: true,
+        input: textImageInput(),
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
+      {
         id: 'claude-opus-4-8',
         name: 'Claude Opus 4.8',
         reasoning: true,

--- a/packages/pi/src/tests/convert.test.ts
+++ b/packages/pi/src/tests/convert.test.ts
@@ -378,12 +378,14 @@ describe('buildAnthropicRequest — Claude Code system[] shape', () => {
     expect(content[0]).toEqual({ type: 'text', text: 'PI PROMPT' })
   })
 
-  test('falls back to system[] when there is no user message', async () => {
+  test('drops the prompt when there is no user message to carry it', async () => {
     const body = await buildBody([assistantMsg('only assistant')], 'PI PROMPT')
-    expect(body.system).toHaveLength(3)
-    // toMatchObject, not toEqual: the ephemeral cache anchor attaches to the
-    // last system entry, which in this fallback path is the prompt itself.
-    expect(body.system?.[2]).toMatchObject({ type: 'text', text: 'PI PROMPT' })
+    // convertMessages emits only user/assistant and trailing assistants are
+    // stripped, so a conversation with no user message converts to empty.
+    // system[] must stay at two entries even on this path.
+    expect(body.messages).toHaveLength(0)
+    expect(body.system).toHaveLength(2)
+    expect(JSON.stringify(body.system)).not.toContain('PI PROMPT')
   })
 
   test('leaves the identity block as the last system entry for cache anchoring', async () => {

--- a/packages/pi/src/tests/convert.test.ts
+++ b/packages/pi/src/tests/convert.test.ts
@@ -33,8 +33,8 @@ function toolResultMsg(toolCallId: string, text: string): Message {
 
 const defaultCache = { enabled: false, mode: 'hybrid' as const }
 
-// systemPrompt is opt-in. buildAnthropicRequest relocates a non-empty prompt
-// onto the first user message, so tests that assert raw conversion output pass
+// systemPrompt is opt-in. buildAnthropicRequest carries a non-empty prompt as a
+// separate role: "system" message, so tests that assert raw conversion output pass
 // no prompt and observe messages unchanged. The relocation itself is covered by
 // the "Claude Code system[] shape" block below.
 async function buildMessages(messages: Message[], systemPrompt?: string) {
@@ -331,10 +331,10 @@ describe('convertMessages — empty base64 image guard', () => {
 })
 
 describe('buildAnthropicRequest — Claude Code system[] shape', () => {
-  // Anthropic rejects OAuth requests carrying Claude Code billing headers when
-  // third-party system content sits in system[] alongside the identity block.
-  // These cases pin the resulting shape: system[] holds only the billing header
-  // and the identity block, and Pi's prompt rides on the first user message.
+  // Pi's prompt cannot sit in the top-level system[] array — see the note in
+  // convert.ts. These cases pin the resulting shape: system[] holds only the
+  // billing header and the identity block, and Pi's prompt is carried as a
+  // role: "system" message immediately after the first user message.
   async function buildBody(messages: Message[], systemPrompt?: string) {
     const { body } = await buildAnthropicRequest(
       'claude-sonnet-4-20250514',
@@ -351,15 +351,25 @@ describe('buildAnthropicRequest — Claude Code system[] shape', () => {
     expect(JSON.stringify(body.system)).not.toContain('PI PROMPT')
   })
 
-  test('prepends the prompt to a string first user message', async () => {
+  test('carries the prompt as a system message after the first user message', async () => {
     const body = await buildBody([userMsg('hello')], 'PI PROMPT')
-    expect(body.messages[0]).toEqual({
-      role: 'user',
-      content: 'PI PROMPT\n\nhello',
+    expect(body.messages[0]).toEqual({ role: 'user', content: 'hello' })
+    expect(body.messages[1]).toEqual({
+      role: 'system',
+      content: [
+        {
+          type: 'text',
+          text: 'PI PROMPT',
+          // Set explicitly: addEphemeralCacheControl's message-level breakpoint
+          // only fires for array content on the last user message, which Pi's
+          // plain-string messages never satisfy.
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
     })
   })
 
-  test('prepends a text block when the first user message is structured', async () => {
+  test('leaves a structured first user message untouched', async () => {
     const body = await buildBody(
       [
         {
@@ -374,8 +384,9 @@ describe('buildAnthropicRequest — Claude Code system[] shape', () => {
       'PI PROMPT',
     )
     const content = body.messages[0]?.content as Array<Record<string, unknown>>
-    expect(content).toHaveLength(3)
-    expect(content[0]).toEqual({ type: 'text', text: 'PI PROMPT' })
+    expect(content).toHaveLength(2)
+    expect(content[0]).toMatchObject({ type: 'text', text: 'see image' })
+    expect(body.messages[1]).toMatchObject({ role: 'system' })
   })
 
   test('drops the prompt when there is no user message to carry it', async () => {

--- a/packages/pi/src/tests/convert.test.ts
+++ b/packages/pi/src/tests/convert.test.ts
@@ -33,10 +33,14 @@ function toolResultMsg(toolCallId: string, text: string): Message {
 
 const defaultCache = { enabled: false, mode: 'hybrid' as const }
 
-async function buildMessages(messages: Message[]) {
+// systemPrompt is opt-in. buildAnthropicRequest relocates a non-empty prompt
+// onto the first user message, so tests that assert raw conversion output pass
+// no prompt and observe messages unchanged. The relocation itself is covered by
+// the "Claude Code system[] shape" block below.
+async function buildMessages(messages: Message[], systemPrompt?: string) {
   const context = {
     messages,
-    systemPrompt: 'test',
+    systemPrompt,
     tools: [],
   }
   const { body } = await buildAnthropicRequest(
@@ -323,6 +327,74 @@ describe('convertMessages — empty base64 image guard', () => {
     const content = messages[0]?.content as Array<Record<string, unknown>>
     expect(content.length).toBe(2)
     expect(content[1]?.type).toBe('image')
+  })
+})
+
+describe('buildAnthropicRequest — Claude Code system[] shape', () => {
+  // Anthropic rejects OAuth requests carrying Claude Code billing headers when
+  // third-party system content sits in system[] alongside the identity block.
+  // These cases pin the resulting shape: system[] holds only the billing header
+  // and the identity block, and Pi's prompt rides on the first user message.
+  async function buildBody(messages: Message[], systemPrompt?: string) {
+    const { body } = await buildAnthropicRequest(
+      'claude-sonnet-4-20250514',
+      { messages, systemPrompt, tools: [] } as any,
+      undefined,
+      defaultCache,
+    )
+    return body
+  }
+
+  test('keeps system[] to the billing header and identity block', async () => {
+    const body = await buildBody([userMsg('hello')], 'PI PROMPT')
+    expect(body.system).toHaveLength(2)
+    expect(JSON.stringify(body.system)).not.toContain('PI PROMPT')
+  })
+
+  test('prepends the prompt to a string first user message', async () => {
+    const body = await buildBody([userMsg('hello')], 'PI PROMPT')
+    expect(body.messages[0]).toEqual({
+      role: 'user',
+      content: 'PI PROMPT\n\nhello',
+    })
+  })
+
+  test('prepends a text block when the first user message is structured', async () => {
+    const body = await buildBody(
+      [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'see image' },
+            { type: 'image', mimeType: 'image/png', data: 'aGVsbG8=' },
+          ],
+          timestamp: 0,
+        } as Message,
+      ],
+      'PI PROMPT',
+    )
+    const content = body.messages[0]?.content as Array<Record<string, unknown>>
+    expect(content).toHaveLength(3)
+    expect(content[0]).toEqual({ type: 'text', text: 'PI PROMPT' })
+  })
+
+  test('falls back to system[] when there is no user message', async () => {
+    const body = await buildBody([assistantMsg('only assistant')], 'PI PROMPT')
+    expect(body.system).toHaveLength(3)
+    // toMatchObject, not toEqual: the ephemeral cache anchor attaches to the
+    // last system entry, which in this fallback path is the prompt itself.
+    expect(body.system?.[2]).toMatchObject({ type: 'text', text: 'PI PROMPT' })
+  })
+
+  test('leaves the identity block as the last system entry for cache anchoring', async () => {
+    const body = await buildBody([userMsg('hello')], 'PI PROMPT')
+    expect(String(body.system?.at(-1)?.text)).toContain('Claude Code')
+  })
+
+  test('leaves system[] and messages untouched when no prompt is set', async () => {
+    const body = await buildBody([userMsg('hello')])
+    expect(body.system).toHaveLength(2)
+    expect(body.messages[0]).toEqual({ role: 'user', content: 'hello' })
   })
 })
 

--- a/packages/pi/src/tests/convert.test.ts
+++ b/packages/pi/src/tests/convert.test.ts
@@ -33,9 +33,17 @@ function toolResultMsg(toolCallId: string, text: string): Message {
 
 const defaultCache = { enabled: false, mode: 'hybrid' as const }
 
-// systemPrompt is opt-in. buildAnthropicRequest carries a non-empty prompt as a
-// separate role: "system" message, so tests that assert raw conversion output pass
-// no prompt and observe messages unchanged. The relocation itself is covered by
+// Mirrors the shape of Pi's real prompt: instruction paragraphs followed by the
+// documentation paragraph, which is the only part Anthropic rejects in system[].
+const PI_PROMPT = [
+  'KEEP ONE: you are an assistant.',
+  'KEEP TWO: available tools.',
+  'Pi documentation (read only when the user asks about pi itself):\n- MOVE THIS',
+].join('\n\n')
+
+// systemPrompt is opt-in. buildAnthropicRequest splits a non-empty prompt between
+// system[] and the first user message, so tests that assert raw conversion output
+// pass no prompt and observe messages unchanged. The split itself is covered by
 // the "Claude Code system[] shape" block below.
 async function buildMessages(messages: Message[], systemPrompt?: string) {
   const context = {
@@ -331,10 +339,11 @@ describe('convertMessages — empty base64 image guard', () => {
 })
 
 describe('buildAnthropicRequest — Claude Code system[] shape', () => {
-  // Pi's prompt cannot sit in the top-level system[] array — see the note in
-  // convert.ts. These cases pin the resulting shape: system[] holds only the
-  // billing header and the identity block, and Pi's prompt is carried as a
-  // role: "system" message immediately after the first user message.
+  // Anthropic rejects Pi's documentation paragraph inside the top-level
+  // system[] array — see the note in convert.ts. These cases pin the resulting
+  // shape: the remaining paragraphs stay in system[], and the documentation
+  // paragraph is carried as its own marked content block ahead of the user's
+  // text inside the first user message.
   async function buildBody(messages: Message[], systemPrompt?: string) {
     const { body } = await buildAnthropicRequest(
       'claude-sonnet-4-20250514',
@@ -345,31 +354,33 @@ describe('buildAnthropicRequest — Claude Code system[] shape', () => {
     return body
   }
 
-  test('keeps system[] to the billing header and identity block', async () => {
-    const body = await buildBody([userMsg('hello')], 'PI PROMPT')
-    expect(body.system).toHaveLength(2)
-    expect(JSON.stringify(body.system)).not.toContain('PI PROMPT')
+  test('keeps the non-documentation paragraphs in system[]', async () => {
+    const body = await buildBody([userMsg('hello')], PI_PROMPT)
+    expect(body.system).toHaveLength(3)
+    const text = String(body.system?.[2]?.text)
+    expect(text).toContain('KEEP ONE')
+    expect(text).toContain('KEEP TWO')
+    expect(text).not.toContain('MOVE THIS')
   })
 
-  test('carries the prompt as a system message after the first user message', async () => {
-    const body = await buildBody([userMsg('hello')], 'PI PROMPT')
-    expect(body.messages[0]).toEqual({ role: 'user', content: 'hello' })
-    expect(body.messages[1]).toEqual({
-      role: 'system',
-      content: [
-        {
-          type: 'text',
-          text: 'PI PROMPT',
-          // Set explicitly: addEphemeralCacheControl's message-level breakpoint
-          // only fires for array content on the last user message, which Pi's
-          // plain-string messages never satisfy.
-          cache_control: { type: 'ephemeral' },
-        },
-      ],
-    })
+  test('carries the documentation paragraph as its own block ahead of the user text', async () => {
+    const body = await buildBody([userMsg('hello')], PI_PROMPT)
+    const content = body.messages[0]?.content as Array<Record<string, unknown>>
+    expect(content).toHaveLength(2)
+    expect(String(content[0]?.text)).toContain('MOVE THIS')
+    expect(content[1]).toMatchObject({ type: 'text', text: 'hello' })
   })
 
-  test('leaves a structured first user message untouched', async () => {
+  test('marks the documentation block so the cached prefix ends before the user text', async () => {
+    // Without this marker the prefix would extend into the user's own words,
+    // and a new conversation with a different first message would have to
+    // re-cache the paragraph.
+    const body = await buildBody([userMsg('hello')], PI_PROMPT)
+    const content = body.messages[0]?.content as Array<Record<string, unknown>>
+    expect(content[0]?.cache_control).toEqual({ type: 'ephemeral' })
+  })
+
+  test('unshifts the documentation block onto a structured first user message', async () => {
     const body = await buildBody(
       [
         {
@@ -381,27 +392,30 @@ describe('buildAnthropicRequest — Claude Code system[] shape', () => {
           timestamp: 0,
         } as Message,
       ],
-      'PI PROMPT',
+      PI_PROMPT,
     )
     const content = body.messages[0]?.content as Array<Record<string, unknown>>
-    expect(content).toHaveLength(2)
-    expect(content[0]).toMatchObject({ type: 'text', text: 'see image' })
-    expect(body.messages[1]).toMatchObject({ role: 'system' })
+    expect(content).toHaveLength(3)
+    expect(String(content[0]?.text)).toContain('MOVE THIS')
+    expect(content[1]).toMatchObject({ type: 'text', text: 'see image' })
   })
 
-  test('drops the prompt when there is no user message to carry it', async () => {
-    const body = await buildBody([assistantMsg('only assistant')], 'PI PROMPT')
+  test('drops the documentation paragraph when there is no user message to carry it', async () => {
     // convertMessages emits only user/assistant and trailing assistants are
-    // stripped, so a conversation with no user message converts to empty.
-    // system[] must stay at two entries even on this path.
+    // stripped, so a conversation with no user message converts to empty. The
+    // remaining paragraphs still go to system[], which is a shape Anthropic
+    // accepts; only the documentation paragraph is dropped.
+    const body = await buildBody([assistantMsg('only assistant')], PI_PROMPT)
     expect(body.messages).toHaveLength(0)
-    expect(body.system).toHaveLength(2)
-    expect(JSON.stringify(body.system)).not.toContain('PI PROMPT')
+    expect(body.system).toHaveLength(3)
+    expect(JSON.stringify(body.system)).not.toContain('MOVE THIS')
   })
 
-  test('leaves the identity block as the last system entry for cache anchoring', async () => {
-    const body = await buildBody([userMsg('hello')], 'PI PROMPT')
-    expect(String(body.system?.at(-1)?.text)).toContain('Claude Code')
+  test('leaves the whole prompt in system[] when it has no documentation paragraph', async () => {
+    const body = await buildBody([userMsg('hello')], 'KEEP ONLY')
+    expect(body.system).toHaveLength(3)
+    expect(String(body.system?.[2]?.text)).toContain('KEEP ONLY')
+    expect(body.messages[0]).toEqual({ role: 'user', content: 'hello' })
   })
 
   test('leaves system[] and messages untouched when no prompt is set', async () => {

--- a/packages/pi/src/tests/index.test.ts
+++ b/packages/pi/src/tests/index.test.ts
@@ -44,4 +44,23 @@ describe('cortexKitPiAnthropicAuth provider registration', () => {
       maxTokens: 128_000,
     })
   })
+
+  test('exposes Claude Opus 5 in the Pi Anthropic catalog', () => {
+    const { pi, providers } = mockPi()
+
+    cortexKitPiAnthropicAuth(pi)
+
+    const opus5 = providers
+      .get('anthropic')
+      ?.models?.find((model) => model.id === 'claude-opus-5')
+    expect(opus5).toMatchObject({
+      id: 'claude-opus-5',
+      name: 'Claude Opus 5',
+      reasoning: true,
+      input: ['text', 'image'],
+      cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Two fixes in `packages/pi`, both reproduced against the released package and verified on a clean macOS VM.

1. **All Claude requests from Pi fail with `400 You're out of extra usage`** on a valid Claude subscription.
2. **`claude-opus-5` is not selectable in Pi**, despite #143 adding Opus 5 request conversion and documenting `/claude-fast` support for it.

This description has been rewritten since the PR was opened: the original diagnosis was wrong, and the fix has changed as a result. See "What changed since the PR was opened" at the end.

---

## 1. `fix(pi): split the prompt, cache the documentation paragraph ahead of user text`

### Symptom

Every Claude request from Pi returns:

```
400 {"type":"error","error":{"type":"invalid_request_error",
"message":"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."}}
```

Reproduced on `claude-opus-4-8`. The dumped request is well-formed Claude Code traffic — correct `user-agent`, the full `anthropic-beta` set, the stainless headers, and a valid `x-anthropic-billing-header` — and the same account works in OpenCode with `@cortexkit/opencode-anthropic-auth`.

### Cause

`packages/pi/src/convert.ts` pushes Pi's whole system prompt as a third entry in `system[]`. Only part of that prompt is a problem: **two lines inside the Pi documentation paragraph**, each independently sufficient to produce the 400.

```
- When asked about: extensions (docs/extensions.md, examples/extensions/), themes
  (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), …
- When working on pi topics, read the docs and examples, and follow .md cross-references
  before implementing
```

Isolated by bisecting the prompt paragraph by paragraph, then line by line, against the released build. Ruled out along the way:

| hypothesis | test | result |
|---|---|---|
| entry count | 2697 bytes of neutral filler as a third entry | 200 |
| payload size | 2697 bytes passes, 2529 bytes fails | not size |
| a hash of the block | append one character to the paragraph | still 400 |
| the install paths / `@earendil-works` | the paragraph's first four lines only | 200 |
| the harness identity sentence | remove it, keep the rest | still 400 |
| the `cch` billing header | see notes below | not implicated |

The same two lines are accepted without issue inside `messages[]`.

### Fix

`system[]` and `messages[]` are separate fields of the request body. Keep the identity, tool contract and guidelines in `system[]`, and move only the documentation paragraph into `messages[]` — as its own content block ahead of the user's text:

```
system[]     [0] x-anthropic-billing-header: …
             [1] You are Claude Code, …
             [2] Pi's prompt minus the documentation paragraph

messages[0]  block 0: the documentation paragraph  ← cache_control: ephemeral
             block 1: what the user typed
messages[1]  role: assistant …
```

Nothing is deleted, and the paragraphs that actually shape behaviour keep system-level weight and stay out of anything that rewrites conversation history.

### Why a content block rather than a message

Two constraints. A `role: "system"` message cannot go at `messages[0]` — Anthropic returns `messages.0: use the top-level 'system' parameter for the initial system prompt` — so nothing can be placed ahead of the user's first *message*.

And a cache prefix matches contiguously from the start of the request, stopping at the first byte that differs. Anything placed at or behind the user's first message therefore falls outside the reusable prefix, because that message differs between conversations.

Measured with the whole prompt relocated, across three consecutive sessions in the same directory: the first establishes the cache, the second repeats the same opening message, and the third opens with a different one. The third is what matters — it is what a user does every time they start a new conversation.

| where the relocated text is placed | tokens written on session 3 |
|---|---|
| concatenated into the user's first message, one block | ~1.1k |
| a separate `role: "system"` message after the user's first message | ~1.1k |
| **a separate block inside the user's first message, before their text** | **11** |

The first two put the relocated text at or behind text that changes, so the match ends before reaching it and all of it is written again. The third puts the breakpoint at a block boundary the user's words cannot move, so it is still cached when the next conversation starts.

`cache_control` is set explicitly rather than left to `addEphemeralCacheControl`, whose message-level breakpoint targets the *last* user message — not this one, after the first turn.

### Notes for review

**The split keys on a string.** `PI_DOCS_ANCHOR` is `'Pi documentation'`. If pi upstream renames that heading the split stops separating, the whole prompt returns to `system[]`, and every request 400s. Matching on prompt text is the same approach `PARAGRAPH_REMOVAL_ANCHORS` already takes on the OpenCode side, so the precedent exists — but the failure here is total rather than cosmetic. A fallback that moves the whole prompt into `messages[0]` as its own block when no paragraph matches would keep requests working instead of breaking them, and I'm happy to add it — but it is a degraded state rather than an equivalent one, and worth understanding before choosing it. `system[]` is rebuilt from `context.systemPrompt` on every request, so whatever sits there is present in full every time. `messages[]` is conversation history, and a long enough session gets trimmed. The split deliberately puts only the documentation paragraph on the trimmable side: losing Pi's doc pointers late in a session costs the model the ability to look up its own internals, which is recoverable. The fallback would put the identity, tool contract and editing guidelines there too, and losing those mid-session is not.

**The `cch` billing header is not implicated.** The released build never mutates `messages` between `buildBillingHeaderValue` and `signRequestBody`, so `cch` covers exactly the transmitted first user message — and it still 400s. Removing the prompt entirely, with `cch` computed the same way, returns 200.

**`addEphemeralCacheControl`'s message-level breakpoint never fires in normal use.** It walks backward to the last user message but only marks it when the content is an array; `convertTextAndImages` joins text-only content into a plain string, so the array branch is unreachable for ordinary text. Consequence: the conversation tail is not covered by a breakpoint and is reprocessed each turn, including on the current released build. Independent of this PR and out of scope for it. I have a change that fixes it for plain text, but it also affects `tool_result` and image content which I haven't exercised — happy to open an issue, or a separate PR if you'd rather see the code.

---

## 2. `fix(pi): register claude-opus-5 in the provider model list`

#143 added Opus 5 request conversion in `packages/pi/src/convert.ts`, wiring up `isClaudeOpus5Model` and `CLAUDE_OPUS_5_ADAPTIVE_THINKING` from core, and updated `packages/pi/README.md` to document `/claude-fast` support for `claude-opus-5`. The model was never added to the `models` array in `packages/pi/src/index.ts` — that file was last touched by #118.

Without that entry the Opus 5 code path is unreachable from Pi, so the documented model does not appear in `/model`. The cost entry follows Anthropic's published rates for Opus 5: $5/MTok input, $25/MTok output, $0.50/MTok cache reads and $6.25/MTok cache writes.

A separate commit updates `packages/pi/README.md`, which enumerates the provider catalog and would otherwise omit the newly registered model.

---

## Tests

`packages/pi/src/tests/convert.test.ts` asserts on the shape of `messages[]` through a shared `buildMessages` helper that hard-coded `systemPrompt: 'test'` for every case. With a prompt now split across two locations, every index-based assertion would shift, so `systemPrompt` is now an optional parameter and those cases assert raw conversion output as before. The new shape gets its own coverage:

- the non-documentation paragraphs land in `system[]`, and the documentation paragraph does not
- the documentation paragraph becomes the first block of the first user message, with the user's text after it
- that block carries `cache_control`
- a structured first user message (text + image) gets the block unshifted rather than replaced
- with no user message at all, the remaining paragraphs still reach `system[]` and the documentation paragraph is dropped
- a prompt containing no documentation paragraph is left whole in `system[]`

`packages/pi/src/tests/index.test.ts` gains an Opus 5 registration case alongside the existing Sonnet 5 one.

Note for reviewers: the root `test` script is `cd packages/opencode && bun run test`, so `packages/pi`'s own suite is not reached by CI — it runs with `bun run --cwd packages/pi test`.

---

## Verification

Clean macOS VM — `brew install pi-coding-agent` 0.84.1, `pi install npm:@cortexkit/pi-anthropic-auth`, authenticated with Pi's `/login anthropic`. The released package reproduced both bugs (tested on 1.19.0; v1.19.1 does not touch `convert.ts`). Each configuration was produced by editing one block in `convert.ts`, rebuilding `packages/pi/dist` and copying it over the installed package; `packages/core` stayed at the released build.

`bun run typecheck`, `bun run build`, `bun run test` (1023 pass), `bun run --cwd packages/pi test` (66 pass), `bun run lint` and `bun run format:check` are clean on `849baf1`.

`claude-opus-4-8` returns 200 on this branch where the released package returns 400.

`claude-opus-5` now appears in `/model` and returns 200, with `thinking: {"type":"adaptive","display":"summarized"}` and `output_config: {"effort":"medium"}`, confirming the `CLAUDE_OPUS_5_ADAPTIVE_THINKING` path executes. Anthropic validates model IDs — an unrecognised id returns `404 not_found_error` — so a successful response confirms the model string was accepted.

---

## What changed since the PR was opened

The PR originally claimed Anthropic rejects *any* third-party content in `system[]` alongside the identity block, and fixed it by moving the whole prompt into the first user message. @iceteaSA disproved the diagnosis with an OpenCode request carrying four `system[]` entries and 96KB of prompt that returns 200, and separately flagged that the relocation would cost prompt caching.

Both were right. Bisecting the prompt showed the trigger is two specific lines, not third-party content generally; and measuring the cache showed the first fix left the prompt outside the reusable prefix. The current version moves only what has to move and keeps it inside the prefix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789067134&installation_model_id=22398&pr_number=147&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F147&signature=2f3d9ac7827c6fb5db710d8941f360ff4583d2c07af4d3a41fef7554de71a4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude Code OAuth billing rejections in Pi and makes `claude-opus-5` selectable. Old: Pi placed its full prompt in system[], causing 400 “You're out of extra usage.” New: system[] keeps the billing header, Claude Code identity, and non-doc guidance; only the “Pi documentation” paragraph moves to messages[0] as a cache-marked block before the user’s text.

- The documentation block sets cache_control: { type: 'ephemeral' } so it’s cached across turns and the cached prefix ends before user text; it is dropped when no user message exists. Split keyed by the “Pi documentation” heading.
- Registers `claude-opus-5` with reasoning, text+image input, costs { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 }, contextWindow: 1_000_000, maxTokens: 128_000; updates `packages/pi/README.md`.

<sup>Written for commit 849baf1783aef6e1e6cde9292271dfc55ab1d5b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adjusts Pi’s Claude request construction to keep the identified documentation paragraph out of top-level `system[]` while preserving the remaining system instructions, and registers Claude Opus 5 in the provider catalog.
- Splits the Pi prompt and moves its documentation paragraph into the first user message with an ephemeral cache breakpoint.
- Drops that paragraph when no converted user message exists, completing the previously requested fallback fix.
- Adds Claude Opus 5 metadata, documentation, and focused conversion and registration tests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pi/src/convert.ts | Splits the Pi prompt between top-level system instructions and a cacheable first-user documentation block, while safely dropping the rejected paragraph when no user message exists. |
| packages/pi/src/index.ts | Registers Claude Opus 5 with reasoning support, text/image input, pricing, and token limits. |
| packages/pi/src/tests/convert.test.ts | Adds focused coverage for prompt splitting, cache marking, structured user content, empty converted conversations, and unchanged no-prompt behavior. |
| packages/pi/src/tests/index.test.ts | Verifies the Claude Opus 5 provider registration metadata. |
| packages/pi/README.md | Updates the documented Pi provider catalog to include Claude Opus 5. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Pi
  participant Convert as buildAnthropicRequest
  participant Sign as signRequestBody
  participant Anthropic
  Pi->>Convert: context with systemPrompt and messages
  Convert->>Convert: Split documentation paragraph from remaining prompt
  Convert->>Convert: Keep remaining instructions in system[]
  alt First user message exists
    Convert->>Convert: Prepend documentation cache block to user content
  else No user message exists
    Convert->>Convert: Drop documentation paragraph
  end
  Convert->>Sign: Serialize final request body
  Sign->>Sign: Compute CCH over final body
  Sign->>Anthropic: Send signed request
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(pi): split the prompt, cache the doc..."](https://github.com/cortexkit/anthropic-auth/commit/849baf1783aef6e1e6cde9292271dfc55ab1d5b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52321511)</sub>

**Context used:**

- Knowledge Base — [pi Package: Anthropic OAuth Extension for Pi Coding Agent](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/anthropic-auth/-/docs/pi-cli.md)

<!-- /greptile_comment -->