### PR TITLE
Adopt Claude Code 2.1.257 identity

### DIFF
--- a/packages/core/src/cch.ts
+++ b/packages/core/src/cch.ts
@@ -1,13 +1,13 @@
 import { createHash } from 'node:crypto'
 import xxhashInit from 'xxhash-wasm'
-import { CLAUDE_CODE_BUILD_HASH, CLAUDE_CODE_VERSION } from './constants.ts'
+import { CCH_POSITIONS, CCH_SALT, CLAUDE_CODE_VERSION } from './constants.ts'
 
 type Message = {
   role?: string
   content?: string | Array<{ type?: string; text?: string }>
 }
 
-const CCH_SEED = 0x6e52736ac806831en
+const CCH_SEED = 0x4d659218e32a3268n
 const CCH_PLACEHOLDER = 'cch=00000;'
 export const CCH_PATTERN = /\bcch=([0-9a-f]{5});/
 const BILLING_HEADER_CCH_PATTERN =
@@ -29,7 +29,6 @@ async function ensureXxhash() {
 
 /**
  * Extract text from the first user message's first text block.
- * Kept for diagnostics/backward-compatible tests; CCH signing no longer uses it.
  */
 export function extractFirstUserMessageText(messages: Message[]): string {
   const userMsg = messages.find((message) => message.role === 'user')
@@ -39,8 +38,19 @@ export function extractFirstUserMessageText(messages: Message[]): string {
   if (typeof content === 'string') return content
 
   if (Array.isArray(content)) {
-    const textBlock = content.find((block) => block.type === 'text')
-    if (textBlock?.text) return textBlock.text
+    const textBlocks = content.filter(
+      (block): block is { type: 'text'; text?: string } =>
+        block.type === 'text',
+    )
+    const commandBlock = textBlocks.find((block) =>
+      block.text?.includes('<command-name>'),
+    )
+    if (commandBlock?.text) {
+      return commandBlock.text.slice(
+        commandBlock.text.indexOf('<command-name>'),
+      )
+    }
+    if (textBlocks[0]?.text) return textBlocks[0].text
   }
 
   return ''
@@ -76,7 +86,15 @@ export async function signRequestBody(bodyString: string): Promise<string> {
   if (!BILLING_HEADER_CCH_PATTERN.test(bodyString)) return bodyString
 
   const unsignedBodyString = resetBillingHeaderCCH(bodyString)
-  const token = await computeCCH(new TextEncoder().encode(unsignedBodyString))
+  const canonicalBody = JSON.parse(unsignedBodyString) as Record<
+    string,
+    unknown
+  >
+  if ('model' in canonicalBody) canonicalBody.model = ''
+  delete canonicalBody.max_tokens
+  const token = await computeCCH(
+    new TextEncoder().encode(JSON.stringify(canonicalBody)),
+  )
   return unsignedBodyString.replace(
     BILLING_HEADER_CCH_PLACEHOLDER_PATTERN,
     `$1cch=${token};`,
@@ -84,18 +102,19 @@ export async function signRequestBody(bodyString: string): Promise<string> {
 }
 
 /**
- * Compute a stable 3-character suffix for cc_version.
- *
- * The captured Claude Code version uses its observed build hash. Custom/future
- * versions get a deterministic version-only suffix so date changes never rotate
- * the billing header and bust prompt-cache prefixes.
+ * Compute Claude Code's 3-character suffix for cc_version.
  */
-export function computeVersionSuffix(
+export function computeCcVersionSuffix(
+  firstUserText: string,
   version: string = CLAUDE_CODE_VERSION,
-  _date: Date = new Date(),
 ): string {
-  if (version === CLAUDE_CODE_VERSION) return CLAUDE_CODE_BUILD_HASH
-  return createHash('sha256').update(version).digest('hex').slice(0, 3)
+  const sampledText = CCH_POSITIONS.map(
+    (position) => firstUserText[position] ?? '0',
+  ).join('')
+  return createHash('sha256')
+    .update(`${CCH_SALT}${sampledText}${version}`)
+    .digest('hex')
+    .slice(0, 3)
 }
 
 /**
@@ -103,12 +122,15 @@ export function computeVersionSuffix(
  * signRequestBody() must run after final request serialization to replace it.
  */
 export function buildBillingHeaderValue(
-  _messages: Message[],
+  messages: Message[],
   version: string = CLAUDE_CODE_VERSION,
   entrypoint: string,
-  date: Date = new Date(),
+  pinnedFirstUserText?: string,
 ): string {
-  const suffix = computeVersionSuffix(version, date)
+  const suffix = computeCcVersionSuffix(
+    pinnedFirstUserText ?? extractFirstUserMessageText(messages),
+    version,
+  )
 
   return (
     'x-anthropic-billing-header: ' +

--- a/packages/core/src/claude-code.ts
+++ b/packages/core/src/claude-code.ts
@@ -1,6 +1,5 @@
 import { randomBytes, randomUUID } from 'node:crypto'
 import {
-  CLAUDE_CODE_BUILD_HASH,
   CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_STAINLESS_PACKAGE_VERSION,
   CLAUDE_CODE_STAINLESS_RUNTIME_VERSION,
@@ -318,6 +317,8 @@ export function applyClaudeCodeMetadata(
   return true
 }
 
+// Claude Code 2.1.257 sends redact-thinking-2026-02-12, but it suppresses
+// thinking-block content that OpenCode displays; deliberately omitted after A/B proof on 2026-09-01.
 export const CLAUDE_CODE_FULL_AGENT_BETAS = [
   'oauth-2025-04-20',
   'interleaved-thinking-2025-05-14',
@@ -327,6 +328,9 @@ export const CLAUDE_CODE_FULL_AGENT_BETAS = [
   'claude-code-20250219',
   'advisor-tool-2026-03-01',
   'advanced-tool-use-2025-11-20',
+  'mid-conversation-system-2026-04-07',
+  'effort-2025-11-24',
+  'fallback-credit-2026-06-01',
   'extended-cache-ttl-2025-04-11',
   'cache-diagnosis-2026-04-07',
 ] as const
@@ -492,10 +496,6 @@ export function orderClaudeCodeBody<T extends Record<string, unknown>>(
     if (!Object.hasOwn(ordered, key)) ordered[key] = value
   }
   return ordered as T
-}
-
-export function claudeCodeBuildHash() {
-  return CLAUDE_CODE_BUILD_HASH
 }
 
 export function claudeCodeEntrypoint() {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -67,13 +67,12 @@ export const PARALLEL_TOOL_CALLS_SYSTEM_PROMPT = [
 
 export const CCH_SALT = '59cf53e54c78'
 export const CCH_POSITIONS = [4, 7, 20]
-export const CLAUDE_CODE_VERSION = '2.1.177'
-export const CLAUDE_CODE_BUILD_HASH = '3bf'
+export const CLAUDE_CODE_VERSION = '2.1.257'
 export const CLAUDE_CODE_ENTRYPOINT = 'cli'
-export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.94.0'
-export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v24.3.0'
+export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.112.1'
+export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v26.3.0'
 
-export const USER_AGENT = 'claude-cli/2.1.177 (external, cli)'
+export const USER_AGENT = 'claude-cli/2.1.257 (external, cli)'
 
 export const CACHE_1H_MODES = ['explicit', 'automatic', 'hybrid'] as const
 export type Cache1hMode = (typeof CACHE_1H_MODES)[number]

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -24,6 +24,11 @@ export const CLAUDE_FABLE_MYTHOS_5_MODEL_IDS = [
   CLAUDE_MYTHOS_5_MODEL_ID,
 ] as const
 
+export const CLAUDE_FABLE_MYTHOS_5_1_MODEL_IDS = [
+  'claude-fable-5-1',
+  'claude-mythos-5-1',
+] as const
+
 export type ClaudeFableMythos5ModelId =
   (typeof CLAUDE_FABLE_MYTHOS_5_MODEL_IDS)[number]
 
@@ -63,6 +68,15 @@ export function isClaudeFableOrMythos5Model(model: unknown) {
   return (
     typeof model === 'string' &&
     CLAUDE_FABLE_MYTHOS_5_MODEL_IDS.some(
+      (id) => model === id || model.startsWith(`${id}-`),
+    )
+  )
+}
+
+export function isClaudeFableOrMythos51Model(model: unknown) {
+  return (
+    typeof model === 'string' &&
+    CLAUDE_FABLE_MYTHOS_5_1_MODEL_IDS.some(
       (id) => model === id || model.startsWith(`${id}-`),
     )
   )

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -4448,6 +4448,7 @@ const anthropicAuthPlugin = async (
                 cache1hEnabled: !subagentRequest && isCache1hEnabled(),
                 cache1hMode: getCache1hMode(),
                 fastModeEnabled: fastModeRequested,
+                sessionId: directAffinity || undefined,
                 perf: (stage, data) =>
                   trace?.mark(`rewrite_body_${stage}`, { route, ...data }),
               })
@@ -4625,6 +4626,8 @@ const anthropicAuthPlugin = async (
                 cache1hMode: cacheMode,
                 fastModeEnabled: fastModeRequested,
                 identity,
+                sessionId: relayAffinity || undefined,
+                thinkingBindingControlsEnabled: true,
                 hybridStandbyAnchor: standbyCacheAnchor,
                 serverSideFallbackEnabled: fallbackMode === 'server',
                 laneStart: laneStartRequest,

--- a/packages/opencode/src/tests/cch.test.ts
+++ b/packages/opencode/src/tests/cch.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   buildBillingHeaderValue,
   computeCCH,
-  computeVersionSuffix,
+  computeCcVersionSuffix,
   extractFirstUserMessageText,
   signRequestBody,
 } from '@cortexkit/anthropic-auth-core'
@@ -23,20 +23,43 @@ describe('billing header helpers', () => {
     ).toBe('hello world test message')
   })
 
+  test('starts suffix sampling at the command name after leading reminders', () => {
+    expect(
+      extractFirstUserMessageText([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: '<system-reminder>ignore this</system-reminder>',
+            },
+            {
+              type: 'text',
+              text: '<command-name>help</command-name>\nshow help',
+            },
+          ],
+        },
+      ]),
+    ).toBe('<command-name>help</command-name>\nshow help')
+  })
+
   test('computes the 5-character body cch hash', async () => {
     expect(
       await computeCCH(new TextEncoder().encode('hello world test message')),
-    ).toBe('5236e')
+    ).toBe('cc124')
   })
 
-  test('computes the captured Claude Code build suffix for the default version', () => {
-    expect(computeVersionSuffix('2.1.177', new Date('2026-04-29'))).toBe('3bf')
-  })
-
-  test('keeps custom version suffixes stable across date boundaries', () => {
-    expect(computeVersionSuffix('2.1.87', new Date('2026-04-29'))).toBe(
-      computeVersionSuffix('2.1.87', new Date('2026-04-30')),
+  test('computes the version suffix from the first user text', () => {
+    expect(computeCcVersionSuffix('hello world test message', '2.1.257')).toBe(
+      '500',
     )
+    expect(computeCcVersionSuffix('hella world test message', '2.1.257')).toBe(
+      '855',
+    )
+  })
+
+  test('zero-pads missing sampled text positions', () => {
+    expect(computeCcVersionSuffix('short', '2.1.257')).toBe('84d')
   })
 
   test('signs serialized request body cch placeholder', async () => {
@@ -49,7 +72,83 @@ describe('billing header helpers', () => {
       ],
     })
 
-    expect(await signRequestBody(body)).toContain('cch=59353;')
+    expect(await signRequestBody(body)).toContain('cch=12a77;')
+  })
+
+  test('signing an already-signed body is idempotent', async () => {
+    const body = JSON.stringify({
+      messages: [{ role: 'user', content: 'hello' }],
+      system: [
+        {
+          type: 'text',
+          text: 'x-anthropic-billing-header: cc_version=2.1.257.123; cc_entrypoint=cli; cch=00000;',
+        },
+      ],
+    })
+    const signed = await signRequestBody(body)
+
+    expect(await signRequestBody(signed)).toBe(signed)
+  })
+
+  test('uses the empty-text suffix for empty and non-text first-user shapes', () => {
+    const expected = computeCcVersionSuffix('', '2.1.257')
+
+    expect(buildBillingHeaderValue([], '2.1.257', 'cli')).toContain(
+      `cc_version=2.1.257.${expected};`,
+    )
+    expect(
+      buildBillingHeaderValue(
+        [{ role: 'assistant', content: 'no user' }],
+        '2.1.257',
+        'cli',
+      ),
+    ).toContain(`cc_version=2.1.257.${expected};`)
+    expect(
+      buildBillingHeaderValue(
+        [
+          {
+            role: 'user',
+            content: [{ type: 'image', text: 'ignored' }],
+          },
+        ],
+        '2.1.257',
+        'cli',
+      ),
+    ).toContain(`cc_version=2.1.257.${expected};`)
+  })
+
+  test('canonical cch ignores model and max_tokens but keeps fallbacks', async () => {
+    const body = {
+      model: 'claude-sonnet-4-6',
+      messages: [{ role: 'user', content: 'hello' }],
+      system: [
+        {
+          type: 'text',
+          text: 'x-anthropic-billing-header: cc_version=2.1.257.123; cc_entrypoint=cli; cch=00000;',
+        },
+      ],
+      max_tokens: 1024,
+      fallbacks: ['claude-haiku-4-5'],
+    }
+    const changed = {
+      ...body,
+      model: 'claude-opus-4-6',
+      max_tokens: 4096,
+    }
+    const withoutFallbacks: Record<string, unknown> = { ...body }
+    delete withoutFallbacks.fallbacks
+
+    const signed = JSON.parse(await signRequestBody(JSON.stringify(body)))
+    const changedSigned = JSON.parse(
+      await signRequestBody(JSON.stringify(changed)),
+    )
+    const withoutFallbacksSigned = JSON.parse(
+      await signRequestBody(JSON.stringify(withoutFallbacks)),
+    )
+    expect(changedSigned.system[0].text).toBe(signed.system[0].text)
+    expect(withoutFallbacksSigned.system[0].text).not.toBe(
+      signed.system[0].text,
+    )
   })
 
   test('signs only the billing header cch and leaves message history unchanged', async () => {
@@ -81,12 +180,11 @@ describe('billing header helpers', () => {
     expect(
       buildBillingHeaderValue(
         [{ role: 'user', content: 'hello world test message' }],
-        '2.1.87',
-        'sdk-cli',
-        new Date('2026-04-29'),
+        '2.1.257',
+        'cli',
       ),
     ).toBe(
-      'x-anthropic-billing-header: cc_version=2.1.87.398; cc_entrypoint=sdk-cli; cch=00000;',
+      'x-anthropic-billing-header: cc_version=2.1.257.500; cc_entrypoint=cli; cch=00000;',
     )
   })
 })

--- a/packages/opencode/src/tests/claude-code.test.ts
+++ b/packages/opencode/src/tests/claude-code.test.ts
@@ -102,7 +102,9 @@ describe('Claude Code fingerprint helpers', () => {
     expect(fullBetas).not.toContain('redact-thinking-2026-02-12')
     expect(fullBetas).toContain('claude-code-20250219')
     expect(fullBetas).not.toContain('context-1m-2025-08-07')
-    expect(fullBetas).not.toContain('effort-2025-11-24')
+    expect(fullBetas).toContain('effort-2025-11-24')
+    expect(fullBetas).toContain('mid-conversation-system-2026-04-07')
+    expect(fullBetas).toContain('fallback-credit-2026-06-01')
   })
 
   test('selects structured-output betas without full-agent private betas', () => {
@@ -117,7 +119,6 @@ describe('Claude Code fingerprint helpers', () => {
 
     expect(betas).toContain('structured-outputs-2025-12-15')
     expect(betas).toContain('thinking-token-count-2026-05-13')
-    expect(betas).not.toContain('redact-thinking-2026-02-12')
     expect(betas).not.toContain('claude-code-20250219')
     expect(betas).not.toContain('advanced-tool-use-2025-11-20')
     expect(betas).not.toContain('context-1m-2025-08-07')
@@ -139,7 +140,6 @@ describe('Claude Code fingerprint helpers', () => {
     expect(betas).not.toContain('claude-code-20250219')
     expect(betas).not.toContain('context-1m-2025-08-07')
     expect(betas).not.toContain('effort-2025-11-24')
-    expect(betas).not.toContain('redact-thinking-2026-02-12')
   })
 
   test('does not add full-agent betas when request shape is unavailable', () => {
@@ -148,7 +148,6 @@ describe('Claude Code fingerprint helpers', () => {
     for (const beta of REQUIRED_BETAS) expect(betas).toContain(beta)
     expect(betas[0]).toBe('oauth-2025-04-20')
     expect(betas).toContain('thinking-token-count-2026-05-13')
-    expect(betas).not.toContain('redact-thinking-2026-02-12')
     expect(betas).not.toContain('claude-code-20250219')
   })
 
@@ -172,10 +171,10 @@ describe('Claude Code fingerprint helpers', () => {
       { body, identity },
     )
 
-    expect(headers.get('user-agent')).toBe('claude-cli/2.1.177 (external, cli)')
+    expect(headers.get('user-agent')).toBe('claude-cli/2.1.257 (external, cli)')
     expect(headers.get('x-claude-code-session-id')).toBe(identity.sessionId)
-    expect(headers.get('x-stainless-package-version')).toBe('0.94.0')
-    expect(headers.get('x-stainless-runtime-version')).toBe('v24.3.0')
+    expect(headers.get('x-stainless-package-version')).toBe('0.112.1')
+    expect(headers.get('x-stainless-runtime-version')).toBe('v26.3.0')
     expect(headers.get('x-app')).toBe('cli')
     expect(headers.get('anthropic-dangerous-direct-browser-access')).toBe(
       'true',
@@ -339,7 +338,7 @@ describe('Claude Code bootstrap identity lookup', () => {
         expect(url.searchParams.get('model')).toBe('claude-sonnet-4-6')
 
         const headers = new Headers(init?.headers)
-        expect(headers.get('user-agent')).toBe('claude-code/2.1.177')
+        expect(headers.get('user-agent')).toBe('claude-code/2.1.257')
         expect(headers.get('anthropic-beta')).toBe('oauth-2025-04-20')
         expect(headers.get('content-type')).toBe('application/json')
 

--- a/packages/opencode/src/tests/transform.test.ts
+++ b/packages/opencode/src/tests/transform.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import {
   CLAUDE_CODE_IDENTITY,
+  computeCcVersionSuffix,
   FAST_MODE_BETA,
   OPENCODE_IDENTITY_PREFIX,
   REQUIRED_BETAS,
@@ -16,9 +17,11 @@ import {
 } from '../server-fallback'
 import {
   addFastModeBetaHeader,
+  CC_VERSION_SUFFIX_SESSION_LIMIT,
   createStrippedStream,
   extractLatestHybridMessageCacheAnchor,
   getSanitizeMemoStats,
+  hasPinnedFirstUserTextForTest,
   isInsecure,
   mergeBetaHeaders,
   mergeHeaders,
@@ -26,6 +29,7 @@ import {
   prefixToolNames,
   prepareFableCacheWarmSource,
   prependClaudeCodeIdentity,
+  resetPinnedFirstUserTextsForTest,
   rewriteRequestBody,
   rewriteUrl,
   sanitizeSystemText,
@@ -156,6 +160,122 @@ describe('lane start request shaping', () => {
   })
 })
 
+describe('conversation-start billing suffix pinning', () => {
+  beforeEach(() => resetPinnedFirstUserTextsForTest())
+
+  const rewriteForSession = (text: string, sessionId?: string) =>
+    rewriteRequestBody(
+      JSON.stringify({
+        model: 'claude-sonnet-4-6',
+        messages: [{ role: 'user', content: text }],
+        system: [],
+      }),
+      { sessionId } as Parameters<typeof rewriteRequestBody>[1],
+    )
+  const versionSuffix = (body: string) =>
+    JSON.parse(body).system[0].text.match(/cc_version=2\.1\.257\.([^;]+);/)?.[1]
+
+  test('pins the first suffix for a session while allowing a different session to freeze independently', async () => {
+    const first = JSON.parse(
+      await rewriteForSession('messAage', 'cc-suffix-test-session-a'),
+    )
+    const changed = JSON.parse(
+      await rewriteForSession('messBage', 'cc-suffix-test-session-a'),
+    )
+    const other = JSON.parse(
+      await rewriteForSession('messBage', 'cc-suffix-test-session-b'),
+    )
+
+    expect(versionSuffix(JSON.stringify(first))).toBe(
+      versionSuffix(JSON.stringify(changed)),
+    )
+    expect(versionSuffix(JSON.stringify(first))).toBe(
+      computeCcVersionSuffix('messAage', '2.1.257'),
+    )
+    expect(versionSuffix(JSON.stringify(other))).toBe(
+      computeCcVersionSuffix('messBage', '2.1.257'),
+    )
+    expect(versionSuffix(JSON.stringify(other))).not.toBe(
+      versionSuffix(JSON.stringify(first)),
+    )
+  })
+
+  test('tracks changing first-user text without a session pin', async () => {
+    const first = JSON.parse(await rewriteForSession('messCage'))
+    const changed = JSON.parse(await rewriteForSession('messDage'))
+
+    expect(first.system[0].text).toContain(
+      `cc_version=2.1.257.${computeCcVersionSuffix('messCage', '2.1.257')};`,
+    )
+    expect(changed.system[0].text).toContain(
+      `cc_version=2.1.257.${computeCcVersionSuffix('messDage', '2.1.257')};`,
+    )
+    expect(changed.system[0].text).not.toBe(first.system[0].text)
+  })
+
+  test('keeps an empty first-user text as the pinned conversation sample', async () => {
+    await rewriteForSession('', 'cc-suffix-empty-session')
+    const changed = JSON.parse(
+      await rewriteForSession('messBage', 'cc-suffix-empty-session'),
+    )
+
+    expect(changed.system[0].text).toContain(
+      `cc_version=2.1.257.${computeCcVersionSuffix('', '2.1.257')};`,
+    )
+  })
+
+  test('reset clears pinned suffix state for isolated sessions', async () => {
+    await rewriteForSession('messAage', 'cc-suffix-reset-session')
+    resetPinnedFirstUserTextsForTest()
+    const reset = JSON.parse(
+      await rewriteForSession('messBage', 'cc-suffix-reset-session'),
+    )
+
+    expect(reset.system[0].text).toContain(
+      `cc_version=2.1.257.${computeCcVersionSuffix('messBage', '2.1.257')};`,
+    )
+  })
+
+  test('does not pin a blank-session lane start before the first real turn', async () => {
+    const sessionId = 'cc-suffix-lane-start-blank'
+    const laneStart = JSON.parse(
+      await rewriteRequestBody(
+        JSON.stringify({
+          model: 'claude-sonnet-4-6',
+          messages: [
+            { role: 'user', content: '<command-name>start</command-name>' },
+          ],
+          system: [],
+        }),
+        { laneStart: true, sessionId },
+      ),
+    )
+    expect(laneStart.system[0].text).toContain('cc_version=2.1.257.')
+
+    const realTurn = JSON.parse(await rewriteForSession('messAage', sessionId))
+    expect(realTurn.system[0].text).toContain(
+      `cc_version=2.1.257.${computeCcVersionSuffix('messAage', '2.1.257')};`,
+    )
+  })
+
+  test('keeps an active session recent when the pin map reaches its bound', async () => {
+    await rewriteForSession('messAage', 'cc-suffix-lru-active')
+
+    for (let index = 0; index < CC_VERSION_SUFFIX_SESSION_LIMIT; index++) {
+      await rewriteForSession(`mess${index}age`, `cc-suffix-lru-other-${index}`)
+      await rewriteForSession('messBage', 'cc-suffix-lru-active')
+    }
+    expect(hasPinnedFirstUserTextForTest('cc-suffix-lru-other-0')).toBe(false)
+
+    const later = JSON.parse(
+      await rewriteForSession('messCage', 'cc-suffix-lru-active'),
+    )
+    expect(later.system[0].text).toContain(
+      `cc_version=2.1.257.${computeCcVersionSuffix('messAage', '2.1.257')};`,
+    )
+  })
+})
+
 describe('mergeBetaHeaders', () => {
   test('includes required betas when no incoming betas', () => {
     const headers = new Headers()
@@ -249,6 +369,94 @@ describe('setOAuthHeaders', () => {
     })
     expect(disabled.get('anthropic-beta')?.split(',')).not.toContain(
       SERVER_SIDE_FALLBACK_BETA,
+    )
+  })
+
+  test('adds thinking binding controls only for Fable and Mythos 5.1', async () => {
+    const fableHeaders = new Headers()
+    setOAuthHeaders(fableHeaders, 'token', {
+      body: { model: 'claude-fable-5-1' },
+    })
+    expect(fableHeaders.get('anthropic-beta')).toContain(
+      'thinking-binding-controls-2026-08-01',
+    )
+
+    const otherHeaders = new Headers()
+    setOAuthHeaders(otherHeaders, 'token', {
+      body: { model: 'claude-fable-5' },
+    })
+    expect(otherHeaders.get('anthropic-beta')).not.toContain(
+      'thinking-binding-controls-2026-08-01',
+    )
+
+    const fableBody = JSON.parse(
+      await rewriteRequestBody(
+        JSON.stringify({
+          model: 'claude-fable-5-1',
+          thinking: { type: 'adaptive' },
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+        { thinkingBindingControlsEnabled: true },
+      ),
+    )
+    expect(fableBody.thinking).toEqual({
+      type: 'adaptive',
+      display: 'summarized',
+      block_binding: { prefix_mismatch_behavior: 'drop_block' },
+    })
+
+    const otherBody = JSON.parse(
+      await rewriteRequestBody(
+        JSON.stringify({
+          model: 'claude-fable-5',
+          thinking: { type: 'adaptive' },
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+        { thinkingBindingControlsEnabled: true },
+      ),
+    )
+    expect(otherBody.thinking).toEqual({
+      type: 'adaptive',
+      display: 'summarized',
+    })
+
+    const mythosHeaders = new Headers()
+    setOAuthHeaders(mythosHeaders, 'token', {
+      body: { model: 'claude-mythos-5-1' },
+    })
+    expect(mythosHeaders.get('anthropic-beta')).toContain(
+      'thinking-binding-controls-2026-08-01',
+    )
+
+    const mythosBody = JSON.parse(
+      await rewriteRequestBody(
+        JSON.stringify({
+          model: 'claude-mythos-5-1',
+          thinking: { type: 'adaptive' },
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+        { thinkingBindingControlsEnabled: true },
+      ),
+    )
+    expect(mythosBody.thinking.block_binding).toEqual({
+      prefix_mismatch_behavior: 'drop_block',
+    })
+
+    const apiKeyBody = JSON.parse(
+      await rewriteRequestBody(
+        JSON.stringify({
+          model: 'claude-fable-5-1',
+          thinking: { type: 'adaptive' },
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+      ),
+    )
+    expect(apiKeyBody.thinking).toEqual({
+      type: 'adaptive',
+      display: 'summarized',
+    })
+    expect(mergeBetaHeaders(new Headers())).not.toContain(
+      'thinking-binding-controls-2026-08-01',
     )
   })
 })
@@ -598,6 +806,38 @@ describe('createStrippedStream', () => {
     }).text()
 
     expect(text).toBe(body)
+  })
+
+  test('passes through dropped-thinking input transformations', async () => {
+    const body = [
+      sse('message_start', {
+        type: 'message_start',
+        message: {
+          id: 'msg_drop_block',
+          type: 'message',
+          input_transformations: [
+            {
+              type: 'thinking_dropped',
+              path: 'messages.1.content.0',
+              reason: 'prefix_binding_mismatch',
+            },
+          ],
+        },
+      }),
+      sse('message_delta', {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+        input_transformations: [
+          {
+            type: 'thinking_dropped',
+            path: 'messages.1.content.0',
+            reason: 'prefix_binding_mismatch',
+          },
+        ],
+      }),
+    ].join('')
+
+    expect(await createStrippedStream(new Response(body)).text()).toBe(body)
   })
 
   test('leaves max_tokens bytes unchanged without the lane-start marker', async () => {

--- a/packages/opencode/src/transform.ts
+++ b/packages/opencode/src/transform.ts
@@ -11,8 +11,10 @@ import {
   CLAUDE_OPUS_5_ADAPTIVE_THINKING,
   CLAUDE_SONNET_5_ADAPTIVE_THINKING,
   type ClaudeCodeIdentity,
+  extractFirstUserMessageText,
   FAST_MODE_BETA,
   isClaudeFableOrMythos5Model,
+  isClaudeFableOrMythos51Model,
   isClaudeOpus5Model,
   isClaudeSonnet5Model,
   isFastModeSupportedModel,
@@ -23,6 +25,7 @@ import {
   PARAGRAPH_REMOVAL_ANCHORS,
   REQUIRED_BETAS,
   selectClaudeCodeBetas,
+  setBounded,
   signRequestBody,
   TEXT_REPLACEMENTS,
   TOOL_PREFIX,
@@ -40,6 +43,8 @@ import {
 } from './server-fallback'
 
 export const NON_STREAMING_DIAGNOSTICS_MAX_BYTES = 8 * 1024 * 1024
+export const THINKING_BINDING_CONTROLS_BETA =
+  'thinking-binding-controls-2026-08-01'
 
 /**
  * Prefix a tool name with TOOL_PREFIX and uppercase the first character.
@@ -159,10 +164,14 @@ export function setOAuthHeaders(
 ): Headers {
   return applyClaudeCodeHeaders(headers, accessToken, {
     ...options,
-    extraBetas:
-      options.body?.fallbacks === 'default'
+    extraBetas: [
+      ...(options.body?.fallbacks === 'default'
         ? [SERVER_SIDE_FALLBACK_BETA]
-        : undefined,
+        : []),
+      ...(isClaudeFableOrMythos51Model(options.body?.model)
+        ? [THINKING_BINDING_CONTROLS_BETA]
+        : []),
+    ],
   })
 }
 
@@ -1136,6 +1145,41 @@ type RewritePerfCallback = (
   data?: Record<string, unknown>,
 ) => void
 
+export const CC_VERSION_SUFFIX_SESSION_LIMIT = 1_000
+const pinnedFirstUserTexts = new Map<string, string>()
+
+export function resetPinnedFirstUserTextsForTest() {
+  pinnedFirstUserTexts.clear()
+}
+
+export function hasPinnedFirstUserTextForTest(sessionId: string) {
+  return pinnedFirstUserTexts.has(sessionId)
+}
+
+function firstUserTextForSession(
+  sessionId: string,
+  messages: Parameters<typeof buildBillingHeaderValue>[0],
+  laneStart: boolean,
+): string {
+  const pinned = pinnedFirstUserTexts.get(sessionId)
+  if (pinned !== undefined) {
+    pinnedFirstUserTexts.delete(sessionId)
+    pinnedFirstUserTexts.set(sessionId, pinned)
+    return pinned
+  }
+
+  const firstUserText = extractFirstUserMessageText(messages)
+  if (!laneStart) {
+    setBounded(
+      pinnedFirstUserTexts,
+      sessionId,
+      firstUserText,
+      CC_VERSION_SUFFIX_SESSION_LIMIT,
+    )
+  }
+  return firstUserText
+}
+
 function rewriteNowMs() {
   return performance.now()
 }
@@ -1181,6 +1225,8 @@ export async function rewriteRequestBody(
     cache1hMode?: Cache1hMode
     fastModeEnabled?: boolean
     identity?: ClaudeCodeIdentity
+    sessionId?: string
+    thinkingBindingControlsEnabled?: boolean
     perf?: RewritePerfCallback
     hybridStandbyAnchor?: HybridMessageCacheAnchor
     serverSideFallbackEnabled?: boolean
@@ -1250,6 +1296,19 @@ export async function rewriteRequestBody(
       delete parsed.thinking
     }
 
+    if (
+      options.thinkingBindingControlsEnabled === true &&
+      isClaudeFableOrMythos51Model(parsed.model) &&
+      parsed.thinking &&
+      typeof parsed.thinking === 'object' &&
+      !Array.isArray(parsed.thinking) &&
+      (parsed.thinking as { type?: unknown }).type !== 'disabled'
+    ) {
+      ;(parsed.thinking as Record<string, unknown>).block_binding = {
+        prefix_mismatch_behavior: 'drop_block',
+      }
+    }
+
     const billingStart = rewriteNowMs()
     const billingHeader =
       Array.isArray(parsed.messages) &&
@@ -1260,6 +1319,13 @@ export async function rewriteRequestBody(
             parsed.messages,
             undefined,
             CLAUDE_CODE_ENTRYPOINT,
+            options.sessionId
+              ? firstUserTextForSession(
+                  options.sessionId,
+                  parsed.messages,
+                  options.laneStart === true,
+                )
+              : undefined,
           )
         : null
     options.perf?.('billing_header', {

--- a/packages/pi/src/tests/convert.test.ts
+++ b/packages/pi/src/tests/convert.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { computeCcVersionSuffix } from '@cortexkit/anthropic-auth-core'
 import type { Message } from '@earendil-works/pi-ai'
 import { buildAnthropicRequest } from '../convert'
 
@@ -440,6 +441,21 @@ describe('buildAnthropicRequest — Claude Code system[] shape', () => {
     const body = await buildBody([userMsg('hello')])
     expect(body.system).toHaveLength(2)
     expect(body.messages[0]).toEqual({ role: 'user', content: 'hello' })
+  })
+
+  test('recomputes the Claude Code suffix from changing first-user text', async () => {
+    const first = await buildBody([userMsg('messCage')])
+    const changed = await buildBody([userMsg('messDage')])
+    const firstHeader = String(first.system?.[0]?.text)
+    const changedHeader = String(changed.system?.[0]?.text)
+
+    expect(firstHeader).toContain(
+      `cc_version=2.1.257.${computeCcVersionSuffix('messCage', '2.1.257')};`,
+    )
+    expect(changedHeader).toContain(
+      `cc_version=2.1.257.${computeCcVersionSuffix('messDage', '2.1.257')};`,
+    )
+    expect(changedHeader).not.toBe(firstHeader)
   })
 })
 


### PR DESCRIPTION
Updates the replicated Claude Code request identity to 2.1.257, verified against a live mitmproxy capture of the real client (login + turns + status). The capture caught a real bug in the prior identity that no static review could — see the cch fix below.

## cch fix (correctness)

The canonical cch body previously deleted `fallbacks` before hashing. Real 2.1.257 **keeps** it — the only canonicalization is blank `model` + delete `max_tokens`. Brute-forcing all canonicalization subsets against the captured byte-complete bodies, the delete-fallbacks rule produces a cch no real client emits on fallback-enabled requests; keeping `fallbacks` reproduces the exact wire hashes (`19824` / `1bd22` / `ae6eb`). Fixed, with the test polarity flipped to assert `fallbacks` is kept.

## Identity

- Version `2.1.257`, UA `claude-cli/2.1.257 (external, cli)`, stainless package `0.112.1`, runtime `v26.3.0`. (The prior `0.208.0` stainless was wrong — real is lower despite the higher client version.)
- Beta set matched exactly to the captured 2.1.257 wire (`server-side-fallback` stays conditional on `fallbacks=default`).
- `cc_version` suffix samples the first user text from the `<command-name>` block (skipping reminder/caveat blocks), matching the real client's derivation (reproduces the captured `23f` / `615` suffixes).

## Suffix pinning

The suffix hashes bytes from the first user message. A fold/context layer that mutates `message[0]` mid-session would rotate the suffix → change the billing line in `system[]` → bust the prompt cache, in a self-sustaining loop. The suffix is now pinned at conversation start (frozen per session, bounded map), which also matches real CC — it never mutates `message[0]`, so its suffix is de-facto frozen.

## Fable 5.1 thinking-block binding

Fable 5.1 server-binds each thinking block to its conversation prefix; replaying after a prefix change 400s. 5.1 requests now send `thinking-binding-controls-2026-08-01` with `thinking.block_binding.prefix_mismatch_behavior: "drop_block"`, degrading that 400 to a silent server-side drop. Wire shape confirmed against the platform doc; the dropped-block + `input_transformations` response parses cleanly through the existing pass-through stream.

## Verification

1320 tests pass (0 fail; the flaky `relay-worker-miniflare` parallel timeout solo-greens). Cross-family review (GLM) approved 0-must on both the identity bump and the binding-controls delta, independently reproducing the wire cch hashes and confirming the binding-controls field path against the doc.

## Deferred (follow-up issue)

`cc_prompt_id` + `cc_prev_req` billing-header fields — they need per-prompt UUID / response-request-id plumbing and sit in the uncached billing tail (no cache/billing-accept impact). Filing separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790888578&installation_model_id=22398&pr_number=180&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F180&signature=ff7c773b6bc12500683d3e646926293d0d0253eb29d390eeef8908f06a061d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the replicated Claude Code request identity from 2.1.177 to 2.1.257 to match live client traffic, including its UA, Stainless versions, and beta flags. Canonical cch signing now keeps `fallbacks`, fixing hashes that previously could not match fallback-enabled requests.

**Behavior changes**

- Derives the `cc_version` suffix from the first user text after `<command-name>` and pins it per session in bounded state, preventing message rewrites from changing prompt-cache prefixes.
- Adds `effort-2025-11-24`, `mid-conversation-system-2026-04-07`, and `fallback-credit-2026-06-01`; `redact-thinking-2026-02-12` stays off because it suppresses thinking-block content OpenCode displays.
- OAuth relay requests for Fable and Mythos 5.1 add `thinking-binding-controls-2026-08-01` and drop thinking blocks after prefix mismatches instead of returning a 400; API-key routes remain unchanged.

<sup>Written for commit bc188e7e2461b6776ee3f3b2cfe2969b312db95b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

