### PR TITLE
Publish per-field quota provenance in the header feed (schema v3)

### DIFF
--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -27,6 +27,7 @@ export const QUOTA_FIELD_NAMES = [
   'scoped',
   'extraUsage',
   'bindingWindow',
+  'fallbackAdvised',
 ] as const
 export type QuotaFieldName = (typeof QUOTA_FIELD_NAMES)[number]
 export type QuotaFieldSource = 'poll' | 'headers'

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -713,6 +713,19 @@ function normalizeQuota(value: unknown): OAuthAccount['quota'] {
     }
   }
 
+  if (isRecord(value.fieldSources)) {
+    const fieldSources: QuotaFieldSources = {}
+    for (const field of QUOTA_FIELD_NAMES) {
+      const source = value.fieldSources[field]
+      if (source === 'poll' || source === 'headers') {
+        fieldSources[field] = source
+      }
+    }
+    if (Object.keys(fieldSources).length > 0) {
+      quota.fieldSources = fieldSources
+    }
+  }
+
   if (typeof value.bindingWindow === 'string' && value.bindingWindow.trim()) {
     quota.bindingWindow = value.bindingWindow.trim()
   }

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -713,19 +713,6 @@ function normalizeQuota(value: unknown): OAuthAccount['quota'] {
     }
   }
 
-  if (isRecord(value.fieldSources)) {
-    const fieldSources: QuotaFieldSources = {}
-    for (const field of QUOTA_FIELD_NAMES) {
-      const source = value.fieldSources[field]
-      if (source === 'poll' || source === 'headers') {
-        fieldSources[field] = source
-      }
-    }
-    if (Object.keys(fieldSources).length > 0) {
-      quota.fieldSources = fieldSources
-    }
-  }
-
   if (typeof value.bindingWindow === 'string' && value.bindingWindow.trim()) {
     quota.bindingWindow = value.bindingWindow.trim()
   }
@@ -740,6 +727,20 @@ function normalizeQuota(value: unknown): OAuthAccount['quota'] {
   }
   if (value.source === 'poll' || value.source === 'headers') {
     quota.source = value.source
+  }
+
+  if (isRecord(value.fieldSources)) {
+    const fieldSources: QuotaFieldSources = {}
+    for (const field of QUOTA_FIELD_NAMES) {
+      if (quota[field] === undefined) continue
+      const source = value.fieldSources[field]
+      if (source === 'poll' || source === 'headers') {
+        fieldSources[field] = source
+      }
+    }
+    if (Object.keys(fieldSources).length > 0) {
+      quota.fieldSources = fieldSources
+    }
   }
 
   return Object.keys(quota).length ? quota : undefined
@@ -1179,6 +1180,14 @@ function fieldSourcesForMergedQuota(
       fieldSources[field] = 'poll'
       continue
     }
+    if (
+      field === 'fallbackAdvised' &&
+      incoming.fieldSources?.fallbackAdvised === undefined
+    ) {
+      const source = quotaFieldSource(existing, field)
+      if (source) fieldSources[field] = source
+      continue
+    }
     const source =
       incoming[field] === merged[field]
         ? quotaFieldSource(incoming, field)
@@ -1204,6 +1213,10 @@ export function mergeHeaderQuotaForPersistence(
     seven_day: mergeHeaderOwnedWindow(existing, incoming, 'seven_day'),
     scoped: mergeHeaderScopedQuota(existing, incoming),
     extraUsage: existing.extraUsage ?? incoming.extraUsage,
+    fallbackAdvised:
+      incoming.fieldSources?.fallbackAdvised !== undefined
+        ? incoming.fallbackAdvised
+        : (existing.fallbackAdvised ?? incoming.fallbackAdvised),
     bindingWindow: preservePollBinding
       ? existing.bindingWindow
       : (incoming.bindingWindow ?? existing.bindingWindow),

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -21,6 +21,18 @@ export const ACCOUNT_STATE_FILE_NAME = 'anthropic-auth-state.json'
 export const QUOTA_URL = 'https://api.anthropic.com/api/oauth/usage'
 
 export type QuotaWindowName = 'five_hour' | 'seven_day'
+export const QUOTA_FIELD_NAMES = [
+  'five_hour',
+  'seven_day',
+  'scoped',
+  'extraUsage',
+  'bindingWindow',
+] as const
+export type QuotaFieldName = (typeof QUOTA_FIELD_NAMES)[number]
+export type QuotaFieldSource = 'poll' | 'headers'
+export type QuotaFieldSources = Partial<
+  Record<QuotaFieldName, QuotaFieldSource>
+>
 
 export type AccountBase = {
   id: string
@@ -155,6 +167,7 @@ export type OAuthQuotaSnapshot = Partial<
   extraUsage?: OAuthExtraUsageSnapshot
   bindingWindow?: string
   bindingWindowSource?: 'poll' | 'headers'
+  fieldSources?: QuotaFieldSources
   fallbackAdvised?: boolean
   source?: 'poll' | 'headers'
   // Top-level freshness stamp for the whole snapshot. mergeAccountRuntimeState
@@ -1119,13 +1132,58 @@ function mergeHeaderOwnedWindow(
     : incoming
 }
 
+export function quotaFieldSource(
+  snapshot: OAuthQuotaSnapshot | undefined,
+  field: QuotaFieldName,
+): QuotaFieldSource | undefined {
+  if (!snapshot || snapshot[field] === undefined) return undefined
+  return (
+    snapshot.fieldSources?.[field] ??
+    (snapshot.source === 'poll' || snapshot.source === 'headers'
+      ? snapshot.source
+      : undefined)
+  )
+}
+
+function fieldSourcesForMergedQuota(
+  existing: OAuthQuotaSnapshot,
+  incoming: OAuthQuotaSnapshot,
+  merged: OAuthQuotaSnapshot,
+): QuotaFieldSources | undefined {
+  const fieldSources: QuotaFieldSources = {}
+  for (const field of QUOTA_FIELD_NAMES) {
+    if (merged[field] === undefined) continue
+    if (field === 'scoped' || field === 'extraUsage') {
+      fieldSources[field] = 'poll'
+      continue
+    }
+    if (
+      field === 'bindingWindow' &&
+      existing.bindingWindowSource === 'poll' &&
+      existing.bindingWindow === merged.bindingWindow
+    ) {
+      fieldSources[field] = 'poll'
+      continue
+    }
+    const source =
+      incoming[field] === merged[field]
+        ? quotaFieldSource(incoming, field)
+        : existing[field] === merged[field]
+          ? quotaFieldSource(existing, field)
+          : (quotaFieldSource(existing, field) ??
+            quotaFieldSource(incoming, field))
+    if (source) fieldSources[field] = source
+  }
+  return Object.keys(fieldSources).length > 0 ? fieldSources : undefined
+}
+
 export function mergeHeaderQuotaForPersistence(
   existing: OAuthQuotaSnapshot | undefined,
   incoming: OAuthQuotaSnapshot,
 ) {
   if (!existing || incoming.source !== 'headers') return incoming
   const preservePollBinding = existing.bindingWindowSource === 'poll'
-  return {
+  const merged = {
     ...existing,
     ...incoming,
     five_hour: mergeHeaderOwnedWindow(existing, incoming, 'five_hour'),
@@ -1139,6 +1197,11 @@ export function mergeHeaderQuotaForPersistence(
       ? 'poll'
       : (incoming.bindingWindowSource ?? existing.bindingWindowSource),
   } satisfies OAuthQuotaSnapshot
+  const fieldSources = fieldSourcesForMergedQuota(existing, incoming, merged)
+  return {
+    ...merged,
+    ...(fieldSources && { fieldSources }),
+  }
 }
 
 function mergeAccountRuntimeState(
@@ -3303,7 +3366,7 @@ export async function fetchOAuthQuotaSnapshot(input: {
   const checkedAt = input.now?.() ?? Date.now()
   const usage = (await response.json()) as OAuthUsageResponse
   const bindingWindow = mapBindingWindow(usage.limits)
-  return {
+  const snapshot = {
     five_hour: mapUsageWindow(usage.five_hour, checkedAt),
     seven_day: mapUsageWindow(usage.seven_day, checkedAt),
     scoped: mapScopedWeeklyLimits(usage.limits, checkedAt),
@@ -3315,6 +3378,17 @@ export async function fetchOAuthQuotaSnapshot(input: {
     source: 'poll',
     checkedAt,
   } satisfies OAuthQuotaSnapshot
+  const fieldSources: QuotaFieldSources = {
+    ...(snapshot.five_hour && { five_hour: 'poll' }),
+    ...(snapshot.seven_day && { seven_day: 'poll' }),
+    ...(snapshot.scoped && { scoped: 'poll' }),
+    ...(snapshot.extraUsage && { extraUsage: 'poll' }),
+    ...(snapshot.bindingWindow && { bindingWindow: 'poll' }),
+  }
+  return {
+    ...snapshot,
+    ...(Object.keys(fieldSources).length > 0 && { fieldSources }),
+  }
 }
 
 function updateStoredAccount(

--- a/packages/core/src/quota-header-feed.ts
+++ b/packages/core/src/quota-header-feed.ts
@@ -18,10 +18,14 @@ import {
   isOAuthAccount,
   type OAuthExtraUsageSnapshot,
   type OAuthQuotaSnapshot,
+  QUOTA_FIELD_NAMES,
+  type QuotaFieldName,
+  type QuotaFieldSource,
+  type QuotaFieldSources,
   type QuotaMoney,
 } from './accounts.ts'
 
-export const QUOTA_HEADER_FEED_SCHEMA_VERSION = 2
+export const QUOTA_HEADER_FEED_SCHEMA_VERSION = 3
 export const QUOTA_HEADER_FEED_LEASE_MS = 180_000
 
 export type QuotaHeaderFeedIdentity =
@@ -29,21 +33,41 @@ export type QuotaHeaderFeedIdentity =
   | { identity_source: 'account_ref'; account_ref: string }
   | { identity_source: 'none' }
 
-export type QuotaHeaderFeedEntry = QuotaHeaderFeedIdentity & {
+export type QuotaHeaderFeedProvenance = Partial<
+  Record<QuotaFieldName, QuotaFieldSource>
+>
+
+type QuotaHeaderFeedQuota = Pick<
+  OAuthQuotaSnapshot,
+  | 'five_hour'
+  | 'seven_day'
+  | 'bindingWindow'
+  | 'fallbackAdvised'
+  | 'scoped'
+  | 'extraUsage'
+> & {
+  provenance?: QuotaHeaderFeedProvenance
+}
+
+type QuotaHeaderFeedMetadata = {
   schema_version: typeof QUOTA_HEADER_FEED_SCHEMA_VERSION
   provider: 'anthropic'
   configured_account_count: number
   observed_at_ms: number
-  quota: Pick<
-    OAuthQuotaSnapshot,
-    | 'five_hour'
-    | 'seven_day'
-    | 'bindingWindow'
-    | 'fallbackAdvised'
-    | 'scoped'
-    | 'extraUsage'
-  >
 }
+
+export type QuotaHeaderFeedEntry = QuotaHeaderFeedIdentity &
+  QuotaHeaderFeedMetadata & {
+    quota: QuotaHeaderFeedQuota
+  }
+
+export type QuotaHeaderFeedPublishEntry = QuotaHeaderFeedIdentity &
+  QuotaHeaderFeedMetadata & {
+    quota: Omit<QuotaHeaderFeedQuota, 'provenance'> & {
+      fieldSources?: QuotaFieldSources
+    }
+    accountKey: string
+  }
 
 type FeedRecord = {
   version: typeof QUOTA_HEADER_FEED_SCHEMA_VERSION
@@ -206,7 +230,20 @@ function projectExtraUsage(
   }
 }
 
-function projectQuota(quota: QuotaHeaderFeedEntry['quota']) {
+function projectQuotaProvenance(
+  value: unknown,
+): QuotaHeaderFeedProvenance | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const candidate = value as Record<string, unknown>
+  const provenance: QuotaHeaderFeedProvenance = {}
+  for (const field of QUOTA_FIELD_NAMES) {
+    const source = candidate[field]
+    if (source === 'poll' || source === 'headers') provenance[field] = source
+  }
+  return Object.keys(provenance).length > 0 ? provenance : undefined
+}
+
+function projectQuota(quota: QuotaHeaderFeedPublishEntry['quota']) {
   const fiveHour = projectQuotaWindow(quota.five_hour)
   const sevenDay = projectQuotaWindow(quota.seven_day)
   const scoped = Array.isArray(quota.scoped)
@@ -215,6 +252,7 @@ function projectQuota(quota: QuotaHeaderFeedEntry['quota']) {
         .filter((entry): entry is AccountScopedQuotaWindow => entry != null)
     : undefined
   const extraUsage = projectExtraUsage(quota.extraUsage)
+  const provenance = projectQuotaProvenance(quota.fieldSources)
   return {
     ...(fiveHour && { five_hour: fiveHour }),
     ...(sevenDay && { seven_day: sevenDay }),
@@ -226,6 +264,7 @@ function projectQuota(quota: QuotaHeaderFeedEntry['quota']) {
     }),
     ...(scoped && { scoped }),
     ...(extraUsage && { extraUsage }),
+    ...(provenance && { provenance }),
   }
 }
 
@@ -248,12 +287,12 @@ export class QuotaHeaderFeedRegistry {
     )
   }
 
-  publish(entry: QuotaHeaderFeedEntry & { accountKey: string }): Promise<void> {
+  publish(entry: QuotaHeaderFeedPublishEntry): Promise<void> {
     const { accountKey, quota, ...entryWithoutQuota } = entry
     const cleanEntry = {
       ...entryWithoutQuota,
       quota: projectQuota(quota),
-    }
+    } as QuotaHeaderFeedEntry
     try {
       validatePublishEntry(cleanEntry)
     } catch (error) {

--- a/packages/core/src/quota-header-feed.ts
+++ b/packages/core/src/quota-header-feed.ts
@@ -232,11 +232,13 @@ function projectExtraUsage(
 
 function projectQuotaProvenance(
   value: unknown,
+  presentFields: ReadonlySet<QuotaFieldName>,
 ): QuotaHeaderFeedProvenance | undefined {
   if (!value || typeof value !== 'object') return undefined
   const candidate = value as Record<string, unknown>
   const provenance: QuotaHeaderFeedProvenance = {}
   for (const field of QUOTA_FIELD_NAMES) {
+    if (!presentFields.has(field)) continue
     const source = candidate[field]
     if (source === 'poll' || source === 'headers') provenance[field] = source
   }
@@ -252,7 +254,18 @@ function projectQuota(quota: QuotaHeaderFeedPublishEntry['quota']) {
         .filter((entry): entry is AccountScopedQuotaWindow => entry != null)
     : undefined
   const extraUsage = projectExtraUsage(quota.extraUsage)
-  const provenance = projectQuotaProvenance(quota.fieldSources)
+  const presentFields = new Set<QuotaFieldName>()
+  if (fiveHour) presentFields.add('five_hour')
+  if (sevenDay) presentFields.add('seven_day')
+  if (typeof quota.bindingWindow === 'string') {
+    presentFields.add('bindingWindow')
+  }
+  if (typeof quota.fallbackAdvised === 'boolean') {
+    presentFields.add('fallbackAdvised')
+  }
+  if (scoped) presentFields.add('scoped')
+  if (extraUsage) presentFields.add('extraUsage')
+  const provenance = projectQuotaProvenance(quota.fieldSources, presentFields)
   return {
     ...(fiveHour && { five_hour: fiveHour }),
     ...(sevenDay && { seven_day: sevenDay }),

--- a/packages/core/src/quota-headers.ts
+++ b/packages/core/src/quota-headers.ts
@@ -58,8 +58,9 @@ export function normalizeQuotaHeaders(
   now = Date.now(),
 ): OAuthQuotaSnapshot {
   const fieldSources: QuotaFieldSources = {}
+  const fallbackHeader = headers.get(`${PREFIX}fallback`)
   const snapshot: OAuthQuotaSnapshot = {
-    fallbackAdvised: headers.get(`${PREFIX}fallback`) === 'available',
+    fallbackAdvised: fallbackHeader === 'available',
     source: 'headers',
     checkedAt: now,
   }
@@ -76,9 +77,10 @@ export function normalizeQuotaHeaders(
     snapshot.bindingWindowSource = 'headers'
     fieldSources.bindingWindow = 'headers'
   }
+  if (fallbackHeader !== null) fieldSources.fallbackAdvised = 'headers'
   return {
     ...snapshot,
-    ...(Object.keys(fieldSources).length > 0 && { fieldSources }),
+    fieldSources,
   }
 }
 
@@ -106,24 +108,35 @@ export function mergeHeaderQuotaSnapshot(
         ? existingScoped
         : field === 'extraUsage'
           ? existingExtraUsage
-          : field === 'bindingWindow'
-            ? existing?.bindingWindowSource === 'poll'
-              ? existing?.bindingWindow
-              : (incoming.bindingWindow ?? existing?.bindingWindow)
-            : (incoming[field] ?? existing?.[field])
+          : field === 'fallbackAdvised'
+            ? incomingFieldSources?.fallbackAdvised !== undefined
+              ? incoming.fallbackAdvised
+              : (existing?.fallbackAdvised ?? incoming.fallbackAdvised)
+            : field === 'bindingWindow'
+              ? existing?.bindingWindowSource === 'poll'
+                ? existing?.bindingWindow
+                : (incoming.bindingWindow ?? existing?.bindingWindow)
+              : (incoming[field] ?? existing?.[field])
     if (value === undefined) continue
     const source =
-      (field === 'scoped' || field === 'extraUsage') && value !== undefined
-        ? 'poll'
-        : field === 'bindingWindow' &&
-            existing?.bindingWindowSource === 'poll' &&
-            existing.bindingWindow !== undefined
+      field === 'fallbackAdvised'
+        ? (incomingFieldSources?.fallbackAdvised ??
+          (existing?.fallbackAdvised !== undefined
+            ? existingFieldSources
+              ? existingFieldSources.fallbackAdvised
+              : quotaFieldSource(existing, field)
+            : undefined))
+        : (field === 'scoped' || field === 'extraUsage') && value !== undefined
           ? 'poll'
-          : incoming[field] !== undefined
-            ? (incomingFieldSources?.[field] ??
-              quotaFieldSource(incoming, field))
-            : (existingFieldSources?.[field] ??
-              quotaFieldSource(existing, field))
+          : field === 'bindingWindow' &&
+              existing?.bindingWindowSource === 'poll' &&
+              existing.bindingWindow !== undefined
+            ? 'poll'
+            : incoming[field] !== undefined
+              ? (incomingFieldSources?.[field] ??
+                quotaFieldSource(incoming, field))
+              : (existingFieldSources?.[field] ??
+                quotaFieldSource(existing, field))
     if (source) fieldSources[field] = source
   }
 
@@ -132,6 +145,10 @@ export function mergeHeaderQuotaSnapshot(
     ...incomingWithoutPollOwnedFields,
     ...(Array.isArray(existingScoped) && { scoped: existingScoped }),
     ...(existingExtraUsage != null && { extraUsage: existingExtraUsage }),
+    fallbackAdvised:
+      incomingFieldSources?.fallbackAdvised !== undefined
+        ? incoming.fallbackAdvised
+        : (existing?.fallbackAdvised ?? incoming.fallbackAdvised),
     bindingWindow:
       existing?.bindingWindowSource === 'poll'
         ? existing.bindingWindow

--- a/packages/core/src/quota-headers.ts
+++ b/packages/core/src/quota-headers.ts
@@ -1,8 +1,10 @@
 import type {
   AccountQuotaWindow,
   OAuthQuotaSnapshot,
+  QuotaFieldSources,
   QuotaWindowName,
 } from './accounts.ts'
+import { QUOTA_FIELD_NAMES, quotaFieldSource } from './accounts.ts'
 
 const PREFIX = 'anthropic-ratelimit-unified-'
 const WINDOW_KEYS: Record<string, QuotaWindowName> = {
@@ -55,6 +57,7 @@ export function normalizeQuotaHeaders(
   headers: Headers,
   now = Date.now(),
 ): OAuthQuotaSnapshot {
+  const fieldSources: QuotaFieldSources = {}
   const snapshot: OAuthQuotaSnapshot = {
     fallbackAdvised: headers.get(`${PREFIX}fallback`) === 'available',
     source: 'headers',
@@ -62,14 +65,21 @@ export function normalizeQuotaHeaders(
   }
   for (const [suffix, key] of Object.entries(WINDOW_KEYS)) {
     const window = normalizeWindow(headers, suffix, now)
-    if (window) snapshot[key] = window
+    if (window) {
+      snapshot[key] = window
+      fieldSources[key] = 'headers'
+    }
   }
   const representativeClaim = headers.get(`${PREFIX}representative-claim`)
   if (representativeClaim) {
     snapshot.bindingWindow = representativeClaim
     snapshot.bindingWindowSource = 'headers'
+    fieldSources.bindingWindow = 'headers'
   }
-  return snapshot
+  return {
+    ...snapshot,
+    ...(Object.keys(fieldSources).length > 0 && { fieldSources }),
+  }
 }
 
 export function mergeHeaderQuotaSnapshot(
@@ -79,13 +89,43 @@ export function mergeHeaderQuotaSnapshot(
   const {
     scoped: existingScoped,
     extraUsage: existingExtraUsage,
+    fieldSources: existingFieldSources,
     ...existingWithoutPollOwnedFields
   } = existing ?? {}
   const {
     scoped: _incomingScoped,
     extraUsage: _incomingExtraUsage,
+    fieldSources: incomingFieldSources,
     ...incomingWithoutPollOwnedFields
   } = incoming
+
+  const fieldSources: QuotaFieldSources = {}
+  for (const field of QUOTA_FIELD_NAMES) {
+    const value =
+      field === 'scoped'
+        ? existingScoped
+        : field === 'extraUsage'
+          ? existingExtraUsage
+          : field === 'bindingWindow'
+            ? existing?.bindingWindowSource === 'poll'
+              ? existing?.bindingWindow
+              : (incoming.bindingWindow ?? existing?.bindingWindow)
+            : (incoming[field] ?? existing?.[field])
+    if (value === undefined) continue
+    const source =
+      (field === 'scoped' || field === 'extraUsage') && value !== undefined
+        ? 'poll'
+        : field === 'bindingWindow' &&
+            existing?.bindingWindowSource === 'poll' &&
+            existing.bindingWindow !== undefined
+          ? 'poll'
+          : incoming[field] !== undefined
+            ? (incomingFieldSources?.[field] ??
+              quotaFieldSource(incoming, field))
+            : (existingFieldSources?.[field] ??
+              quotaFieldSource(existing, field))
+    if (source) fieldSources[field] = source
+  }
 
   return {
     ...existingWithoutPollOwnedFields,
@@ -100,7 +140,8 @@ export function mergeHeaderQuotaSnapshot(
       existing?.bindingWindowSource === 'poll'
         ? 'poll'
         : (incoming.bindingWindowSource ?? existing?.bindingWindowSource),
-    // Source tracks 5h/7d freshness; preserved scoped and credit fields remain poll-owned.
+    ...(Object.keys(fieldSources).length > 0 && { fieldSources }),
+    // Top-level source remains headers for compatibility; fieldSources records ownership after partial harvests.
     source: 'headers',
   }
 }

--- a/packages/e2e-tests/tests/quota-header-relay.test.ts
+++ b/packages/e2e-tests/tests/quota-header-relay.test.ts
@@ -104,7 +104,7 @@ describe('quota headers through relay', () => {
     expect(state?.main?.quotaToken).toBeUndefined()
   }, 90_000)
 
-  it('writes one equivalent schema-v2 feed record for an HTTP relay response', async () => {
+  it('writes one equivalent schema-v3 feed record for an HTTP relay response', async () => {
     harness = await E2EHarness.create({ relay: 'http', quotaFeed: true })
     harness.script([{ type: 'text', text: 'http relay response', headers: quotaHeaders }])
     const sessionId = await harness.createSession()
@@ -112,10 +112,10 @@ describe('quota headers through relay', () => {
     await harness.waitFor(() => (harness?.relay?.acceptedRequests() ?? 0) >= 1)
     const files = await waitForFeed(harness)
     const record = JSON.parse(files[0]!)
-    expect(record.version).toBe(2)
+    expect(record.version).toBe(3)
     expect(Object.values(record.entries)).toHaveLength(1)
     expect(Object.values(record.entries)[0]).toEqual(
-      expect.objectContaining({ provider: 'anthropic', schema_version: 2 }),
+      expect.objectContaining({ provider: 'anthropic', schema_version: 3 }),
     )
     expect(files[0]).not.toContain('authorization')
     expect(files[0]).not.toContain('access-token')
@@ -143,7 +143,7 @@ describe('quota headers through relay', () => {
     expect(Object.values(record.entries)[0]).toEqual(
       expect.objectContaining({
         provider: 'anthropic',
-        schema_version: 2,
+        schema_version: 3,
         quota: expect.objectContaining({
           five_hour: expect.objectContaining({ usedPercent: 78 }),
         }),

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -123,7 +123,7 @@ import {
   QUOTA_HEADER_FEED_SCHEMA_VERSION,
   type QuotaAccountSummary,
   type QuotaEntry,
-  type QuotaHeaderFeedEntry,
+  type QuotaHeaderFeedPublishEntry,
   QuotaHeaderFeedRegistry,
   QuotaManager,
   type QuotaState,
@@ -1383,17 +1383,28 @@ const anthropicAuthPlugin = async (
       fallbackAdvised: entry.quota.fallbackAdvised,
       scoped: entry.quota.scoped,
       extraUsage: entry.quota.extraUsage,
+      fieldSources: entry.quota.fieldSources,
     }
     const accountKey =
       credentialId ??
       (served.accountId === 'main'
         ? (served.mainQuotaIdentity?.accountIdentity ?? 'main')
         : served.accountId)
-    const feedEntry: QuotaHeaderFeedEntry & { accountKey: string } =
-      credentialId
+    const feedEntry: QuotaHeaderFeedPublishEntry = credentialId
+      ? {
+          identity_source: 'credential_id',
+          credential_id: credentialId,
+          schema_version: QUOTA_HEADER_FEED_SCHEMA_VERSION,
+          provider: 'anthropic',
+          configured_account_count: configuredAccountCount,
+          observed_at_ms: observedAtMs,
+          quota,
+          accountKey,
+        }
+      : served.accountId === 'main' && served.mainQuotaIdentity?.accountIdentity
         ? {
-            identity_source: 'credential_id',
-            credential_id: credentialId,
+            identity_source: 'account_ref',
+            account_ref: served.mainQuotaIdentity.accountIdentity,
             schema_version: QUOTA_HEADER_FEED_SCHEMA_VERSION,
             provider: 'anthropic',
             configured_account_count: configuredAccountCount,
@@ -1401,11 +1412,9 @@ const anthropicAuthPlugin = async (
             quota,
             accountKey,
           }
-        : served.accountId === 'main' &&
-            served.mainQuotaIdentity?.accountIdentity
+        : served.accountId === 'main'
           ? {
-              identity_source: 'account_ref',
-              account_ref: served.mainQuotaIdentity.accountIdentity,
+              identity_source: 'none',
               schema_version: QUOTA_HEADER_FEED_SCHEMA_VERSION,
               provider: 'anthropic',
               configured_account_count: configuredAccountCount,
@@ -1413,26 +1422,16 @@ const anthropicAuthPlugin = async (
               quota,
               accountKey,
             }
-          : served.accountId === 'main'
-            ? {
-                identity_source: 'none',
-                schema_version: QUOTA_HEADER_FEED_SCHEMA_VERSION,
-                provider: 'anthropic',
-                configured_account_count: configuredAccountCount,
-                observed_at_ms: observedAtMs,
-                quota,
-                accountKey,
-              }
-            : {
-                identity_source: 'account_ref',
-                account_ref: served.accountId,
-                schema_version: QUOTA_HEADER_FEED_SCHEMA_VERSION,
-                provider: 'anthropic',
-                configured_account_count: configuredAccountCount,
-                observed_at_ms: observedAtMs,
-                quota,
-                accountKey,
-              }
+          : {
+              identity_source: 'account_ref',
+              account_ref: served.accountId,
+              schema_version: QUOTA_HEADER_FEED_SCHEMA_VERSION,
+              provider: 'anthropic',
+              configured_account_count: configuredAccountCount,
+              observed_at_ms: observedAtMs,
+              quota,
+              accountKey,
+            }
     await quotaHeaderFeedRegistry.publish(feedEntry)
   }
 

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -39,13 +39,16 @@ import {
   type KillswitchThresholds,
   killswitchPassesPolicy,
   loadAccounts,
+  mergeHeaderQuotaSnapshot,
   mergeMainQuotaErrorClearedAt,
+  normalizeQuotaHeaders,
   type OAuthAccount,
   type OAuthAccountProfile,
   type OAuthQuotaSnapshot,
   oauthProfileIsFresh,
   PROFILE_TTL_MS,
   QuotaManager,
+  quotaFieldSource,
   quotaSnapshotModelScopeIsExhausted,
   quotaSnapshotPassesModelScope,
   quotaSnapshotPassesPolicy,
@@ -790,6 +793,130 @@ describe('isCostZeroingEnabled', () => {
 })
 
 describe('account storage', () => {
+  test('preserves mixed quota field provenance across a save/load round-trip', async () => {
+    const storage = baseStorage()
+    storage.accounts.push({
+      id: 'fallback-1',
+      type: 'oauth',
+      access: 'access',
+      refresh: 'refresh',
+      expires: 123,
+      quota: {
+        five_hour: {
+          usedPercent: 20,
+          remainingPercent: 80,
+          checkedAt: 600,
+        },
+        seven_day: {
+          usedPercent: 40,
+          remainingPercent: 60,
+          checkedAt: 700,
+        },
+        fieldSources: {
+          five_hour: 'poll',
+          seven_day: 'headers',
+        },
+        source: 'headers',
+        checkedAt: 700,
+      },
+    })
+
+    await saveAccounts(storage, accountPath)
+
+    const loaded = await loadAccounts(accountPath)
+    const quota = expectOAuthAccount(loaded?.accounts[0]).quota
+    expect(quota?.fieldSources).toEqual({
+      five_hour: 'poll',
+      seven_day: 'headers',
+    })
+  })
+
+  test('keeps a reloaded poll window poll-owned during a partial header harvest', async () => {
+    const storage = baseStorage()
+    storage.accounts.push({
+      id: 'fallback-1',
+      type: 'oauth',
+      access: 'access',
+      refresh: 'refresh',
+      expires: 123,
+      quota: {
+        five_hour: {
+          usedPercent: 20,
+          remainingPercent: 80,
+          checkedAt: 600,
+        },
+        seven_day: {
+          usedPercent: 40,
+          remainingPercent: 60,
+          checkedAt: 700,
+        },
+        fieldSources: {
+          five_hour: 'poll',
+          seven_day: 'headers',
+        },
+        source: 'headers',
+        checkedAt: 700,
+      },
+    })
+    await saveAccounts(storage, accountPath)
+
+    const loaded = await loadAccounts(accountPath)
+    const existing = expectOAuthAccount(loaded?.accounts[0]).quota
+    const merged = mergeHeaderQuotaSnapshot(
+      existing,
+      normalizeQuotaHeaders(
+        new Headers({
+          'anthropic-ratelimit-unified-7d-utilization': '0.5',
+        }),
+        800,
+      ),
+    )
+
+    expect(quotaFieldSource(merged, 'five_hour')).toBe('poll')
+    expect(quotaFieldSource(merged, 'seven_day')).toBe('headers')
+  })
+
+  test('filters unknown quota provenance fields and invalid sources on load', async () => {
+    const storage = baseStorage()
+    storage.accounts.push({
+      id: 'fallback-1',
+      type: 'oauth',
+      access: 'access',
+      refresh: 'refresh',
+      expires: 123,
+      quota: {
+        five_hour: {
+          usedPercent: 20,
+          remainingPercent: 80,
+          checkedAt: 600,
+        },
+        seven_day: {
+          usedPercent: 40,
+          remainingPercent: 60,
+          checkedAt: 700,
+        },
+        fieldSources: {
+          five_hour: 'poll',
+          seven_day: 'headers',
+          unknown: 'poll',
+          extraUsage: 'database',
+        } as unknown as OAuthQuotaSnapshot['fieldSources'],
+        source: 'headers',
+        checkedAt: 700,
+      },
+    })
+
+    await saveAccounts(storage, accountPath)
+
+    const loaded = await loadAccounts(accountPath)
+    expect(expectOAuthAccount(loaded?.accounts[0]).quota?.fieldSources).toEqual(
+      {
+        five_hour: 'poll',
+        seven_day: 'headers',
+      },
+    )
+  })
+
   test('saves and loads sidecar accounts', async () => {
     const storage = baseStorage()
     storage.accounts.push({

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -917,6 +917,42 @@ describe('account storage', () => {
     )
   })
 
+  test('drops provenance for quota fields rejected during normalization', async () => {
+    const storage = baseStorage()
+    storage.accounts.push({
+      id: 'fallback-1',
+      type: 'oauth',
+      access: 'access',
+      refresh: 'refresh',
+      expires: 123,
+      quota: {
+        five_hour: {
+          usedPercent: 'not-a-number' as unknown as number,
+          remainingPercent: 80,
+          checkedAt: 600,
+        },
+        seven_day: {
+          usedPercent: 40,
+          remainingPercent: 60,
+          checkedAt: 700,
+        },
+        fieldSources: {
+          five_hour: 'poll',
+          seven_day: 'headers',
+        },
+        source: 'headers',
+        checkedAt: 700,
+      },
+    })
+
+    await saveAccounts(storage, accountPath)
+
+    const loaded = await loadAccounts(accountPath)
+    const quota = expectOAuthAccount(loaded?.accounts[0]).quota
+    expect(quota?.five_hour).toBeUndefined()
+    expect(quota?.fieldSources).toEqual({ seven_day: 'headers' })
+  })
+
   test('saves and loads sidecar accounts', async () => {
     const storage = baseStorage()
     storage.accounts.push({

--- a/packages/opencode/src/tests/quota-header-feed.test.ts
+++ b/packages/opencode/src/tests/quota-header-feed.test.ts
@@ -20,6 +20,7 @@ import {
   type QuotaHeaderFeedPublishEntry,
   QuotaHeaderFeedRegistry,
 } from '../../../core/src/quota-header-feed.ts'
+import { normalizeQuotaHeaders } from '../../../core/src/quota-headers.ts'
 
 const quota = { bindingWindow: 'five_hour', fallbackAdvised: false }
 
@@ -333,6 +334,32 @@ describe('quota header feed', () => {
       bindingWindow: 'headers',
     })
     expect(bytes).not.toContain('must-not-publish')
+  })
+
+  test('keeps source internal and excludes it from published entries', async () => {
+    const registry = new QuotaHeaderFeedRegistry({
+      directory,
+      instanceId: 'source-projection',
+    })
+    const internalSnapshot = normalizeQuotaHeaders(
+      new Headers({
+        'anthropic-ratelimit-unified-fallback': 'available',
+      }),
+    )
+    expect(internalSnapshot).toHaveProperty('source', 'headers')
+
+    await registry.publish({
+      ...entry(),
+      quota: {
+        fallbackAdvised: internalSnapshot.fallbackAdvised,
+        source: 'headers',
+      } as unknown as QuotaHeaderFeedPublishEntry['quota'],
+      accountKey: 'a',
+    })
+    const raw = JSON.parse(
+      await readFile(join(directory, 'source-projection.json'), 'utf8'),
+    )
+    expect(raw.entries.a.quota).not.toHaveProperty('source')
   })
 
   test('omits malformed nested quota values without dropping the entry', async () => {

--- a/packages/opencode/src/tests/quota-header-feed.test.ts
+++ b/packages/opencode/src/tests/quota-header-feed.test.ts
@@ -17,6 +17,7 @@ import {
   QUOTA_HEADER_FEED_LEASE_MS,
   QUOTA_HEADER_FEED_SCHEMA_VERSION,
   type QuotaHeaderFeedEntry,
+  type QuotaHeaderFeedPublishEntry,
   QuotaHeaderFeedRegistry,
 } from '../../../core/src/quota-header-feed.ts'
 
@@ -72,27 +73,30 @@ describe('quota header feed', () => {
     const raw = JSON.parse(
       await readFile(join(directory, 'required.json'), 'utf8'),
     )
-    expect(QUOTA_HEADER_FEED_SCHEMA_VERSION).toBe(2)
-    expect(raw.entries.a.schema_version).toBe(2)
+    expect(QUOTA_HEADER_FEED_SCHEMA_VERSION).toBe(3)
+    expect(raw.entries.a.schema_version).toBe(3)
     expect(raw.entries.a.provider).toBe('anthropic')
   })
 
-  test.each([1, 999])('rejects unknown schema versions %p', async (version) => {
-    await mkdir(directory, { recursive: true })
-    await writeFile(
-      join(directory, 'unknown.json'),
-      JSON.stringify({
-        version,
-        entries: { a: { ...entry(), schema_version: version } },
-        updated_at_ms: 1_000,
-      }),
-    )
-    const registry = new QuotaHeaderFeedRegistry({
-      directory,
-      now: () => 1_000,
-    })
-    expect(await registry.list()).toEqual([])
-  })
+  test.each([1, 2, 999])(
+    'rejects unknown schema versions %p',
+    async (version) => {
+      await mkdir(directory, { recursive: true })
+      await writeFile(
+        join(directory, 'unknown.json'),
+        JSON.stringify({
+          version,
+          entries: { a: { ...entry(), schema_version: version } },
+          updated_at_ms: 1_000,
+        }),
+      )
+      const registry = new QuotaHeaderFeedRegistry({
+        directory,
+        now: () => 1_000,
+      })
+      expect(await registry.list()).toEqual([])
+    },
+  )
 
   test('enforces identity exclusivity and omits identity fields for none', async () => {
     const registry = new QuotaHeaderFeedRegistry({
@@ -232,7 +236,7 @@ describe('quota header feed', () => {
         } as unknown as QuotaHeaderFeedEntry['quota'],
       }),
       accountKey: 'a',
-    })
+    } as unknown as QuotaHeaderFeedPublishEntry)
     const raw = JSON.parse(
       await readFile(join(directory, 'quota-fields.json'), 'utf8'),
     )
@@ -279,6 +283,56 @@ describe('quota header feed', () => {
     expect(bytes).not.toContain('must-not-publish')
     expect(bytes).not.toContain('authorization')
     expect(bytes).not.toContain('access-token')
+  })
+
+  test('publishes only allowlisted per-field provenance', async () => {
+    const registry = new QuotaHeaderFeedRegistry({
+      directory,
+      instanceId: 'provenance-fields',
+    })
+    await registry.publish({
+      ...entry({
+        quota: {
+          five_hour: {
+            usedPercent: 10,
+            remainingPercent: 90,
+            checkedAt: 800,
+          },
+          seven_day: {
+            usedPercent: 20,
+            remainingPercent: 80,
+            checkedAt: 801,
+          },
+          bindingWindow: 'five_hour',
+          fallbackAdvised: false,
+          fieldSources: {
+            five_hour: 'headers',
+            seven_day: 'poll',
+            scoped: 'poll',
+            extraUsage: 'poll',
+            bindingWindow: 'headers',
+            unexpected: 'must-not-publish',
+          },
+        } as unknown as QuotaHeaderFeedEntry['quota'],
+      }),
+      accountKey: 'a',
+    } as unknown as QuotaHeaderFeedPublishEntry)
+
+    const raw = JSON.parse(
+      await readFile(join(directory, 'provenance-fields.json'), 'utf8'),
+    )
+    const bytes = await readFile(
+      join(directory, 'provenance-fields.json'),
+      'utf8',
+    )
+    expect(raw.entries.a.quota.provenance).toEqual({
+      five_hour: 'headers',
+      seven_day: 'poll',
+      scoped: 'poll',
+      extraUsage: 'poll',
+      bindingWindow: 'headers',
+    })
+    expect(bytes).not.toContain('must-not-publish')
   })
 
   test('omits malformed nested quota values without dropping the entry', async () => {
@@ -329,7 +383,7 @@ describe('quota header feed', () => {
         } as unknown as QuotaHeaderFeedEntry['quota'],
       }),
       accountKey: 'a',
-    })
+    } as unknown as QuotaHeaderFeedPublishEntry)
     const raw = JSON.parse(
       await readFile(join(directory, 'malformed-nested.json'), 'utf8'),
     )
@@ -359,14 +413,14 @@ describe('quota header feed', () => {
     await writeFile(
       join(directory, 'stale.json'),
       JSON.stringify({
-        version: 2,
+        version: 3,
         entries: { a: entry({ observed_at_ms: 1_000 }) },
       }),
     )
     await writeFile(
       join(directory, 'future.json'),
       JSON.stringify({
-        version: 2,
+        version: 3,
         entries: { a: entry({ observed_at_ms: 181_001 }) },
       }),
     )

--- a/packages/opencode/src/tests/quota-header-feed.test.ts
+++ b/packages/opencode/src/tests/quota-header-feed.test.ts
@@ -329,11 +329,39 @@ describe('quota header feed', () => {
     expect(raw.entries.a.quota.provenance).toEqual({
       five_hour: 'headers',
       seven_day: 'poll',
-      scoped: 'poll',
-      extraUsage: 'poll',
       bindingWindow: 'headers',
     })
     expect(bytes).not.toContain('must-not-publish')
+  })
+
+  test('does not publish provenance for absent quota fields', async () => {
+    const registry = new QuotaHeaderFeedRegistry({
+      directory,
+      instanceId: 'provenance-presence',
+    })
+    await registry.publish({
+      ...entry({
+        quota: {
+          seven_day: {
+            usedPercent: 20,
+            remainingPercent: 80,
+            checkedAt: 801,
+          },
+          fieldSources: {
+            five_hour: 'poll',
+            seven_day: 'headers',
+          },
+        } as unknown as QuotaHeaderFeedEntry['quota'],
+      }),
+      accountKey: 'a',
+    } as unknown as QuotaHeaderFeedPublishEntry)
+
+    const raw = JSON.parse(
+      await readFile(join(directory, 'provenance-presence.json'), 'utf8'),
+    )
+    expect(raw.entries.a.quota.provenance).toEqual({
+      seven_day: 'headers',
+    })
   })
 
   test('keeps source internal and excludes it from published entries', async () => {

--- a/packages/opencode/src/tests/quota-provenance.test.ts
+++ b/packages/opencode/src/tests/quota-provenance.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test'
-import type { OAuthQuotaSnapshot } from '../../../core/src/accounts.ts'
+import {
+  fetchOAuthQuotaSnapshot,
+  type OAuthQuotaSnapshot,
+} from '../../../core/src/accounts.ts'
 import {
   mergeHeaderQuotaSnapshot,
   normalizeQuotaHeaders,
@@ -139,5 +142,99 @@ describe('quota field provenance', () => {
       bindingWindowSource: 'poll',
       fieldSources: { bindingWindow: 'poll' },
     })
+  })
+
+  test('marks fallback advice as header-derived only when its header is present', () => {
+    const available = normalizeQuotaHeaders(
+      new Headers({
+        'anthropic-ratelimit-unified-fallback': 'available',
+      }),
+      1_700_000_000_000,
+    )
+    const unavailable = normalizeQuotaHeaders(
+      new Headers({
+        'anthropic-ratelimit-unified-fallback': 'not-available',
+      }),
+      1_700_000_000_000,
+    )
+    const absent = normalizeQuotaHeaders(new Headers(), 1_700_000_000_000)
+    const existing = {
+      fallbackAdvised: true,
+      fieldSources: { fallbackAdvised: 'poll' },
+      source: 'poll',
+      checkedAt: 1_699_999_000_000,
+    } satisfies OAuthQuotaSnapshot
+
+    expect(available).toMatchObject({
+      fallbackAdvised: true,
+      fieldSources: { fallbackAdvised: 'headers' },
+    })
+    expect(unavailable).toMatchObject({
+      fallbackAdvised: false,
+      fieldSources: { fallbackAdvised: 'headers' },
+    })
+    expect(absent.fieldSources).not.toHaveProperty('fallbackAdvised')
+    expect(
+      mergeHeaderQuotaSnapshot(absent, normalizeQuotaHeaders(new Headers())),
+    ).not.toMatchObject({
+      fieldSources: { fallbackAdvised: expect.anything() },
+    })
+    expect(
+      mergeHeaderQuotaSnapshot(
+        existing,
+        normalizeQuotaHeaders(new Headers(), 1_700_000_000_000),
+      ),
+    ).toMatchObject({
+      fallbackAdvised: true,
+      fieldSources: { fallbackAdvised: 'poll' },
+    })
+  })
+
+  test('preserves the quota-window complement invariant across header and poll producers', async () => {
+    const percentages = Array.from({ length: 1001 }, (_, index) => index / 1000)
+    const boundaryUtilizations = [0.005, 0.015, 0.025]
+    const samples = [...percentages, ...boundaryUtilizations]
+
+    for (const utilization of samples) {
+      const headers = normalizeQuotaHeaders(
+        new Headers({
+          'anthropic-ratelimit-unified-5h-utilization': String(utilization),
+          'anthropic-ratelimit-unified-7d-utilization': String(utilization),
+        }),
+      )
+      expect(
+        headers.five_hour!.usedPercent + headers.five_hour!.remainingPercent,
+      ).toBe(100)
+      expect(
+        headers.seven_day!.usedPercent + headers.seven_day!.remainingPercent,
+      ).toBe(100)
+
+      const poll = await fetchOAuthQuotaSnapshot({
+        accessToken: 'test-token',
+        now: () => 1_700_000_000_000,
+        fetchImpl: (async () =>
+          Response.json({
+            five_hour: { utilization },
+            seven_day: { utilization },
+            limits: [
+              {
+                kind: 'weekly_scoped',
+                group: 'weekly',
+                percent: utilization * 100,
+                scope: { model: { id: 'fable', display_name: 'Fable' } },
+              },
+            ],
+          })) as unknown as typeof fetch,
+      })
+      expect(
+        poll.five_hour!.usedPercent + poll.five_hour!.remainingPercent,
+      ).toBe(100)
+      expect(
+        poll.seven_day!.usedPercent + poll.seven_day!.remainingPercent,
+      ).toBe(100)
+      expect(
+        poll.scoped![0]!.usedPercent + poll.scoped![0]!.remainingPercent,
+      ).toBe(100)
+    }
   })
 })

--- a/packages/opencode/src/tests/quota-provenance.test.ts
+++ b/packages/opencode/src/tests/quota-provenance.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from 'bun:test'
+import type { OAuthQuotaSnapshot } from '../../../core/src/accounts.ts'
+import {
+  mergeHeaderQuotaSnapshot,
+  normalizeQuotaHeaders,
+} from '../../../core/src/quota-headers.ts'
+
+const BOTH_WINDOW_HEADERS = new Headers({
+  'anthropic-ratelimit-unified-5h-utilization': '0.03',
+  'anthropic-ratelimit-unified-7d-utilization': '0.12',
+})
+
+function pollWindows() {
+  return {
+    five_hour: {
+      usedPercent: 10,
+      remainingPercent: 90,
+      checkedAt: 1_699_999_000_000,
+    },
+    seven_day: {
+      usedPercent: 20,
+      remainingPercent: 80,
+      checkedAt: 1_699_999_000_000,
+    },
+    source: 'poll',
+    checkedAt: 1_699_999_000_000,
+  } satisfies OAuthQuotaSnapshot
+}
+
+describe('quota field provenance', () => {
+  test('keeps poll provenance for a missing five-hour header while marking seven-day as headers', () => {
+    const existing = pollWindows()
+    const incoming = normalizeQuotaHeaders(
+      new Headers({
+        'anthropic-ratelimit-unified-7d-utilization': '0.4',
+      }),
+      1_700_000_000_000,
+    )
+
+    const merged = mergeHeaderQuotaSnapshot(existing, incoming)
+
+    expect(merged).toMatchObject({
+      five_hour: existing.five_hour,
+      seven_day: {
+        usedPercent: 40,
+        checkedAt: 1_700_000_000_000,
+      },
+      fieldSources: {
+        five_hour: 'poll',
+        seven_day: 'headers',
+      },
+    })
+  })
+
+  test('marks both windows as header-derived when both headers are supplied', () => {
+    const merged = mergeHeaderQuotaSnapshot(
+      undefined,
+      normalizeQuotaHeaders(BOTH_WINDOW_HEADERS, 1_700_000_000_000),
+    )
+
+    expect(merged).toMatchObject({
+      fieldSources: {
+        five_hour: 'headers',
+        seven_day: 'headers',
+      },
+    })
+  })
+
+  test('retains poll provenance for windows when the header harvest supplies neither', () => {
+    const existing = pollWindows()
+
+    const merged = mergeHeaderQuotaSnapshot(
+      existing,
+      normalizeQuotaHeaders(new Headers(), 1_700_000_000_000),
+    )
+
+    expect(merged).toMatchObject({
+      fieldSources: {
+        five_hour: 'poll',
+        seven_day: 'poll',
+      },
+    })
+  })
+
+  test('keeps scoped and extra usage poll-owned across a header harvest', () => {
+    const existing = {
+      scoped: [
+        {
+          id: 'scope-1',
+          title: 'Fable only',
+          modelName: 'Fable',
+          usedPercent: 55,
+          remainingPercent: 45,
+          checkedAt: 1_699_999_000_000,
+        },
+      ],
+      extraUsage: {
+        used: { amountMinor: 25, currency: 'USD', exponent: 2 },
+        limit: { amountMinor: 100, currency: 'USD', exponent: 2 },
+        exhausted: false,
+      },
+      source: 'poll',
+      checkedAt: 1_699_999_000_000,
+    } satisfies OAuthQuotaSnapshot
+
+    const merged = mergeHeaderQuotaSnapshot(
+      existing,
+      normalizeQuotaHeaders(BOTH_WINDOW_HEADERS, 1_700_000_000_000),
+    )
+
+    expect(merged).toMatchObject({
+      fieldSources: {
+        scoped: 'poll',
+        extraUsage: 'poll',
+      },
+    })
+  })
+
+  test('preserves a poll-origin binding window over an incoming header claim', () => {
+    const existing = {
+      bindingWindow: 'claude-weekly-scoped-fable',
+      bindingWindowSource: 'poll',
+      source: 'poll',
+      checkedAt: 1_699_999_000_000,
+    } satisfies OAuthQuotaSnapshot
+
+    const merged = mergeHeaderQuotaSnapshot(
+      existing,
+      normalizeQuotaHeaders(
+        new Headers({
+          'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+        }),
+        1_700_000_000_000,
+      ),
+    )
+
+    expect(merged).toMatchObject({
+      bindingWindow: 'claude-weekly-scoped-fable',
+      bindingWindowSource: 'poll',
+      fieldSources: { bindingWindow: 'poll' },
+    })
+  })
+})

--- a/packages/opencode/src/tests/quota-provenance.test.ts
+++ b/packages/opencode/src/tests/quota-provenance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   fetchOAuthQuotaSnapshot,
+  mergeHeaderQuotaForPersistence,
   type OAuthQuotaSnapshot,
 } from '../../../core/src/accounts.ts'
 import {
@@ -190,16 +191,62 @@ describe('quota field provenance', () => {
     })
   })
 
-  test('preserves the quota-window complement invariant across header and poll producers', async () => {
-    const percentages = Array.from({ length: 1001 }, (_, index) => index / 1000)
-    const boundaryUtilizations = [0.005, 0.015, 0.025]
-    const samples = [...percentages, ...boundaryUtilizations]
+  test('keeps poll fallback advice across a partial persistence harvest', () => {
+    const existing = {
+      fallbackAdvised: true,
+      fieldSources: { fallbackAdvised: 'poll' },
+      source: 'poll',
+      checkedAt: 1_699_999_000_000,
+    } satisfies OAuthQuotaSnapshot
+    const incoming = normalizeQuotaHeaders(
+      new Headers({
+        'anthropic-ratelimit-unified-7d-utilization': '0.4',
+      }),
+      1_700_000_000_000,
+    )
 
-    for (const utilization of samples) {
+    const merged = mergeHeaderQuotaForPersistence(existing, incoming)
+
+    expect(merged).toMatchObject({
+      fallbackAdvised: true,
+      fieldSources: {
+        fallbackAdvised: 'poll',
+        seven_day: 'headers',
+      },
+    })
+
+    const withoutExistingAdvice = mergeHeaderQuotaForPersistence(
+      {
+        seven_day: {
+          usedPercent: 20,
+          remainingPercent: 80,
+          checkedAt: 1_699_999_000_000,
+        },
+        fieldSources: { seven_day: 'poll' },
+        source: 'poll',
+        checkedAt: 1_699_999_000_000,
+      },
+      incoming,
+    )
+    expect(withoutExistingAdvice.fallbackAdvised).toBe(false)
+    expect(withoutExistingAdvice.fieldSources).not.toHaveProperty(
+      'fallbackAdvised',
+    )
+  })
+
+  test('preserves the quota-window complement invariant across header and poll producers', async () => {
+    const percentages = Array.from({ length: 1001 }, (_, index) => index / 10)
+    const boundaryPercentages = [0.5, 1.5, 2.5]
+    const samples = [...percentages, ...boundaryPercentages]
+
+    for (const usedPercent of samples) {
+      const headerUtilization = usedPercent / 100
       const headers = normalizeQuotaHeaders(
         new Headers({
-          'anthropic-ratelimit-unified-5h-utilization': String(utilization),
-          'anthropic-ratelimit-unified-7d-utilization': String(utilization),
+          'anthropic-ratelimit-unified-5h-utilization':
+            String(headerUtilization),
+          'anthropic-ratelimit-unified-7d-utilization':
+            String(headerUtilization),
         }),
       )
       expect(
@@ -214,13 +261,13 @@ describe('quota field provenance', () => {
         now: () => 1_700_000_000_000,
         fetchImpl: (async () =>
           Response.json({
-            five_hour: { utilization },
-            seven_day: { utilization },
+            five_hour: { utilization: usedPercent },
+            seven_day: { utilization: usedPercent },
             limits: [
               {
                 kind: 'weekly_scoped',
                 group: 'weekly',
-                percent: utilization * 100,
+                percent: usedPercent,
                 scope: { model: { id: 'fable', display_name: 'Fable' } },
               },
             ],
@@ -232,6 +279,18 @@ describe('quota field provenance', () => {
       expect(
         poll.seven_day!.usedPercent + poll.seven_day!.remainingPercent,
       ).toBe(100)
+      expect(poll.five_hour!.usedPercent).toBe(usedPercent)
+      expect(poll.seven_day!.usedPercent).toBe(usedPercent)
+      expect(headers.five_hour!.usedPercent).toBe(
+        Math.round(headerUtilization * 100),
+      )
+      expect(headers.seven_day!.usedPercent).toBe(
+        Math.round(headerUtilization * 100),
+      )
+      if (Number.isInteger(usedPercent)) {
+        expect(headers.five_hour!.usedPercent).toBe(poll.five_hour!.usedPercent)
+        expect(headers.seven_day!.usedPercent).toBe(poll.seven_day!.usedPercent)
+      }
       expect(
         poll.scoped![0]!.usedPercent + poll.scoped![0]!.remainingPercent,
       ).toBe(100)


### PR DESCRIPTION
A consumer of the quota-header feed cannot currently tell which fields came from response headers and which came from polling. This adds an explicit per-field provenance map and bumps the feed schema to v3.

## The defect

`normalizeQuotaHeaders` sets a window **only when that header was present and parseable**, and `mergeHeaderQuotaSnapshot` is a spread. So when a response lacks the 5h header, the previous **poll-derived** `five_hour` survives the merge — and the entry is still stamped `source: 'headers'` at top level.

A field can therefore be poll-derived while everything about the envelope says otherwise, and nothing distinguishes the two.

Timestamps do not resolve it either. `observed_at_ms` is `entry.checkedAt` — the top-level snapshot time — while windows carry their own `checkedAt` from separate paths. A consumer comparing them measures a gap rather than equality, so a "timestamp matches ⇒ header-derived" rule refuses good data in one direction and accepts poll data in the other.

This surfaced from a real consumer: another tool reading the feed proposed exactly that timestamp discriminator, having observed a ~141s skew on `scoped` versus ~16s on the unified windows. It needs to refuse poll-derived fields because it polls the same upstream endpoint — scoring them would mean confirming its own data.

## What this does

`OAuthQuotaSnapshot.fieldSources` tracks `poll` / `headers` for `five_hour`, `seven_day`, `scoped`, `extraUsage`, and `bindingWindow`. Provenance is computed **at the merge**, where the fact is actually known, rather than asserted at publish time from field names.

The feed publishes it as `quota.provenance` through the existing per-level allowlist — new internal fields still cannot leak into the feed by default. `scoped` and `extraUsage` are always `poll`: Anthropic emits only unified 5h/7d rate-limit headers on the OAuth lane (probed live — 12 headers captured, no scoped or per-model headers exist), and `WINDOW_KEYS` is hardcoded to those two.

Top-level `source` is retained for compatibility; per-field provenance is authoritative.

Follows the existing `bindingWindowSource: 'poll' | 'headers'` precedent rather than introducing a second convention, including its rule that a poll origin wins over an incoming header value.

## Verification

The case that is silently wrong today is the red test: a harvest supplying 7d but **not** 5h must mark 7d `headers` and 5h `poll`. It fails before the change.

Mutation-checked each guard, restoring after:

```
supplied window marked 'poll'      → 2 tests redden, by name
merge fallback removed             → 3 pass / 2 fail
bindingWindow poll-precedence      → 4 pass / 1 fail
allowlist loop → Object.assign     → 15 pass / 1 fail
schema read accepts v2             → 15 pass / 1 fail
```

One mutation I ran deserves noting because it did **not** redden: marking windows `headers` when they were not supplied leaves all 21 tests green. That is not a coverage gap — the merge re-derives from value presence and consults incoming `fieldSources` only when the field is actually present, so that path is unobservable by construction. Worth knowing before someone reads it as a hole.

Gates: root `1318 pass` + the known `relay-worker-miniflare` websocket contention flake (solo-greens 4/4), e2e `29/0`, typecheck, format, biome, `aft_inspect` clean.

## Note on test placement

New tests are in `packages/opencode/src/tests/` deliberately. They were initially written under `packages/core/src/tests/`, where they silently did not run — see #171: that directory is unreachable from `bun run test`, `test:e2e`, and every CI step, so 153 tests across 7 files currently never execute. This PR does not touch that; it just avoids adding to it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790542027&installation_model_id=22398&pr_number=172&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F172&signature=bad27c46228932548305b7c063889948b181b5522a266aef11a3899e06e25d04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes per-field quota provenance in the quota-header feed so consumers can tell which fields came from response headers and which from polling. Previously a partial harvest left poll-derived windows in place while the whole snapshot was stamped `source: 'headers'`; now each field carries its own source, ownership follows the same rules in both the feed merge and the persistence merge, and the feed schema moves to v3.

**Bug Fixes**
- A harvest that supplies 7d but not 5h marks 7d as `headers` and keeps 5h as `poll`; the survivor is no longer mislabeled.
- Provenance is computed at merge time for both feed and persistence merges and survives save/load; unknown fields, invalid sources, and fields that fail normalization are dropped on load.
- Provenance is published through the existing allowlist as `quota.provenance`, so internal fields can't leak.
- `scoped` and `extraUsage` are always `poll`, a poll-origin `bindingWindow` wins over an incoming header claim, and `fallbackAdvised` is `headers` only when its header is present.

**Migration**
- Feed schema bumps from v2 to v3; v2 feeds are no longer read.
- Consumers should key off `quota.provenance` — top-level `source` and timestamps still mislabel partial harvests.

<sup>Written for commit 99260e441610079979e8aa01f02c195df315365b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds per-field quota provenance and advances the quota-header feed to schema v3.
- Tracks poll- versus header-derived ownership while normalizing, merging, and persisting quota snapshots.
- Projects allowlisted ownership metadata as `quota.provenance`.
- Updates the OpenCode publisher and quota-feed tests for the new schema and mixed-source snapshots.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/accounts.ts | Adds quota-field source types, persistence normalization, poll provenance generation, and provenance-aware persistence merging. |
| packages/core/src/quota-headers.ts | Records which headers supplied each field and preserves ownership while merging partial header harvests with poll state. |
| packages/core/src/quota-header-feed.ts | Advances the feed to schema v3 and safely projects allowlisted field provenance. |
| packages/opencode/src/index.ts | Passes internal field-source metadata into the typed quota-feed publishing boundary. |
| packages/opencode/src/tests/quota-provenance.test.ts | Covers partial harvests, poll-owned fields, fallback advice, binding-window precedence, and quota-window invariants. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Poll[OAuth usage polling] --> Snapshot[Quota snapshot with fieldSources]
  Headers[Response quota headers] --> Normalize[Normalize header quota]
  Snapshot --> Merge[Merge per-field values and provenance]
  Normalize --> Merge
  Merge --> Persist[Persist account quota]
  Merge --> Publish[Project allowlisted feed fields]
  Persist --> Publish
  Publish --> Feed[Schema v3 quota feed with quota.provenance]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(quota): align provenance merge guard..."](https://github.com/cortexkit/anthropic-auth/commit/2f6e5db3379770edd01dacccb858568c10aa433d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58059596)</sub>

<!-- /greptile_comment -->