### PR TITLE
Run the core test suite in the gate (fixes #171)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:clean": "bun scripts/dev-clean.ts",
     "extract": "bun scripts/extract-system-prompt.ts",
     "analyze:cache": "node scripts/analyze-cache-usage.mjs",
-    "test": "bun run build && cd packages/core && bun run test && cd ../opencode && bun run test",
+    "test": "cd packages/core && bun run test && cd ../opencode && bun run test",
     "test:e2e": "cd packages/core && bun run build && cd ../.. && bun run --cwd packages/e2e-tests test",
     "typecheck": "cd packages/core && bun run build && cd ../opencode && bun run typecheck && cd ../pi && bun run typecheck && cd ../.. && tsc -p tsconfig.scripts.json",
     "types": "bun run typecheck",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:clean": "bun scripts/dev-clean.ts",
     "extract": "bun scripts/extract-system-prompt.ts",
     "analyze:cache": "node scripts/analyze-cache-usage.mjs",
-    "test": "bun run build && cd packages/opencode && bun run test",
+    "test": "bun run build && cd packages/core && bun run test && cd ../opencode && bun run test",
     "test:e2e": "cd packages/core && bun run build && cd ../.. && bun run --cwd packages/e2e-tests test",
     "typecheck": "cd packages/core && bun run build && cd ../opencode && bun run typecheck && cd ../pi && bun run typecheck && cd ../.. && tsc -p tsconfig.scripts.json",
     "types": "bun run typecheck",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:clean": "bun scripts/dev-clean.ts",
     "extract": "bun scripts/extract-system-prompt.ts",
     "analyze:cache": "node scripts/analyze-cache-usage.mjs",
-    "test": "cd packages/core && bun run test && cd ../opencode && bun run test",
+    "test": "bun run build && cd packages/core && bun test src/tests && cd ../opencode && bun run test",
     "test:e2e": "cd packages/core && bun run build && cd ../.. && bun run --cwd packages/e2e-tests test",
     "typecheck": "cd packages/core && bun run build && cd ../opencode && bun run typecheck && cd ../pi && bun run typecheck && cd ../.. && tsc -p tsconfig.scripts.json",
     "types": "bun run typecheck",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "test": "bun test src/tests",
     "typecheck": "tsc",
     "types": "tsc",
     "prepublishOnly": "bun run build"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
-    "test": "bun test src/tests",
+    "test": "bun run build && bun test src/tests",
     "typecheck": "tsc",
     "types": "tsc",
     "prepublishOnly": "bun run build"


### PR DESCRIPTION
Fixes #171. Two lines: `packages/core` gets a `test` script, and the root `test` script runs it.

```diff
- "test": "bun run build && cd packages/opencode && bun run test"
+ "test": "bun run build && cd packages/core && bun run test && cd ../opencode && bun run test"
```
```diff
+ "test": "bun test src/tests"     # packages/core/package.json
```

## What was not running

`packages/core` had no `test` script, and CI invokes only `bun run test` and `bun run test:e2e`. So `packages/core/src/tests/` was unreachable from every gate:

```
dump.test.ts  killswitch.test.ts  models.test.ts
prime-manager.test.ts  prime.test.ts  prime-usage-race.test.ts  quota-surfaces.test.ts
```

**153 tests.** All passing standalone, none of them executed by CI. They cover killswitch thresholds, prime scheduling and its usage race, dump sweeping, and quota surfaces — spend-gating and request-blocking behaviour, not peripheral code.

## Verification

Observed in a clean worktree at `db2f6c1`:

```
before   1312 pass / 0 fail          (opencode only)
after     153 pass / 0 fail   (core)
         1312 pass / 0 fail   (opencode)
         ────
         1465 total, delta +153
```

Delta matches the previously-stranded count exactly. e2e 29/0, typecheck, format, biome clean.

No CI workflow change needed — `ci.yml` and `release.yaml` already invoke the root script, so wiring it there is sufficient.

## Two notes

**Build ordering matters.** Core tests resolve `@cortexkit/anthropic-auth-core` through the workspace symlink to `dist/`, so they would test stale output if run before a build. The root script already builds first, which is why the core suite is placed after `bun run build` rather than in front of it. Worth stating because getting this wrong would reintroduce a silent-pass defect of exactly the kind this fix removes.

**On the miniflare flake:** an intermediate run of mine showed `relay-worker-miniflare.test.ts` timing out, and I nearly reported this PR as leaving the gate red. It did not reproduce on a quiet machine — that run had two other heavy tasks in parallel. The full gate is green as measured above. The flake is load-induced contention that predates this change, and adding the core suite did not make it worse in my runs, though it does add ~153 tests of load before opencode starts.

## How this was found

A subagent added 4 tests to `packages/core/src/tests/` and reported the root count going up by 1. The arithmetic did not work, and chasing that mismatch surfaced the gap. Nothing else looked wrong — the suites were green, CI was green, and the tests existed. That is what makes this failure mode worth fixing rather than just patching: the only signal was a number that did not add up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790580891&installation_model_id=22398&pr_number=173&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F173&signature=e24bfb4c625488e61c588d5bd9d278253edb21b8bc6e58ff5e5c7d58dffc3ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the `packages/core` test suite from the root `test` script so CI executes the 153 core tests that were previously stranded, fixing #171.

- Adds a self-contained `test` script to `packages/core` that builds and runs `bun test src/tests`.
- The root `test` script keeps the upfront workspace build, then runs core tests directly against the fresh `dist` before `packages/opencode`'s suite.
- The build stays so the gate still fails if any package fails to compile; CI already invokes the root script, so no workflow change is needed.

<sup>Written for commit a44054eb146080d5829563c94664d2be33ed0841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds the core package’s test suite to the root test gate while preserving the required core build ordering.

- Adds a core package test script that builds core and runs `src/tests`.
- Runs the core suite before the OpenCode suite from the root test command.
- Avoids the redundant full-workspace build previously performed by the root command.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Updates the root test command to run the core package’s build-backed suite before the existing OpenCode suite. |
| packages/core/package.json | Adds a test script that rebuilds core before executing its existing tests. |

</details>

<sub>Reviews (4): Last reviewed commit: ["test(core): drop the redundant build fro..."](https://github.com/cortexkit/anthropic-auth/commit/2df62d5928e87516dfa612456ffe9042eefc85f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58178645)</sub>

<!-- /greptile_comment -->