### PR TITLE
Support claude-fable-5-1 and claude-mythos-5-1

### DIFF
--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -112,6 +112,14 @@ export function isClaudeFableOrMythos51Model(model: unknown) {
   )
 }
 
+export function isClaudeFable51Model(model: unknown) {
+  if (typeof model !== 'string') return false
+  return (
+    model === CLAUDE_FABLE_5_1_MODEL_ID ||
+    model.startsWith(`${CLAUDE_FABLE_5_1_MODEL_ID}-`)
+  )
+}
+
 export const CLAUDE_SONNET_5_MODEL_ID = 'claude-sonnet-5'
 
 /**

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -1,5 +1,7 @@
 export const CLAUDE_FABLE_5_MODEL_ID = 'claude-fable-5'
 export const CLAUDE_MYTHOS_5_MODEL_ID = 'claude-mythos-5'
+export const CLAUDE_FABLE_5_1_MODEL_ID = 'claude-fable-5-1'
+export const CLAUDE_MYTHOS_5_1_MODEL_ID = 'claude-mythos-5-1'
 
 /**
  * Haiku 4.5 model identifier used by `/claude-prime` to start each OAuth
@@ -19,9 +21,15 @@ export const CLAUDE_HAIKU_4_5_PRICING = {
   output: 5,
 } as const
 
+export const CLAUDE_FABLE_MYTHOS_5_1_MODEL_IDS = [
+  CLAUDE_FABLE_5_1_MODEL_ID,
+  CLAUDE_MYTHOS_5_1_MODEL_ID,
+] as const
+
 export const CLAUDE_FABLE_MYTHOS_5_MODEL_IDS = [
   CLAUDE_FABLE_5_MODEL_ID,
   CLAUDE_MYTHOS_5_MODEL_ID,
+  ...CLAUDE_FABLE_MYTHOS_5_1_MODEL_IDS,
 ] as const
 
 export type ClaudeFableMythos5ModelId =
@@ -36,6 +44,14 @@ export const CLAUDE_FABLE_MYTHOS_5_PRICING = {
   input: 10,
   output: 50,
   cacheRead: 1,
+  cacheWrite5m: 12.5,
+  cacheWrite1h: 20,
+} as const
+
+export const CLAUDE_FABLE_MYTHOS_5_1_PRICING = {
+  input: 10,
+  output: 50,
+  cacheRead: 0.25,
   cacheWrite5m: 12.5,
   cacheWrite1h: 20,
 } as const
@@ -57,12 +73,40 @@ export const CLAUDE_FABLE_MYTHOS_5_MODEL_SPECS: Record<
     name: 'Claude Mythos 5',
     limited: true,
   },
+  [CLAUDE_FABLE_5_1_MODEL_ID]: {
+    id: CLAUDE_FABLE_5_1_MODEL_ID,
+    name: 'Claude Fable 5.1',
+  },
+  [CLAUDE_MYTHOS_5_1_MODEL_ID]: {
+    id: CLAUDE_MYTHOS_5_1_MODEL_ID,
+    name: 'Claude Mythos 5.1',
+    limited: true,
+  },
 }
+
+export const CLAUDE_FABLE_MYTHOS_5_1_MODEL_SPECS = {
+  [CLAUDE_FABLE_5_1_MODEL_ID]:
+    CLAUDE_FABLE_MYTHOS_5_MODEL_SPECS[CLAUDE_FABLE_5_1_MODEL_ID],
+  [CLAUDE_MYTHOS_5_1_MODEL_ID]:
+    CLAUDE_FABLE_MYTHOS_5_MODEL_SPECS[CLAUDE_MYTHOS_5_1_MODEL_ID],
+} satisfies Record<
+  (typeof CLAUDE_FABLE_MYTHOS_5_1_MODEL_IDS)[number],
+  { id: string; name: string; limited?: boolean }
+>
 
 export function isClaudeFableOrMythos5Model(model: unknown) {
   return (
     typeof model === 'string' &&
     CLAUDE_FABLE_MYTHOS_5_MODEL_IDS.some(
+      (id) => model === id || model.startsWith(`${id}-`),
+    )
+  )
+}
+
+export function isClaudeFableOrMythos51Model(model: unknown) {
+  return (
+    typeof model === 'string' &&
+    CLAUDE_FABLE_MYTHOS_5_1_MODEL_IDS.some(
       (id) => model === id || model.startsWith(`${id}-`),
     )
   )

--- a/packages/core/src/tests/models.test.ts
+++ b/packages/core/src/tests/models.test.ts
@@ -1,10 +1,60 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  CLAUDE_FABLE_5_1_MODEL_ID,
+  CLAUDE_FABLE_MYTHOS_5_1_MODEL_IDS,
+  CLAUDE_FABLE_MYTHOS_5_1_MODEL_SPECS,
+  CLAUDE_FABLE_MYTHOS_5_1_PRICING,
+  CLAUDE_MYTHOS_5_1_MODEL_ID,
   CLAUDE_OPUS_5_ADAPTIVE_THINKING,
   CLAUDE_OPUS_5_MODEL_ID,
+  isClaudeFableOrMythos5Model,
   isClaudeOpus5Model,
   isClaudeSonnet5Model,
 } from '../models'
+
+describe('Claude Fable/Mythos 5.1 models', () => {
+  test('exposes both 5.1 model ids and complete specs', () => {
+    expect(CLAUDE_FABLE_5_1_MODEL_ID).toBe('claude-fable-5-1')
+    expect(CLAUDE_MYTHOS_5_1_MODEL_ID).toBe('claude-mythos-5-1')
+    expect(CLAUDE_FABLE_MYTHOS_5_1_MODEL_IDS).toEqual([
+      CLAUDE_FABLE_5_1_MODEL_ID,
+      CLAUDE_MYTHOS_5_1_MODEL_ID,
+    ])
+    expect(CLAUDE_FABLE_MYTHOS_5_1_MODEL_SPECS).toMatchObject({
+      [CLAUDE_FABLE_5_1_MODEL_ID]: {
+        id: CLAUDE_FABLE_5_1_MODEL_ID,
+        name: 'Claude Fable 5.1',
+      },
+      [CLAUDE_MYTHOS_5_1_MODEL_ID]: {
+        id: CLAUDE_MYTHOS_5_1_MODEL_ID,
+        name: 'Claude Mythos 5.1',
+        limited: true,
+      },
+    })
+    expect(CLAUDE_FABLE_MYTHOS_5_1_PRICING).toEqual({
+      input: 10,
+      output: 50,
+      cacheRead: 0.25,
+      cacheWrite5m: 12.5,
+      cacheWrite1h: 20,
+    })
+  })
+
+  test('normalizes exact ids and dated snapshots as Fable/Mythos 5 models', () => {
+    for (const model of [
+      'claude-fable-5',
+      'claude-mythos-5',
+      'claude-fable-5-20260608',
+      'claude-mythos-5-20260608',
+      'claude-fable-5-1',
+      'claude-mythos-5-1',
+      'claude-fable-5-1-20260701',
+      'claude-mythos-5-1-20260701',
+    ]) {
+      expect(isClaudeFableOrMythos5Model(model)).toBe(true)
+    }
+  })
+})
 
 describe('isClaudeSonnet5Model', () => {
   test('matches the bare claude-sonnet-5 id', () => {

--- a/packages/core/src/tests/models.test.ts
+++ b/packages/core/src/tests/models.test.ts
@@ -7,6 +7,7 @@ import {
   CLAUDE_MYTHOS_5_1_MODEL_ID,
   CLAUDE_OPUS_5_ADAPTIVE_THINKING,
   CLAUDE_OPUS_5_MODEL_ID,
+  isClaudeFable51Model,
   isClaudeFableOrMythos5Model,
   isClaudeOpus5Model,
   isClaudeSonnet5Model,
@@ -53,6 +54,18 @@ describe('Claude Fable/Mythos 5.1 models', () => {
     ]) {
       expect(isClaudeFableOrMythos5Model(model)).toBe(true)
     }
+  })
+})
+
+describe('isClaudeFable51Model', () => {
+  test('matches exact and dated Fable 5.1 ids only', () => {
+    expect(isClaudeFable51Model('claude-fable-5-1')).toBe(true)
+    expect(isClaudeFable51Model('claude-fable-5-1-20260830')).toBe(true)
+    expect(isClaudeFable51Model('claude-mythos-5-1')).toBe(false)
+    expect(isClaudeFable51Model('claude-fable-5')).toBe(false)
+    expect(isClaudeFable51Model('claude-mythos-5')).toBe(false)
+    expect(isClaudeFable51Model('claude-fable-5-1x')).toBe(false)
+    expect(isClaudeFable51Model(42)).toBe(false)
   })
 })
 

--- a/packages/opencode/src/fable-fallback.ts
+++ b/packages/opencode/src/fable-fallback.ts
@@ -44,13 +44,11 @@ type FableFallbackState = {
 
 /**
  * Models whose content-filter refusal we recover from by downgrading to Opus 4.8
- * for a short window. Fable 5 and Fable 5.1 are separate source families because
- * recovery state must not cross-contaminate distinct requested models; Opus 5 is identical in
- * shape (cyber safety classifiers that can return `stop_reason: "refusal"`,
- * Anthropic's own fallback default is `claude-opus-4-8`, same pricing). Mythos
- * has no classifiers and Sonnet 5 is not flagged — both stay outside this
- * gate. The single shared fallback id matches Anthropic's default for both
- * source models, so the recovery period is uniform.
+ * for a short window. Fable 5, Fable 5.1, and Opus 5 each have a separate
+ * source family because recovery state must not cross-contaminate distinct
+ * requested models. All three use Anthropic's `claude-opus-4-8` fallback for
+ * the same classifier refusal shape and recovery period. Mythos has no
+ * classifiers and Sonnet 5 is not flagged — both stay outside this gate.
  */
 export type RecoverableRefusalFamily = 'fable-5' | 'fable-5-1' | 'opus-5'
 

--- a/packages/opencode/src/fable-fallback.ts
+++ b/packages/opencode/src/fable-fallback.ts
@@ -1,4 +1,5 @@
 import {
+  CLAUDE_FABLE_5_1_MODEL_ID,
   CLAUDE_FABLE_5_MODEL_ID,
   isClaudeOpus5Model,
 } from '@cortexkit/anthropic-auth-core'
@@ -43,20 +44,27 @@ type FableFallbackState = {
 
 /**
  * Models whose content-filter refusal we recover from by downgrading to Opus 4.8
- * for a short window. Fable 5 is the original case; Opus 5 is identical in
+ * for a short window. Fable 5 and Fable 5.1 are separate source families because
+ * recovery state must not cross-contaminate distinct requested models; Opus 5 is identical in
  * shape (cyber safety classifiers that can return `stop_reason: "refusal"`,
  * Anthropic's own fallback default is `claude-opus-4-8`, same pricing). Mythos
  * has no classifiers and Sonnet 5 is not flagged — both stay outside this
  * gate. The single shared fallback id matches Anthropic's default for both
  * source models, so the recovery period is uniform.
  */
-export type RecoverableRefusalFamily = 'fable-5' | 'opus-5'
+export type RecoverableRefusalFamily = 'fable-5' | 'fable-5-1' | 'opus-5'
 
 export function recoverableRefusalFamily(
   model: unknown,
 ): RecoverableRefusalFamily | null {
   if (typeof model !== 'string') return null
   if (isClaudeOpus5Model(model)) return 'opus-5'
+  if (
+    model === CLAUDE_FABLE_5_1_MODEL_ID ||
+    model.startsWith(`${CLAUDE_FABLE_5_1_MODEL_ID}-`)
+  ) {
+    return 'fable-5-1'
+  }
   if (
     model === CLAUDE_FABLE_5_MODEL_ID ||
     model.startsWith(`${CLAUDE_FABLE_5_MODEL_ID}-`)

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -17,6 +17,7 @@ import {
   CLAUDE_ACCOUNT_COMMAND_NAME,
   CLAUDE_CACHE_KEEP_COMMAND_NAME,
   CLAUDE_DUMP_COMMAND_NAME,
+  CLAUDE_FABLE_MYTHOS_5_1_PRICING,
   CLAUDE_FABLE_MYTHOS_5_CONTEXT_WINDOW,
   CLAUDE_FABLE_MYTHOS_5_MAX_OUTPUT_TOKENS,
   CLAUDE_FABLE_MYTHOS_5_MODEL_SPECS,
@@ -78,6 +79,7 @@ import {
   isCacheKeepHybridActive,
   isCacheKeepPersistentlyEnabled,
   isCacheKeepSubagentsEnabled,
+  isClaudeFableOrMythos51Model,
   isClaudeOpus5Model,
   isCostZeroingEnabled,
   isDumpPersistentlyEnabled,
@@ -668,6 +670,13 @@ function buildRestoredNotice(modelId: string): string {
 
 function fallbackModelLabel(modelId: string): string {
   if (isClaudeOpus5Model(modelId)) return 'Opus 5'
+  if (
+    modelId === 'claude-mythos-5-1' ||
+    modelId.startsWith('claude-mythos-5-1-')
+  )
+    return 'Mythos 5.1'
+  if (modelId === 'claude-fable-5-1' || modelId.startsWith('claude-fable-5-1-'))
+    return 'Fable 5.1'
   if (modelId === 'claude-fable-5' || modelId.startsWith('claude-fable-5-'))
     return 'Fable 5'
   if (modelId === 'claude-opus-4-8' || modelId.startsWith('claude-opus-4-8-')) {
@@ -710,35 +719,40 @@ function addFableMythos5Models<
   return {
     ...models,
     ...Object.fromEntries(
-      Object.values(CLAUDE_FABLE_MYTHOS_5_MODEL_SPECS).map((spec) => [
-        spec.id,
-        {
-          ...base,
-          id: spec.id,
-          name: spec.name,
-          api: base.api ? { ...base.api, id: spec.id } : undefined,
-          cost: {
-            input: CLAUDE_FABLE_MYTHOS_5_PRICING.input,
-            output: CLAUDE_FABLE_MYTHOS_5_PRICING.output,
-            cache: {
-              read: CLAUDE_FABLE_MYTHOS_5_PRICING.cacheRead,
-              write: CLAUDE_FABLE_MYTHOS_5_PRICING.cacheWrite5m,
+      Object.values(CLAUDE_FABLE_MYTHOS_5_MODEL_SPECS).map((spec) => {
+        const pricing = isClaudeFableOrMythos51Model(spec.id)
+          ? CLAUDE_FABLE_MYTHOS_5_1_PRICING
+          : CLAUDE_FABLE_MYTHOS_5_PRICING
+        return [
+          spec.id,
+          {
+            ...base,
+            id: spec.id,
+            name: spec.name,
+            api: base.api ? { ...base.api, id: spec.id } : undefined,
+            cost: {
+              input: pricing.input,
+              output: pricing.output,
+              cache: {
+                read: pricing.cacheRead,
+                write: pricing.cacheWrite5m,
+              },
             },
+            limit: {
+              ...(base.limit ?? {}),
+              context: CLAUDE_FABLE_MYTHOS_5_CONTEXT_WINDOW,
+              output: CLAUDE_FABLE_MYTHOS_5_MAX_OUTPUT_TOKENS,
+            },
+            capabilities: {
+              ...(base.capabilities ?? {}),
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+            },
+            release_date: CLAUDE_FABLE_MYTHOS_5_RELEASE_DATE,
           },
-          limit: {
-            ...(base.limit ?? {}),
-            context: CLAUDE_FABLE_MYTHOS_5_CONTEXT_WINDOW,
-            output: CLAUDE_FABLE_MYTHOS_5_MAX_OUTPUT_TOKENS,
-          },
-          capabilities: {
-            ...(base.capabilities ?? {}),
-            reasoning: true,
-            attachment: true,
-            toolcall: true,
-          },
-          release_date: CLAUDE_FABLE_MYTHOS_5_RELEASE_DATE,
-        },
-      ]),
+        ]
+      }),
     ),
   } as T
 }

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -658,6 +658,10 @@ function buildSwitchedToOpusNotice(modelId: string): string {
   if (isClaudeOpus5Model(modelId)) {
     return 'Opus 5 content filter detected. Switched to Opus 4.8 for a 10-response recovery window while keeping the Opus 5 cache warm.'
   }
+  if (isClaudeFableOrMythos51Model(modelId)) {
+    const label = fallbackModelLabel(modelId)
+    return `${label} content filter detected. Switched to Opus 4.8 for a 10-response recovery window while keeping the ${label} cache warm.`
+  }
   return FABLE_SWITCHED_TO_OPUS_NOTICE
 }
 
@@ -665,18 +669,18 @@ function buildRestoredNotice(modelId: string): string {
   if (isClaudeOpus5Model(modelId)) {
     return 'Opus 5 recovery window complete. Returning to Opus 5.'
   }
+  if (isClaudeFableOrMythos51Model(modelId)) {
+    return `Recovery window complete. Returning to ${fallbackModelLabel(modelId)}.`
+  }
   return FABLE_RESTORED_NOTICE
 }
 
 function fallbackModelLabel(modelId: string): string {
   if (isClaudeOpus5Model(modelId)) return 'Opus 5'
-  if (
-    modelId === 'claude-mythos-5-1' ||
-    modelId.startsWith('claude-mythos-5-1-')
-  )
-    return 'Mythos 5.1'
-  if (modelId === 'claude-fable-5-1' || modelId.startsWith('claude-fable-5-1-'))
-    return 'Fable 5.1'
+  if (isClaudeFableOrMythos51Model(modelId)) {
+    if (modelId.startsWith('claude-mythos-5-1')) return 'Mythos 5.1'
+    if (modelId.startsWith('claude-fable-5-1')) return 'Fable 5.1'
+  }
   if (modelId === 'claude-fable-5' || modelId.startsWith('claude-fable-5-'))
     return 'Fable 5'
   if (modelId === 'claude-opus-4-8' || modelId.startsWith('claude-opus-4-8-')) {

--- a/packages/opencode/src/server-fallback.ts
+++ b/packages/opencode/src/server-fallback.ts
@@ -1,3 +1,4 @@
+import { isClaudeFableOrMythos51Model } from '@cortexkit/anthropic-auth-core'
 import {
   isRecoverableRefusalModel,
   recoverableRefusalFamily,
@@ -144,7 +145,10 @@ export function applyServerSideFallbackToBody(
   restoredMarkers: number
   droppedMarkers: number
 } {
-  const enabled = requested && isRecoverableRefusalModel(body.model)
+  const enabled =
+    requested &&
+    (isRecoverableRefusalModel(body.model) ||
+      isClaudeFableOrMythos51Model(body.model))
   const markerResult = rewriteStoredMarkers(body, enabled)
   if (enabled) {
     body.fallbacks = 'default'

--- a/packages/opencode/src/server-fallback.ts
+++ b/packages/opencode/src/server-fallback.ts
@@ -1,4 +1,4 @@
-import { isClaudeFableOrMythos51Model } from '@cortexkit/anthropic-auth-core'
+import { isClaudeFable51Model } from '@cortexkit/anthropic-auth-core'
 import {
   isRecoverableRefusalModel,
   recoverableRefusalFamily,
@@ -147,8 +147,7 @@ export function applyServerSideFallbackToBody(
 } {
   const enabled =
     requested &&
-    (isRecoverableRefusalModel(body.model) ||
-      isClaudeFableOrMythos51Model(body.model))
+    (isRecoverableRefusalModel(body.model) || isClaudeFable51Model(body.model))
   const markerResult = rewriteStoredMarkers(body, enabled)
   if (enabled) {
     body.fallbacks = 'default'

--- a/packages/opencode/src/sidebar-state.ts
+++ b/packages/opencode/src/sidebar-state.ts
@@ -795,11 +795,21 @@ export function formatScopedQuotaLabel(title: string) {
 }
 
 /**
- * Pretty label for a recoverable-refusal source model (Fable 5 or Opus 5).
+ * Pretty label for a recoverable-refusal source model (Fable 5/5.1 or Opus 5).
  * Falls back to the raw id for unrecognized ids so the sidebar never goes
  * blank on a future model that has not yet been cataloged here.
  */
 export function formatFallbackModelLabel(modelId: string | undefined): string {
+  if (
+    modelId === 'claude-mythos-5-1' ||
+    modelId?.startsWith('claude-mythos-5-1-')
+  )
+    return 'Mythos 5.1'
+  if (
+    modelId === 'claude-fable-5-1' ||
+    modelId?.startsWith('claude-fable-5-1-')
+  )
+    return 'Fable 5.1'
   if (modelId === 'claude-fable-5' || modelId?.startsWith('claude-fable-5-'))
     return 'Fable 5'
   if (modelId === 'claude-opus-5' || modelId?.startsWith('claude-opus-5-'))

--- a/packages/opencode/src/tests/accounts.test.ts
+++ b/packages/opencode/src/tests/accounts.test.ts
@@ -4204,7 +4204,13 @@ describe('fetchOAuthQuotaSnapshot duck-typed error producer', () => {
     expect(getScopedQuotaWindowForModel(quota, 'claude-fable-5')?.title).toBe(
       'Fable only',
     )
+    expect(getScopedQuotaWindowForModel(quota, 'claude-fable-5-1')?.title).toBe(
+      'Fable only',
+    )
     expect(quotaSnapshotModelScopeIsExhausted(quota, 'claude-fable-5')).toBe(
+      true,
+    )
+    expect(quotaSnapshotModelScopeIsExhausted(quota, 'claude-fable-5-1')).toBe(
       true,
     )
     expect(quotaSnapshotPassesModelScope(quota, 'claude-opus-4-8')).toBe(true)

--- a/packages/opencode/src/tests/fable-fallback.test.ts
+++ b/packages/opencode/src/tests/fable-fallback.test.ts
@@ -225,6 +225,28 @@ describe('FableFallbackManager', () => {
     expect(plan.effectiveModel).toBe(FABLE_FALLBACK_MODEL_ID)
     expect(JSON.parse(plan.bodyText).model).toBe(FABLE_FALLBACK_MODEL_ID)
   })
+
+  test('keeps Fable 5.1 recovery state independent from Fable 5', () => {
+    const manager = new FableFallbackManager()
+    const fable5 = manager.plan('session-a', body('claude-fable-5'))!
+    manager.activate(fable5, 'fable5-account')
+
+    const fable51 = manager.plan('session-a', body('claude-fable-5-1'))!
+    expect(fable51).toMatchObject({
+      requestedModel: 'claude-fable-5-1',
+      effectiveModel: 'claude-fable-5-1',
+      downgraded: false,
+    })
+    manager.activate(fable51, 'fable51-account')
+
+    const fable5Recovery = manager.plan('session-a', body('claude-fable-5'))!
+    const fable51Recovery = manager.plan('session-a', body('claude-fable-5-1'))!
+    expect(fable5Recovery.downgraded).toBe(true)
+    expect(fable51Recovery.downgraded).toBe(true)
+    expect(fable5Recovery.cycle).not.toBe(fable51Recovery.cycle)
+    expect(fable5Recovery.cacheAccountId).toBe('fable5-account')
+    expect(fable51Recovery.cacheAccountId).toBe('fable51-account')
+  })
 })
 
 describe('FableFallbackManager — Opus 5 recovery parity', () => {

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -2696,6 +2696,13 @@ describe('provider.models', () => {
       output: 128_000,
     })
     expect(result?.['claude-mythos-5']?.name).toBe('Claude Mythos 5')
+    expect(result?.['claude-fable-5-1']?.name).toBe('Claude Fable 5.1')
+    expect(result?.['claude-fable-5-1']?.cost).toEqual({
+      input: 0,
+      output: 0,
+      cache: { read: 0, write: 0 },
+    })
+    expect(result?.['claude-mythos-5-1']?.name).toBe('Claude Mythos 5.1')
     expect(models['claude-opus-4-8'].cost).toEqual({
       input: 5,
       output: 25,
@@ -2703,7 +2710,7 @@ describe('provider.models', () => {
     })
   })
 
-  test('keeps Anthropic API-key model costs unchanged and prices Fable 5', async () => {
+  test('keeps Anthropic API-key model costs unchanged and prices Fable 5/5.1', async () => {
     const plugin = await getPlugin()
     const models = {
       'claude-opus-4-8': {
@@ -2737,6 +2744,11 @@ describe('provider.models', () => {
       input: 10,
       output: 50,
       cache: { read: 1, write: 12.5 },
+    })
+    expect(result?.['claude-fable-5-1']?.cost).toEqual({
+      input: 10,
+      output: 50,
+      cache: { read: 0.25, write: 12.5 },
     })
   })
 

--- a/packages/opencode/src/tests/index.test.ts
+++ b/packages/opencode/src/tests/index.test.ts
@@ -10552,7 +10552,7 @@ describe('auth.loader', () => {
     expect(responseText).toContain(SERVER_FALLBACK_SIGNATURE_PREFIX)
   })
 
-  test('uses Anthropic server-side fallback by default and reports fallback and restoration transitions', async () => {
+  test('uses Anthropic server-side fallback for Fable 5.1 and reports transitions', async () => {
     delete process.env.OPENCODE_ANTHROPIC_AUTH_FALLBACK_MODE
     await useTempAccountFile(
       createFallbackStorage({
@@ -10575,7 +10575,7 @@ describe('auth.loader', () => {
         index: 0,
         content_block: {
           type: 'fallback',
-          from: { model: 'claude-fable-5' },
+          from: { model: 'claude-fable-5-1' },
           to: { model: 'claude-opus-5' },
         },
       }),
@@ -10599,7 +10599,7 @@ describe('auth.loader', () => {
           iterations: [
             {
               type: 'message',
-              model: 'claude-fable-5',
+              model: 'claude-fable-5-1',
               input_tokens: 100,
               output_tokens: 0,
             },
@@ -10617,7 +10617,7 @@ describe('auth.loader', () => {
     const restoredSse = [
       frame('message_start', {
         type: 'message_start',
-        message: { id: 'msg_restored', model: 'claude-fable-5' },
+        message: { id: 'msg_restored', model: 'claude-fable-5-1' },
       }),
       frame('content_block_start', {
         type: 'content_block_start',
@@ -10638,7 +10638,7 @@ describe('auth.loader', () => {
           iterations: [
             {
               type: 'message',
-              model: 'claude-fable-5',
+              model: 'claude-fable-5-1',
               input_tokens: 100,
               output_tokens: 2,
             },
@@ -10676,7 +10676,7 @@ describe('auth.loader', () => {
           agent: 'Alfonso - CTO',
           model: {
             providerID: 'anthropic',
-            modelID: 'claude-fable-5',
+            modelID: 'claude-fable-5-1',
             variant: 'xhigh',
           },
         },
@@ -10687,7 +10687,7 @@ describe('auth.loader', () => {
           role: 'assistant',
           agent: 'Alfonso - CTO',
           providerID: 'anthropic',
-          modelID: 'claude-fable-5',
+          modelID: 'claude-fable-5-1',
           variant: 'xhigh',
         },
       },
@@ -10707,7 +10707,7 @@ describe('auth.loader', () => {
       method: 'POST',
       headers: { 'x-session-affinity': 'ses_server_fallback' },
       body: JSON.stringify({
-        model: 'claude-fable-5',
+        model: 'claude-fable-5-1',
         stream: true,
         messages: [{ role: 'user', content: 'hello' }],
       }),
@@ -10731,7 +10731,7 @@ describe('auth.loader', () => {
       ),
     )
     expect(switched.fableRecoveries?.[0]).toMatchObject({
-      requestedModelId: 'claude-fable-5',
+      requestedModelId: 'claude-fable-5-1',
       targetModelId: 'claude-opus-5',
       remaining: 0,
     })
@@ -10827,7 +10827,7 @@ describe('auth.loader', () => {
       ),
     )
     expect(restored.fableRecoveries?.[0]?.requestedModelId).toBe(
-      'claude-fable-5',
+      'claude-fable-5-1',
     )
     await plugin.event?.({
       event: {
@@ -10847,7 +10847,7 @@ describe('auth.loader', () => {
         body: expect.objectContaining({
           parts: [
             expect.objectContaining({
-              text: expect.stringContaining('Returning to Fable 5'),
+              text: expect.stringContaining('Returning to Fable 5.1'),
             }),
           ],
         }),

--- a/packages/opencode/src/tests/server-fallback.test.ts
+++ b/packages/opencode/src/tests/server-fallback.test.ts
@@ -100,11 +100,10 @@ describe('resolveContentFilterFallbackMode', () => {
 })
 
 describe('applyServerSideFallbackToBody', () => {
-  test('opts Fable 5 and Opus 5 requests into the default server policy', () => {
+  test('opts only recoverable Fable/Opus models into the default server policy', () => {
     for (const model of [
       'claude-fable-5',
       'claude-fable-5-1',
-      'claude-mythos-5-1',
       'claude-opus-5-20260701',
     ]) {
       const body = { model, messages: [{ role: 'user', content: 'hello' }] }
@@ -116,6 +115,15 @@ describe('applyServerSideFallbackToBody', () => {
       expect((body as { fallbacks?: unknown }).fallbacks).toBe('default')
     }
     expect(SERVER_SIDE_FALLBACK_BETA).toBe('server-side-fallback-2026-07-01')
+  })
+
+  test('does not opt Mythos 5.1 into server-side fallback', () => {
+    const body = {
+      model: 'claude-mythos-5-1',
+      messages: [{ role: 'user', content: 'hello' }],
+    }
+    expect(applyServerSideFallbackToBody(body, true).enabled).toBe(false)
+    expect(body).not.toHaveProperty('fallbacks')
   })
 
   test('does not opt unrelated models into server-side fallback', () => {

--- a/packages/opencode/src/tests/server-fallback.test.ts
+++ b/packages/opencode/src/tests/server-fallback.test.ts
@@ -101,7 +101,12 @@ describe('resolveContentFilterFallbackMode', () => {
 
 describe('applyServerSideFallbackToBody', () => {
   test('opts Fable 5 and Opus 5 requests into the default server policy', () => {
-    for (const model of ['claude-fable-5', 'claude-opus-5-20260701']) {
+    for (const model of [
+      'claude-fable-5',
+      'claude-fable-5-1',
+      'claude-mythos-5-1',
+      'claude-opus-5-20260701',
+    ]) {
       const body = { model, messages: [{ role: 'user', content: 'hello' }] }
       expect(applyServerSideFallbackToBody(body, true)).toEqual({
         enabled: true,
@@ -116,6 +121,15 @@ describe('applyServerSideFallbackToBody', () => {
   test('does not opt unrelated models into server-side fallback', () => {
     const body = {
       model: 'claude-sonnet-5',
+      messages: [{ role: 'user', content: 'hello' }],
+    }
+    expect(applyServerSideFallbackToBody(body, true).enabled).toBe(false)
+    expect(body).not.toHaveProperty('fallbacks')
+  })
+
+  test('does not opt legacy Mythos 5 into the new 5.1 fallback policy', () => {
+    const body = {
+      model: 'claude-mythos-5',
       messages: [{ role: 'user', content: 'hello' }],
     }
     expect(applyServerSideFallbackToBody(body, true).enabled).toBe(false)

--- a/packages/opencode/src/tests/sidebar-state.test.ts
+++ b/packages/opencode/src/tests/sidebar-state.test.ts
@@ -369,6 +369,14 @@ describe('formatFallbackModelLabel', () => {
   test('formats Fable 5 ids', () => {
     expect(formatFallbackModelLabel('claude-fable-5')).toBe('Fable 5')
     expect(formatFallbackModelLabel('claude-fable-5-20260608')).toBe('Fable 5')
+    expect(formatFallbackModelLabel('claude-fable-5-1')).toBe('Fable 5.1')
+    expect(formatFallbackModelLabel('claude-fable-5-1-20260701')).toBe(
+      'Fable 5.1',
+    )
+    expect(formatFallbackModelLabel('claude-mythos-5-1')).toBe('Mythos 5.1')
+    expect(formatFallbackModelLabel('claude-mythos-5-1-20260701')).toBe(
+      'Mythos 5.1',
+    )
   })
 
   test('formats Opus 5 ids', () => {

--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -251,6 +251,83 @@ describe('setOAuthHeaders', () => {
       SERVER_SIDE_FALLBACK_BETA,
     )
   })
+
+  test('adds the server-side fallback beta for OAuth Fable/Mythos 5.1 bodies', () => {
+    for (const model of ['claude-fable-5-1', 'claude-mythos-5-1']) {
+      const headers = new Headers()
+      setOAuthHeaders(headers, 'token', {
+        body: { model, fallbacks: 'default' },
+      })
+      expect(headers.get('anthropic-beta')?.split(',')).toContain(
+        SERVER_SIDE_FALLBACK_BETA,
+      )
+    }
+  })
+})
+
+describe('Fable/Mythos 5.1 request normalization', () => {
+  test.each([
+    ['claude-fable-5-1', { type: 'any' }],
+    ['claude-fable-5-1', { type: 'tool', name: 'lookup' }],
+    ['claude-mythos-5-1', { type: 'any' }],
+    ['claude-mythos-5-1', { type: 'tool', name: 'lookup' }],
+  ])(
+    '%s maps manual thinking to adaptive and strips forced tool choice',
+    async (model, toolChoice) => {
+      const result = JSON.parse(
+        await rewriteRequestBody(
+          JSON.stringify({
+            model,
+            max_tokens: 1024,
+            stream: true,
+            thinking: { type: 'enabled', budget_tokens: 4096 },
+            output_config: { effort: 'xhigh' },
+            tool_choice: toolChoice,
+            messages: [{ role: 'user', content: 'hello' }],
+          }),
+        ),
+      )
+
+      expect(result.thinking).toEqual({
+        type: 'adaptive',
+        display: 'summarized',
+      })
+      expect(result.output_config).toEqual({ effort: 'xhigh' })
+      expect(result.tool_choice).toBeUndefined()
+    },
+  )
+
+  test('passes every supported effort variant through unchanged', async () => {
+    for (const effort of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      const result = JSON.parse(
+        await rewriteRequestBody(
+          JSON.stringify({
+            model: 'claude-fable-5-1',
+            max_tokens: 1024,
+            stream: true,
+            output_config: { effort },
+            messages: [{ role: 'user', content: 'hello' }],
+          }),
+        ),
+      )
+      expect(result.output_config).toEqual({ effort })
+    }
+  })
+
+  test('does not strip forced tool choice from legacy Fable 5', async () => {
+    const result = JSON.parse(
+      await rewriteRequestBody(
+        JSON.stringify({
+          model: 'claude-fable-5',
+          max_tokens: 1024,
+          stream: true,
+          tool_choice: { type: 'any' },
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+      ),
+    )
+    expect(result.tool_choice).toEqual({ type: 'any' })
+  })
 })
 
 describe('prefixToolNames', () => {
@@ -1616,6 +1693,20 @@ describe('prepareFableCacheWarmSource', () => {
     expect(selectClaudeCodeBetas(body).split(',')).not.toContain(
       'server-side-fallback-2026-07-01',
     )
+  })
+
+  test('preserves the requested Fable 5.1 model when warming its source cache', () => {
+    const source = prepareFableCacheWarmSource(
+      JSON.stringify({
+        model: 'claude-opus-4-8',
+        messages: [{ role: 'user', content: 'same input' }],
+      }),
+      'claude-fable-5-1',
+    )
+
+    expect(source.ok).toBe(true)
+    if (!source.ok) throw new Error(source.reason)
+    expect(JSON.parse(source.bodyText).model).toBe('claude-fable-5-1')
   })
 })
 

--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -251,18 +251,6 @@ describe('setOAuthHeaders', () => {
       SERVER_SIDE_FALLBACK_BETA,
     )
   })
-
-  test('adds the server-side fallback beta for OAuth Fable/Mythos 5.1 bodies', () => {
-    for (const model of ['claude-fable-5-1', 'claude-mythos-5-1']) {
-      const headers = new Headers()
-      setOAuthHeaders(headers, 'token', {
-        body: { model, fallbacks: 'default' },
-      })
-      expect(headers.get('anthropic-beta')?.split(',')).toContain(
-        SERVER_SIDE_FALLBACK_BETA,
-      )
-    }
-  })
 })
 
 describe('Fable/Mythos 5.1 request normalization', () => {

--- a/packages/opencode/src/transform.ts
+++ b/packages/opencode/src/transform.ts
@@ -13,6 +13,7 @@ import {
   type ClaudeCodeIdentity,
   FAST_MODE_BETA,
   isClaudeFableOrMythos5Model,
+  isClaudeFableOrMythos51Model,
   isClaudeOpus5Model,
   isClaudeSonnet5Model,
   isFastModeSupportedModel,
@@ -962,6 +963,15 @@ function normalizeFableMythosRequest(
   if (!isClaudeFableOrMythos5Model(parsed.model)) return null
   const hadThinking = Object.hasOwn(parsed, 'thinking')
   parsed.thinking = { ...CLAUDE_FABLE_MYTHOS_5_SUMMARIZED_THINKING }
+  if (isClaudeFableOrMythos51Model(parsed.model)) {
+    const toolChoice = parsed.tool_choice
+    if (
+      isRecord(toolChoice) &&
+      (toolChoice.type === 'any' || toolChoice.type === 'tool')
+    ) {
+      delete parsed.tool_choice
+    }
+  }
   return { replacedExisting: hadThinking }
 }
 

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -1,10 +1,12 @@
 import {
   authorize,
+  CLAUDE_FABLE_MYTHOS_5_1_PRICING,
   CLAUDE_FABLE_MYTHOS_5_CONTEXT_WINDOW,
   CLAUDE_FABLE_MYTHOS_5_MAX_OUTPUT_TOKENS,
   CLAUDE_FABLE_MYTHOS_5_MODEL_SPECS,
   CLAUDE_FABLE_MYTHOS_5_PRICING,
   exchange,
+  isClaudeFableOrMythos51Model,
   refreshClaudeOAuthToken,
 } from '@cortexkit/anthropic-auth-core'
 import type {
@@ -66,20 +68,25 @@ export default function cortexKitPiAnthropicAuth(pi: ExtensionAPI) {
     baseUrl: 'https://api.anthropic.com',
     api: 'cortexkit-anthropic-messages',
     models: [
-      ...Object.values(CLAUDE_FABLE_MYTHOS_5_MODEL_SPECS).map((model) => ({
-        id: model.id,
-        name: model.name,
-        reasoning: true,
-        input: textImageInput(),
-        cost: {
-          input: CLAUDE_FABLE_MYTHOS_5_PRICING.input,
-          output: CLAUDE_FABLE_MYTHOS_5_PRICING.output,
-          cacheRead: CLAUDE_FABLE_MYTHOS_5_PRICING.cacheRead,
-          cacheWrite: CLAUDE_FABLE_MYTHOS_5_PRICING.cacheWrite5m,
-        },
-        contextWindow: CLAUDE_FABLE_MYTHOS_5_CONTEXT_WINDOW,
-        maxTokens: CLAUDE_FABLE_MYTHOS_5_MAX_OUTPUT_TOKENS,
-      })),
+      ...Object.values(CLAUDE_FABLE_MYTHOS_5_MODEL_SPECS).map((model) => {
+        const pricing = isClaudeFableOrMythos51Model(model.id)
+          ? CLAUDE_FABLE_MYTHOS_5_1_PRICING
+          : CLAUDE_FABLE_MYTHOS_5_PRICING
+        return {
+          id: model.id,
+          name: model.name,
+          reasoning: true,
+          input: textImageInput(),
+          cost: {
+            input: pricing.input,
+            output: pricing.output,
+            cacheRead: pricing.cacheRead,
+            cacheWrite: pricing.cacheWrite5m,
+          },
+          contextWindow: CLAUDE_FABLE_MYTHOS_5_CONTEXT_WINDOW,
+          maxTokens: CLAUDE_FABLE_MYTHOS_5_MAX_OUTPUT_TOKENS,
+        }
+      }),
       {
         id: 'claude-opus-5',
         name: 'Claude Opus 5',

--- a/packages/pi/src/tests/index.test.ts
+++ b/packages/pi/src/tests/index.test.ts
@@ -45,6 +45,34 @@ describe('cortexKitPiAnthropicAuth provider registration', () => {
     })
   })
 
+  test('exposes Claude Fable and Mythos 5.1 in the Pi Anthropic catalog', () => {
+    const { pi, providers } = mockPi()
+
+    cortexKitPiAnthropicAuth(pi)
+
+    const models = providers.get('anthropic')?.models ?? []
+    expect(models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'claude-fable-5-1',
+          name: 'Claude Fable 5.1',
+          reasoning: true,
+          cost: { input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 },
+          contextWindow: 1_000_000,
+          maxTokens: 128_000,
+        }),
+        expect.objectContaining({
+          id: 'claude-mythos-5-1',
+          name: 'Claude Mythos 5.1',
+          reasoning: true,
+          cost: { input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 },
+          contextWindow: 1_000_000,
+          maxTokens: 128_000,
+        }),
+      ]),
+    )
+  })
+
   test('exposes Claude Opus 5 in the Pi Anthropic catalog', () => {
     const { pi, providers } = mockPi()
 


### PR DESCRIPTION
Adds model support for Fable 5.1 and Mythos 5.1, released this week. Claude Code 2.1.257 already defaults to `claude-fable-5-1` (confirmed on the wire), so a plugin session that selects it currently falls through to default handling.

## What's here

- **Model specs** (`models.ts`) for `claude-fable-5-1` and `claude-mythos-5-1`: 1M context, 128K max output, $10/$50 in/out per MTok. Cache read drops to **$0.25/MTok** (down from $1 on 5.0); 1h cache write stays $20.
- **Adaptive-thinking normalization** extended to the 5.1 ids — manual/disabled `thinking` is stripped to adaptive, same as Fable 5. Effort variants (`low`..`max`) pass through.
- **Forced `tool_choice` stripped for 5.1 only.** 5.1 rejects `tool_choice: any` / `{type:"tool"}` with a 400 (new vs 5.0). The normalizer deletes the field on every request path — main turns, lane-start, and cache prewarm. Fable 5 and Opus are untouched.
- **Server-side safety fallback**: OAuth 5.1 requests opt into the `server-side-fallback-2026-07-01` beta exactly like Fable 5 / Opus 5.
- **Distinct recovery family key** (`fable-5-1`), checked before the `fable-5` prefix so a 5→5.1 model switch can't cross-contaminate an in-flight recovery cycle.
- **Shared weekly Fable scope**: a `claude-fable-5-1` request counts against the same `claude-weekly-scoped-fable` window as Fable 5, matching how the plans meter both.
- Pi catalog entries for both ids.

## Verification

1322 tests pass (0 fail; the one flaky `relay-worker-miniflare` parallel timeout solo-greens). Typecheck, format, biome clean. Cross-family review (GLM) approved 0 must; the normalization, tool_choice strip, family key, and scoped-quota matcher each carry a mutation-proven test.

Mythos 5.1 is Glasswing-only, so its path is present but unexercised here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790883654&installation_model_id=22398&pr_number=179&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F179&signature=c4561130316ffd7670332b52172d2cff510b843a02f2d54f56587e7f98c80266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds model support for the newly released Fable 5.1 and Mythos 5.1. Without it, sessions using these models fall through to default handling.

**New Features**

- Registers `claude-fable-5-1` and `claude-mythos-5-1` with 1M context, 128K max output, and $10/$50 per MTok pricing.
- Cache reads drop to $0.25/MTok (from $1 on 5.0); 1h cache writes stay $20.
- Adds both models to the Pi provider catalog.

**Behavior Changes**

- Strips forced `tool_choice` for 5.1 only; 5.1 rejects it with a 400 error.
- Normalizes manual/disabled thinking to adaptive for 5.1, matching Fable 5.
- Opts Fable 5.1 requests into the server-side fallback beta; Mythos 5.1 is excluded.
- Uses a distinct recovery family key (`fable-5-1`) so a 5→5.1 switch stays isolated.
- Shares the weekly Fable quota scope with Fable 5.

<sup>Written for commit aa699961fc359fb886f8df634b6cd7670638a446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

