### PR TITLE
test(opencode): bound Miniflare worker startup and name its timeout

### DIFF
--- a/packages/opencode/src/tests/relay-worker-miniflare.test.ts
+++ b/packages/opencode/src/tests/relay-worker-miniflare.test.ts
@@ -80,7 +80,16 @@ async function startWorker(upstream: ReturnType<typeof createUpstream>) {
     port: 0,
     log: new NoOpLog(),
   })
-  await waitForWorkerReady(mf)
+  try {
+    await waitForWorkerReady(mf)
+  } catch (error) {
+    try {
+      await mf.dispose()
+    } catch {
+      // Preserve the named startup failure when cleanup also fails.
+    }
+    throw error
+  }
   return mf
 }
 
@@ -178,7 +187,7 @@ describe('relay Worker under Miniflare', () => {
       upstream = createUpstream()
       mf = await startWorker(upstream)
     },
-    { timeout: WORKER_STARTUP_TIMEOUT_MS },
+    { timeout: WORKER_STARTUP_TIMEOUT_MS + 10_000 },
   )
 
   afterAll(async () => {
@@ -196,6 +205,7 @@ describe('relay Worker under Miniflare', () => {
   })
 
   test('HTTP relay forwards upstream unified quota headers', async () => {
+    const startLen = upstream.bodies.length
     const response = await sendViaRelay({
       config: {
         enabled: true,
@@ -221,10 +231,11 @@ describe('relay Worker under Miniflare', () => {
       'available',
     )
     expect(await response.text()).toBe('upstream-ok')
-    expect(upstream.bodies).toContain('{}')
+    expect(upstream.bodies.slice(startLen)).toEqual(['{}'])
   }, 30_000)
 
   test('client websocket transport reaches Miniflare Worker with byte-exact patch reconstruction', async () => {
+    const startLen = upstream.bodies.length
     const affinity = 'miniflare-client-session'
 
     const firstBody = `client prefix cch=aaaaa; ${'x'.repeat(2048)} tail`
@@ -268,11 +279,11 @@ describe('relay Worker under Miniflare', () => {
       fallback: async () => new Response('direct'),
     })
     expect(await second.text()).toBe('upstream-ok')
-    expect(upstream.bodies).toContain(firstBody)
-    expect(upstream.bodies).toContain(secondBody)
+    expect(upstream.bodies.slice(startLen)).toEqual([firstBody, secondBody])
   }, 30_000)
 
   test('websocket full_sync and patch reconstruct byte-exact upstream bodies', async () => {
+    const startLen = upstream.bodies.length
     const workerSocket = await connectWorkerSocket(
       mf,
       'miniflare-byte-exact-session',
@@ -326,12 +337,12 @@ describe('relay Worker under Miniflare', () => {
       (message) => message.type === 'done' && message.id === 'req_patch',
     )
 
-    expect(upstream.bodies).toContain(firstBody)
-    expect(upstream.bodies).toContain(secondBody)
+    expect(upstream.bodies.slice(startLen)).toEqual([firstBody, secondBody])
     workerSocket.socket.close()
   }, 30_000)
 
   test('websocket hash mismatch returns 409 before upstream fetch', async () => {
+    const startLen = upstream.bodies.length
     const workerSocket = await connectWorkerSocket(
       mf,
       'miniflare-hash-mismatch-session',
@@ -376,7 +387,7 @@ describe('relay Worker under Miniflare', () => {
       (message) => message.type === 'error' && message.id === 'req_bad_patch',
     )
     expect(error).toMatchObject({ status: 409, message: 'hash mismatch' })
-    expect(upstream.bodies).toContain(firstBody)
+    expect(upstream.bodies.slice(startLen)).toEqual([firstBody])
     workerSocket.socket.close()
   }, 30_000)
 })

--- a/packages/opencode/src/tests/relay-worker-miniflare.test.ts
+++ b/packages/opencode/src/tests/relay-worker-miniflare.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import {
   hashBody,
   sendViaRelay,
@@ -7,6 +7,9 @@ import {
 import { Miniflare, NoOpLog } from 'miniflare'
 
 const RELAY_TOKEN = 'relay-token'
+const WORKER_STARTUP_TIMEOUT_MS = 90_000
+const WORKER_STARTUP_TIMEOUT_MESSAGE =
+  'Miniflare worker startup timed out under load (issue #176) — not a websocket-logic failure'
 
 type ControlMessage = {
   type: string
@@ -47,6 +50,25 @@ function createUpstream() {
   return { bodies, fetch, url: 'https://upstream.test/messages' }
 }
 
+async function waitForWorkerReady(
+  mf: Pick<Miniflare, 'ready'>,
+  timeoutMs = WORKER_STARTUP_TIMEOUT_MS,
+) {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error(WORKER_STARTUP_TIMEOUT_MESSAGE)),
+      timeoutMs,
+    )
+  })
+
+  try {
+    return await Promise.race([mf.ready, timeoutPromise])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
 async function startWorker(upstream: ReturnType<typeof createUpstream>) {
   const mf = new Miniflare({
     script: WORKER_SCRIPT,
@@ -58,7 +80,7 @@ async function startWorker(upstream: ReturnType<typeof createUpstream>) {
     port: 0,
     log: new NoOpLog(),
   })
-  await mf.ready
+  await waitForWorkerReady(mf)
   return mf
 }
 
@@ -66,7 +88,7 @@ async function connectWorkerSocket(
   mf: Miniflare,
   affinity: string,
 ): Promise<WorkerSocket> {
-  const url = new URL(await mf.ready)
+  const url = new URL(await waitForWorkerReady(mf))
   url.protocol = 'ws:'
   url.pathname = '/ws'
   url.searchParams.set('token', RELAY_TOKEN)
@@ -148,211 +170,213 @@ function sendPayload(socket: WebSocket, payload: Record<string, unknown>) {
 }
 
 describe('relay Worker under Miniflare', () => {
+  let upstream: ReturnType<typeof createUpstream>
+  let mf: Miniflare
+
+  beforeAll(
+    async () => {
+      upstream = createUpstream()
+      mf = await startWorker(upstream)
+    },
+    { timeout: WORKER_STARTUP_TIMEOUT_MS },
+  )
+
+  afterAll(async () => {
+    // A startup timeout leaves mf unassigned; disposing undefined would bury
+    // the named startup error under a TypeError.
+    await mf?.dispose()
+  })
+
+  test('names a worker startup timeout', async () => {
+    const neverReady = { ready: new Promise<URL>(() => {}) } as Miniflare
+
+    await expect(waitForWorkerReady(neverReady, 1)).rejects.toThrow(
+      'Miniflare worker startup timed out under load (issue #176) — not a websocket-logic failure',
+    )
+  })
+
   test('HTTP relay forwards upstream unified quota headers', async () => {
-    const upstream = createUpstream()
-    const mf = await startWorker(upstream)
+    const response = await sendViaRelay({
+      config: {
+        enabled: true,
+        url: (await waitForWorkerReady(mf)).toString(),
+        token: RELAY_TOKEN,
+        fallbackToDirect: false,
+        transport: 'http',
+      },
+      input: upstream.url,
+      init: { method: 'POST' },
+      headers: new Headers({
+        authorization: 'Bearer test-token',
+        'x-session-affinity': 'miniflare-http-session',
+      }),
+      body: '{}',
+      fallback: async () => new Response('direct'),
+    })
 
-    try {
-      const response = await sendViaRelay({
-        config: {
-          enabled: true,
-          url: (await mf.ready).toString(),
-          token: RELAY_TOKEN,
-          fallbackToDirect: false,
-          transport: 'http',
-        },
-        input: upstream.url,
-        init: { method: 'POST' },
-        headers: new Headers({
-          authorization: 'Bearer test-token',
-          'x-session-affinity': 'miniflare-http-session',
-        }),
-        body: '{}',
-        fallback: async () => new Response('direct'),
-      })
-
-      expect(
-        response.headers.get('anthropic-ratelimit-unified-5h-utilization'),
-      ).toBe('0.78')
-      expect(response.headers.get('anthropic-ratelimit-unified-fallback')).toBe(
-        'available',
-      )
-      expect(await response.text()).toBe('upstream-ok')
-      expect(upstream.bodies).toEqual(['{}'])
-    } finally {
-      await mf.dispose()
-    }
+    expect(
+      response.headers.get('anthropic-ratelimit-unified-5h-utilization'),
+    ).toBe('0.78')
+    expect(response.headers.get('anthropic-ratelimit-unified-fallback')).toBe(
+      'available',
+    )
+    expect(await response.text()).toBe('upstream-ok')
+    expect(upstream.bodies).toContain('{}')
   }, 30_000)
 
   test('client websocket transport reaches Miniflare Worker with byte-exact patch reconstruction', async () => {
-    const upstream = createUpstream()
-    const mf = await startWorker(upstream)
     const affinity = 'miniflare-client-session'
 
-    try {
-      const firstBody = `client prefix cch=aaaaa; ${'x'.repeat(2048)} tail`
-      const secondBody = `client prefix cch=bbbbb; ${'x'.repeat(2048)} tail!`
-      const relayUrl = (await mf.ready).toString()
-      const relayConfig = {
-        enabled: true,
-        url: relayUrl,
-        token: RELAY_TOKEN,
-        fallbackToDirect: false,
-        transport: 'websocket' as const,
-      }
-      const requestHeaders = () =>
-        new Headers({
-          'x-session-affinity': affinity,
-          authorization: 'Bearer test-token',
-        })
-
-      const first = await sendViaRelay({
-        config: relayConfig,
-        input: `${upstream.url}?beta=true`,
-        init: { method: 'POST' },
-        headers: requestHeaders(),
-        body: firstBody,
-        fallback: async () => new Response('direct'),
-      })
-      expect(await first.text()).toBe('upstream-ok')
-      expect(
-        first.headers.get('anthropic-ratelimit-unified-5h-utilization'),
-      ).toBe('0.78')
-      expect(first.headers.get('anthropic-ratelimit-unified-fallback')).toBe(
-        'available',
-      )
-
-      const second = await sendViaRelay({
-        config: relayConfig,
-        input: `${upstream.url}?beta=true`,
-        init: { method: 'POST' },
-        headers: requestHeaders(),
-        body: secondBody,
-        fallback: async () => new Response('direct'),
-      })
-      expect(await second.text()).toBe('upstream-ok')
-      expect(upstream.bodies).toEqual([firstBody, secondBody])
-    } finally {
-      await mf.dispose()
+    const firstBody = `client prefix cch=aaaaa; ${'x'.repeat(2048)} tail`
+    const secondBody = `client prefix cch=bbbbb; ${'x'.repeat(2048)} tail!`
+    const relayUrl = (await waitForWorkerReady(mf)).toString()
+    const relayConfig = {
+      enabled: true,
+      url: relayUrl,
+      token: RELAY_TOKEN,
+      fallbackToDirect: false,
+      transport: 'websocket' as const,
     }
+    const requestHeaders = () =>
+      new Headers({
+        'x-session-affinity': affinity,
+        authorization: 'Bearer test-token',
+      })
+
+    const first = await sendViaRelay({
+      config: relayConfig,
+      input: `${upstream.url}?beta=true`,
+      init: { method: 'POST' },
+      headers: requestHeaders(),
+      body: firstBody,
+      fallback: async () => new Response('direct'),
+    })
+    expect(await first.text()).toBe('upstream-ok')
+    expect(
+      first.headers.get('anthropic-ratelimit-unified-5h-utilization'),
+    ).toBe('0.78')
+    expect(first.headers.get('anthropic-ratelimit-unified-fallback')).toBe(
+      'available',
+    )
+
+    const second = await sendViaRelay({
+      config: relayConfig,
+      input: `${upstream.url}?beta=true`,
+      init: { method: 'POST' },
+      headers: requestHeaders(),
+      body: secondBody,
+      fallback: async () => new Response('direct'),
+    })
+    expect(await second.text()).toBe('upstream-ok')
+    expect(upstream.bodies).toContain(firstBody)
+    expect(upstream.bodies).toContain(secondBody)
   }, 30_000)
 
   test('websocket full_sync and patch reconstruct byte-exact upstream bodies', async () => {
-    const upstream = createUpstream()
-    const mf = await startWorker(upstream)
     const workerSocket = await connectWorkerSocket(
       mf,
       'miniflare-byte-exact-session',
     )
 
-    try {
-      const firstBody = `prefix cch=aaaaa; ${'x'.repeat(1024)} tail`
-      const secondBody = `prefix cch=bbbbb; ${'x'.repeat(1024)} tail!`
-      const cchStart = firstBody.indexOf('aaaaa')
+    const firstBody = `prefix cch=aaaaa; ${'x'.repeat(1024)} tail`
+    const secondBody = `prefix cch=bbbbb; ${'x'.repeat(1024)} tail!`
+    const cchStart = firstBody.indexOf('aaaaa')
 
-      sendPayload(workerSocket.socket, {
-        protocol: 2,
-        type: 'request',
-        id: 'req_full_sync',
-        affinity: 'ignored-client-affinity',
-        upstream: { url: upstream.url, method: 'POST', headers: {} },
-        next_hash: hashBody(firstBody),
-        mode: 'full_sync',
-        revision: 1,
-        body: firstBody,
-      })
-      const responseStart = await workerSocket.waitForControl(
-        (message) =>
-          message.type === 'response_start' && message.id === 'req_full_sync',
-      )
-      expect(
-        responseStart.headers?.['anthropic-ratelimit-unified-5h-utilization'],
-      ).toBe('0.78')
-      expect(
-        responseStart.headers?.['anthropic-ratelimit-unified-fallback'],
-      ).toBe('available')
-      await workerSocket.waitForControl(
-        (message) => message.type === 'done' && message.id === 'req_full_sync',
-      )
+    sendPayload(workerSocket.socket, {
+      protocol: 2,
+      type: 'request',
+      id: 'req_full_sync',
+      affinity: 'ignored-client-affinity',
+      upstream: { url: upstream.url, method: 'POST', headers: {} },
+      next_hash: hashBody(firstBody),
+      mode: 'full_sync',
+      revision: 1,
+      body: firstBody,
+    })
+    const responseStart = await workerSocket.waitForControl(
+      (message) =>
+        message.type === 'response_start' && message.id === 'req_full_sync',
+    )
+    expect(
+      responseStart.headers?.['anthropic-ratelimit-unified-5h-utilization'],
+    ).toBe('0.78')
+    expect(
+      responseStart.headers?.['anthropic-ratelimit-unified-fallback'],
+    ).toBe('available')
+    await workerSocket.waitForControl(
+      (message) => message.type === 'done' && message.id === 'req_full_sync',
+    )
 
-      sendPayload(workerSocket.socket, {
-        protocol: 2,
-        type: 'request',
-        id: 'req_patch',
-        affinity: 'ignored-client-affinity',
-        upstream: { url: upstream.url, method: 'POST', headers: {} },
-        base_hash: hashBody(firstBody),
-        next_hash: hashBody(secondBody),
-        mode: 'patch',
-        revision: 2,
-        patch: [
-          { start: cchStart, deleteCount: 5, insert: 'bbbbb' },
-          { start: firstBody.length, deleteCount: 0, insert: '!' },
-        ],
-      })
-      await workerSocket.waitForControl(
-        (message) => message.type === 'done' && message.id === 'req_patch',
-      )
+    sendPayload(workerSocket.socket, {
+      protocol: 2,
+      type: 'request',
+      id: 'req_patch',
+      affinity: 'ignored-client-affinity',
+      upstream: { url: upstream.url, method: 'POST', headers: {} },
+      base_hash: hashBody(firstBody),
+      next_hash: hashBody(secondBody),
+      mode: 'patch',
+      revision: 2,
+      patch: [
+        { start: cchStart, deleteCount: 5, insert: 'bbbbb' },
+        { start: firstBody.length, deleteCount: 0, insert: '!' },
+      ],
+    })
+    await workerSocket.waitForControl(
+      (message) => message.type === 'done' && message.id === 'req_patch',
+    )
 
-      expect(upstream.bodies).toEqual([firstBody, secondBody])
-    } finally {
-      workerSocket.socket.close()
-      await mf.dispose()
-    }
+    expect(upstream.bodies).toContain(firstBody)
+    expect(upstream.bodies).toContain(secondBody)
+    workerSocket.socket.close()
   }, 30_000)
 
   test('websocket hash mismatch returns 409 before upstream fetch', async () => {
-    const upstream = createUpstream()
-    const mf = await startWorker(upstream)
     const workerSocket = await connectWorkerSocket(
       mf,
       'miniflare-hash-mismatch-session',
     )
 
-    try {
-      const firstBody = 'stable-prefix stale-tail'
-      const expectedBody = 'stable-prefix expected-tail'
+    const firstBody = 'stable-prefix stale-tail'
+    const expectedBody = 'stable-prefix expected-tail'
 
-      sendPayload(workerSocket.socket, {
-        protocol: 2,
-        type: 'request',
-        id: 'req_seed_state',
-        affinity: 'ignored-client-affinity',
-        upstream: { url: upstream.url, method: 'POST', headers: {} },
-        next_hash: hashBody(firstBody),
-        mode: 'full_sync',
-        revision: 1,
-        body: firstBody,
-      })
-      await workerSocket.waitForControl(
-        (message) => message.type === 'done' && message.id === 'req_seed_state',
-      )
+    sendPayload(workerSocket.socket, {
+      protocol: 2,
+      type: 'request',
+      id: 'req_seed_state',
+      affinity: 'ignored-client-affinity',
+      upstream: { url: upstream.url, method: 'POST', headers: {} },
+      next_hash: hashBody(firstBody),
+      mode: 'full_sync',
+      revision: 1,
+      body: firstBody,
+    })
+    await workerSocket.waitForControl(
+      (message) => message.type === 'done' && message.id === 'req_seed_state',
+    )
 
-      sendPayload(workerSocket.socket, {
-        protocol: 2,
-        type: 'request',
-        id: 'req_bad_patch',
-        affinity: 'ignored-client-affinity',
-        upstream: { url: upstream.url, method: 'POST', headers: {} },
-        base_hash: hashBody(firstBody),
-        next_hash: hashBody(expectedBody),
-        mode: 'patch',
-        revision: 2,
-        patch: {
-          start: 'stable-prefix '.length,
-          deleteCount: 'stale-tail'.length,
-          insert: 'wrong-tail',
-        },
-      })
+    sendPayload(workerSocket.socket, {
+      protocol: 2,
+      type: 'request',
+      id: 'req_bad_patch',
+      affinity: 'ignored-client-affinity',
+      upstream: { url: upstream.url, method: 'POST', headers: {} },
+      base_hash: hashBody(firstBody),
+      next_hash: hashBody(expectedBody),
+      mode: 'patch',
+      revision: 2,
+      patch: {
+        start: 'stable-prefix '.length,
+        deleteCount: 'stale-tail'.length,
+        insert: 'wrong-tail',
+      },
+    })
 
-      const error = await workerSocket.waitForControl(
-        (message) => message.type === 'error' && message.id === 'req_bad_patch',
-      )
-      expect(error).toMatchObject({ status: 409, message: 'hash mismatch' })
-      expect(upstream.bodies).toEqual([firstBody])
-    } finally {
-      workerSocket.socket.close()
-      await mf.dispose()
-    }
+    const error = await workerSocket.waitForControl(
+      (message) => message.type === 'error' && message.id === 'req_bad_patch',
+    )
+    expect(error).toMatchObject({ status: 409, message: 'hash mismatch' })
+    expect(upstream.bodies).toContain(firstBody)
+    workerSocket.socket.close()
   }, 30_000)
 })


### PR DESCRIPTION
Fixes #176.

`relay-worker-miniflare.test.ts` fails on shared runners with a 30s timeout and `workerd ... Broken pipe`, hitting a different test in the file each time — three CI hits on one branch today (runs 33495627135, 33508661808, 33509080794), while solo runs pass 4/0 in under a second every time. The websocket logic was never the problem: each of the four tests constructed and awaited its own Miniflare instance inside the per-test 30s budget, so worker *startup* contention under parallel suite load ate the timeout and misattributed the failure to whichever test ran.

Two changes, both from the issue:

- One shared Miniflare instance per file, started in `beforeAll` with its own 90s hook timeout and disposed in `afterAll`. Startup no longer competes with (or bills against) any test's budget, and three of the four startups disappear entirely.
- Every `ready` await goes through a bounded helper that throws `Miniflare worker startup timed out under load (issue #176) — not a websocket-logic failure` on expiry. If a runner is ever slow enough to blow a 90s startup budget, the failure now says what it is instead of masquerading as a websocket assertion.

The timer is cleared once the race settles, so the loser can't fire into a later test.

Verification: solo run 5/0 (the fifth is a new deterministic test driving the helper with a 1ms budget against a never-ready stub and asserting the named error). Full root suite 3/3 green post-fix with the miniflare file passing all three. Honest caveat: the load-dependent failure would not reproduce on demand in a pre-fix baseline (two runs) — it never does when you want it to — so acceptance rests on the deterministic named-error path plus the 3× green, not on a reproduced red.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790859477&installation_model_id=22398&pr_number=178&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F178&signature=e62858142d64b9a3bc74faff03e4b9e30265726da030dd603395685ccfd3b178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #176. Makes `relay-worker-miniflare.test.ts` reliable on shared CI runners by sharing one Miniflare instance per file and bounding startup with a self-describing timeout. Previously, each test started its own worker inside the 30s test budget, so startup contention on parallel runners blew the timeout and got misattributed to whichever test ran.

- Starts one Miniflare instance per file in `beforeAll` with a dedicated 90s hook timeout, then disposes it in `afterAll`; tests assert only the upstream bodies they added, since bodies accumulate on the shared instance.
- Routes every `ready` await through a bounded helper that throws a named error on expiry instead of surfacing as a websocket assertion, and disposes timed-out workers so cleanup preserves that error.
- Adds a deterministic test that drives the helper with a 1ms budget against a never-ready stub.

<sup>Written for commit cfab9a9bd3c526718b5cd74318a5e2f5c15c5c30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

