### PR TITLE
fix(core): contain thrown prewarm errors in the cachekeep tick

### DIFF
--- a/packages/core/src/cachekeep.ts
+++ b/packages/core/src/cachekeep.ts
@@ -339,7 +339,7 @@ export type CacheKeepPrewarmResult =
         cache_read_input_tokens?: number
       }
     }
-  | { ok: false; reason: string; status?: number }
+  | { ok: false; reason: string; status?: number; transient?: true }
 
 export class CacheKeepManager {
   private readonly targets = new Map<string, CacheKeepTarget>()
@@ -576,7 +576,15 @@ export class CacheKeepManager {
     const dueAt = now + CACHE_KEEP_PREWARM_LEAD_MS
     for (const target of this.targets.values()) {
       if (target.cacheExpiresAt > dueAt) continue
-      await this.prewarm(target, now)
+      try {
+        await this.prewarm(target, now)
+      } catch (error) {
+        logger.warn('cachekeep', 'prewarm failed', {
+          session: target.id,
+          reason: error instanceof Error ? error.message : String(error),
+        })
+        target.cacheExpiresAt = now + CACHE_KEEP_PREWARM_LEAD_MS + 5 * 60_000
+      }
     }
     this.publishTrackedSessions()
   }
@@ -597,14 +605,23 @@ export class CacheKeepManager {
       : new Headers(target.headers)
     headers.delete('content-length')
     headers.delete('transfer-encoding')
-    const response = await fetchImpl(target.url, {
-      method: 'POST',
-      headers,
-      body: prewarm.bodyText,
-      signal: AbortSignal.timeout(
-        this.options.prewarmTimeoutMs ?? CACHE_KEEP_PREWARM_TIMEOUT_MS,
-      ),
-    })
+    let response: Response
+    try {
+      response = await fetchImpl(target.url, {
+        method: 'POST',
+        headers,
+        body: prewarm.bodyText,
+        signal: AbortSignal.timeout(
+          this.options.prewarmTimeoutMs ?? CACHE_KEEP_PREWARM_TIMEOUT_MS,
+        ),
+      })
+    } catch (error) {
+      return {
+        ok: false,
+        reason: error instanceof Error ? error.message : String(error),
+        transient: true,
+      }
+    }
     if (!response.ok) {
       return {
         ok: false,
@@ -632,7 +649,7 @@ export class CacheKeepManager {
   private async prewarm(target: CacheKeepTarget, now: number) {
     const result = await this.sendPrewarm(target)
     if (!result.ok) {
-      if (result.status == null) {
+      if (result.status == null && !result.transient) {
         logger.debug('cachekeep', 'prewarm skipped', {
           session: target.id,
           reason: result.reason,

--- a/packages/opencode/src/tests/cachekeep.test.ts
+++ b/packages/opencode/src/tests/cachekeep.test.ts
@@ -314,7 +314,7 @@ describe('CacheKeepManager', () => {
       prewarmTimeoutMs: 5,
     })
 
-    const result = manager.prewarmNow({
+    const result = await manager.prewarmNow({
       sessionId: 'ses_timeout',
       url: 'https://api.anthropic.com/v1/messages?beta=true',
       headers: new Headers(),
@@ -330,7 +330,10 @@ describe('CacheKeepManager', () => {
       }),
     })
 
-    await expect(result).rejects.toMatchObject({ name: 'TimeoutError' })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected prewarm to fail')
+    expect(result.transient).toBe(true)
+    expect(result.reason).toContain('timed out')
   })
 
   test('passes OAuth account identity to prewarm header refresh', async () => {
@@ -649,6 +652,100 @@ describe('CacheKeepManager', () => {
     now += 55 * 60_000
     await manager.tick()
     expect(fetchImpl).toHaveBeenCalledTimes(1)
+    manager.stop()
+  })
+
+  test('contains thrown prewarm errors and continues with later targets', async () => {
+    let now = new Date('2026-05-18T10:00:00').getTime()
+    const attempts: string[] = []
+    let publishCount = 0
+    const timeout = new Error('The operation timed out.')
+    timeout.name = 'TimeoutError'
+    const fetchImpl = mock((input: string | URL | Request) => {
+      const url = String(input)
+      attempts.push(url)
+      if (url.endsWith('/A')) throw timeout
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }) as unknown as typeof fetch
+    const manager = new CacheKeepManager({
+      loadStorage: () => Promise.resolve(hybridStorage()),
+      fetchImpl,
+      now: () => now,
+      onTrackedSessionsChanged: () => {
+        publishCount++
+      },
+    })
+    const body = JSON.stringify({
+      system: [
+        { type: 'text', text: 'stable', cache_control: { type: 'ephemeral' } },
+      ],
+      messages: [{ role: 'user', content: 'hello' }],
+    })
+
+    for (const id of ['A', 'B', 'C']) {
+      await manager.track({
+        sessionId: `ses_${id}`,
+        url: `https://api.anthropic.com/v1/messages/${id}`,
+        headers: new Headers(),
+        bodyText: body,
+        storage: hybridStorage(),
+        cacheMode: 'hybrid',
+      })
+    }
+
+    const publishedBeforeTick = publishCount
+    now += 55 * 60_000
+    await manager.tick()
+
+    expect(attempts).toEqual([
+      'https://api.anthropic.com/v1/messages/A',
+      'https://api.anthropic.com/v1/messages/B',
+      'https://api.anthropic.com/v1/messages/C',
+    ])
+    expect(manager.trackedSessions().map((session) => session.id)).toEqual([
+      'ses_A',
+      'ses_B',
+      'ses_C',
+    ])
+    expect(
+      manager.trackedSessions().find((session) => session.id === 'ses_A')
+        ?.cacheExpiresAt,
+    ).toBe(now + 10 * 60_000)
+    expect(publishCount).toBeGreaterThan(publishedBeforeTick)
+
+    attempts.length = 0
+    now += 60_000
+    await manager.tick()
+    expect(attempts).toEqual([])
+    manager.stop()
+  })
+
+  test('deletes a tracked target when its prewarm body is unbuildable', async () => {
+    let now = new Date('2026-05-18T10:00:00').getTime()
+    const fetchImpl = mock(() =>
+      Promise.resolve(new Response('{}', { status: 200 })),
+    ) as unknown as typeof fetch
+    const manager = new CacheKeepManager({
+      loadStorage: () => Promise.resolve(hybridStorage()),
+      fetchImpl,
+      now: () => now,
+    })
+
+    await manager.track({
+      sessionId: 'ses_unbuildable',
+      url: 'https://api.anthropic.com/v1/messages/unbuildable',
+      headers: new Headers(),
+      bodyText: JSON.stringify({
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+      storage: hybridStorage(),
+      cacheMode: 'hybrid',
+    })
+
+    now += 55 * 60_000
+    await manager.tick()
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(manager.trackedCount()).toBe(0)
     manager.stop()
   })
 })


### PR DESCRIPTION
Fixes #150.

`sendPrewarm()` calls `fetch` with `signal: AbortSignal.timeout(...)`, which **throws** on timeout or a network error instead of returning a result. Nothing between that throw and `start()`'s `.catch()` handled it, so a single throwing target aborted the entire `tick()`:

```
prewarm attempts: ["A"]        <- B and C never attempted
tick +1m attempts: ["A"]
tick +2m attempts: ["A"]
tick +3m attempts: ["A"]
```

And it never recovered: the backoff assignment lives in the `!result.ok` branch that a throw skips, so the failing target's `cacheExpiresAt` was never advanced and it stayed first-due, re-aborting every subsequent tick. Later targets were starved until they aged out as stale ~2h later, and `publishTrackedSessions()` never ran, so the cross-process lease stopped refreshing.

## The change

- `sendPrewarm()` catches the fetch throw and returns `{ ok: false, reason, transient: true }`.
- `prewarm()` routes transient failures to the existing backoff branch instead of the delete branch.
- `tick()` wraps each `prewarm()` call defensively, applying the same backoff, so a future unanticipated throw cannot reintroduce head-of-line blocking.

The delete path was the trap here. `prewarm()` used `result.status == null` to mean "unbuildable body, drop the tracked session", so mapping a thrown fetch onto that shape would have made a transient network blip permanently delete a live session — worse than the bug being fixed. Hence the separate `transient` discriminator: `transient: true` is set at exactly one site, and the delete predicate is now `result.status == null && !result.transient`. Unbuildable bodies still delete; HTTP-status failures still back off, unchanged.

## Two things worth flagging

- **`prewarmNow()` is a behavior change for consumers.** It previously rejected on a fetch throw; it now resolves `{ ok: false, transient: true }`. The only in-repo consumer (`warmFableAfterOpus`) already handles both, but this is a public surface of `@cortexkit/anthropic-auth-core`, so it's a contract change worth knowing about.
- **`loadStorage()` at the top of `tick()` is still unguarded** and can abort a tick. I left it alone: it's pre-existing, `start()`'s `.catch()` handles it, it retries in 60s, and skipping a pass when the schedule can't be read is arguably right. Happy to wrap it if you'd rather.

## Verification

New tests assert that a throwing target does not prevent later targets from being prewarmed, that the throwing target is retained rather than deleted, that it backs off instead of retrying on the next tick, and that an unbuildable body still deletes its target.

Proven red before green — reverting the source change makes the new tests fail (2 fail, with the unbuildable-delete test correctly still passing as a regression guard). Gates on the branch: `bun run typecheck` clean, `bun run test` 1025 pass / 0 fail, `bun run lint` clean.

Two other defects in this file are filed separately — #149 (failing prewarms retried at a fixed cadence forever) and #151 (ticks overlapping into duplicate paid prewarms). Kept independent so they can be triaged on their own; happy to send PRs for either if you want them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789677083&installation_model_id=22398&pr_number=155&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F155&signature=bb1b114086ccd43af36e14d19801274206b350d3df52079e05de7e17bc7dc163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contain thrown prewarm errors during cachekeep ticks to prevent head-of-line blocking and session starvation. Previously, a timeout/network error from `fetch` in `sendPrewarm()` threw and aborted the entire `tick()`; now these errors are caught, treated as transient failures, and the tick proceeds to later targets.

**Behavior changes and migration**
- `sendPrewarm()` catches `fetch` throws and returns `{ ok: false, reason, transient: true }`; `prewarm()` treats transient failures as backoff, not delete; `tick()` wraps per-target calls to apply the same backoff on unexpected throws.
- `prewarmNow()` no longer rejects on network/timeout errors. It resolves a failure result with `transient: true`. Migration: update callers to check `result.ok` (and optionally `result.transient`) instead of catching a rejection.
- Delete-on-prewarm now only applies to unbuildable bodies (`status == null` and not transient). Transient/network failures never delete tracked sessions.

<sup>Written for commit e9afa64043be6da6bc6c1790e64ff8e0786881a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR contains fetch failures within cachekeep prewarming so one failed target no longer aborts the tick or starves later targets.
- Adds an explicit transient-failure result for fetch exceptions.
- Preserves transient targets and advances them using the existing retry backoff rather than deleting them.
- Defensively isolates each target during a tick and adds regression coverage for continuation, retention, backoff, publication, and unbuildable-body deletion.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed failure paths preserving target lifecycle semantics while preventing one prewarm failure from aborting the entire tick.

The implementation distinguishes transient fetch failures from unbuildable requests, applies retry backoff without deleting live targets, continues processing later targets, and retains the existing deletion behavior for invalid prewarm bodies.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/cachekeep.ts | Converts thrown fetch failures into transient results, preserves affected targets with backoff, and isolates unexpected per-target failures so each tick can continue and publish state. |
| packages/opencode/src/tests/cachekeep.test.ts | Updates timeout expectations for the resolved transient result and adds coverage for target continuation, retention, backoff, publication, and unbuildable-body deletion. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  T[Cachekeep tick] --> D{Target is due?}
  D -- No --> N[Check next target]
  D -- Yes --> P[Build and send prewarm]
  P --> S{Result}
  S -- Success --> U[Advance cache expiry]
  S -- HTTP or transient failure --> B[Apply retry backoff]
  S -- Unbuildable body --> X[Delete tracked target]
  P -- Unexpected throw --> C[Log and apply defensive backoff]
  U --> N
  B --> N
  X --> N
  C --> N
  N --> F[Publish tracked sessions]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): contain thrown prewarm errors..."](https://github.com/cortexkit/anthropic-auth/commit/e9afa64043be6da6bc6c1790e64ff8e0786881a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54515618)</sub>

**Context used:**

- Knowledge Base — [Core Package: Provider Abstraction, Model Catalog, and Request Shaping](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/anthropic-auth/-/docs/core-index-provider.md)

<!-- /greptile_comment -->