### PR TITLE
fix(pi): accept an array systemPrompt and keep the documentation-paragraph relocation

### DIFF
--- a/packages/pi/src/convert.ts
+++ b/packages/pi/src/convert.ts
@@ -75,6 +75,14 @@ export type AnthropicRequestBody = {
 function sanitize(text: string): string {
   return text.replace(/[\uD800-\uDFFF]/gu, '\uFFFD')
 }
+function extractSystemPromptTexts(systemPrompt: unknown): string[] {
+  const values = Array.isArray(systemPrompt) ? systemPrompt : [systemPrompt]
+  return values.flatMap((value) => {
+    if (typeof value !== 'string') return []
+    const text = value.trim()
+    return text ? [text] : []
+  })
+}
 
 /**
  * Detect lone (unpaired) UTF-16 surrogates. With the `u` flag the character
@@ -494,7 +502,11 @@ export async function buildAnthropicRequest(
     },
     { type: 'text', text: CLAUDE_CODE_IDENTITY },
   ]
-  if (context.systemPrompt?.trim()) {
+  if (Array.isArray(context.systemPrompt)) {
+    for (const text of extractSystemPromptTexts(context.systemPrompt)) {
+      system.push({ type: 'text', text: sanitize(text) })
+    }
+  } else if (context.systemPrompt?.trim()) {
     // Pi's prompt cannot sit whole in the top-level system[] array: two lines of
     // its documentation paragraph (the docs/*.md enumeration and the "follow .md
     // cross-references" instruction) are each independently sufficient to make

--- a/packages/pi/src/convert.ts
+++ b/packages/pi/src/convert.ts
@@ -75,13 +75,8 @@ export type AnthropicRequestBody = {
 function sanitize(text: string): string {
   return text.replace(/[\uD800-\uDFFF]/gu, '\uFFFD')
 }
-function extractSystemPromptTexts(systemPrompt: unknown): string[] {
-  const values = Array.isArray(systemPrompt) ? systemPrompt : [systemPrompt]
-  return values.flatMap((value) => {
-    if (typeof value !== 'string') return []
-    const text = value.trim()
-    return text ? [text] : []
-  })
+function isNonEmptyText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
 }
 
 /**
@@ -502,11 +497,18 @@ export async function buildAnthropicRequest(
     },
     { type: 'text', text: CLAUDE_CODE_IDENTITY },
   ]
-  if (Array.isArray(context.systemPrompt)) {
-    for (const text of extractSystemPromptTexts(context.systemPrompt)) {
-      system.push({ type: 'text', text: sanitize(text) })
-    }
-  } else if (context.systemPrompt?.trim()) {
+  // Pi's host type permits prompt segments even though pi-ai declares a string.
+  const systemPrompt = context.systemPrompt as unknown as
+    | string
+    | readonly string[]
+    | undefined
+  const normalizedSystemPrompt = Array.isArray(systemPrompt)
+    ? systemPrompt
+        .filter(isNonEmptyText)
+        .map((text) => text.trim())
+        .join('\n\n')
+    : systemPrompt
+  if (isNonEmptyText(normalizedSystemPrompt)) {
     // Pi's prompt cannot sit whole in the top-level system[] array: two lines of
     // its documentation paragraph (the docs/*.md enumeration and the "follow .md
     // cross-references" instruction) are each independently sufficient to make
@@ -531,7 +533,7 @@ export async function buildAnthropicRequest(
     // cache_control is set explicitly because addEphemeralCacheControl's
     // message-level breakpoint only fires for array content on the *last* user
     // message, which is not this one after the first turn.
-    const prompt = splitPiSystemPrompt(context.systemPrompt)
+    const prompt = splitPiSystemPrompt(normalizedSystemPrompt)
     if (prompt.systemText) {
       system.push({ type: 'text', text: prompt.systemText })
     }

--- a/packages/pi/src/tests/convert.test.ts
+++ b/packages/pi/src/tests/convert.test.ts
@@ -344,7 +344,7 @@ describe('convertMessages — empty base64 image guard', () => {
   })
 })
 describe('buildAnthropicRequest — system prompt arrays', () => {
-  test('adds each non-empty prompt string as a separate text block', async () => {
+  test('normalizes non-empty prompt strings before relocation', async () => {
     const { body } = await buildAnthropicRequest(
       'claude-sonnet-4-20250514',
       {
@@ -356,16 +356,18 @@ describe('buildAnthropicRequest — system prompt arrays', () => {
       defaultCache,
     )
 
-    expect(body.system).toHaveLength(4)
-    expect(body.system?.map((block) => block.type)).toEqual([
-      'text',
-      'text',
-      'text',
-      'text',
-    ])
-    expect(body.system?.slice(2).map((block) => block.text)).toEqual([
-      'first prompt',
-      'second prompt',
+    expect(body.system).toHaveLength(2)
+    expect(body.messages[0]?.content).toEqual([
+      {
+        type: 'text',
+        text: 'first prompt\n\nsecond prompt',
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: 'hello',
+        cache_control: { type: 'ephemeral' },
+      },
     ])
   })
 
@@ -381,8 +383,19 @@ describe('buildAnthropicRequest — system prompt arrays', () => {
       defaultCache,
     )
 
-    expect(body.system).toHaveLength(3)
-    expect(body.system?.[2]?.text).toBe('valid')
+    expect(body.system).toHaveLength(2)
+    expect(body.messages[0]?.content).toEqual([
+      {
+        type: 'text',
+        text: 'valid',
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: 'hello',
+        cache_control: { type: 'ephemeral' },
+      },
+    ])
   })
 
   test('does not add prompt blocks for an empty prompt array', async () => {
@@ -398,6 +411,54 @@ describe('buildAnthropicRequest — system prompt arrays', () => {
     )
 
     expect(body.system).toHaveLength(2)
+  })
+
+  test('routes array prompts through documentation relocation', async () => {
+    const segments = [
+      'KEEP ONE: you are an assistant.',
+      'KEEP TWO: available tools.',
+      'Pi documentation (read only when the user asks about pi itself):\n- MOVE THIS',
+    ]
+    const stringBody = (
+      await buildAnthropicRequest(
+        'claude-sonnet-4-20250514',
+        {
+          messages: [userMsg('hello')],
+          systemPrompt: segments.join('\n\n'),
+          tools: [],
+        } as any,
+        undefined,
+        defaultCache,
+      )
+    ).body
+    const arrayBody = (
+      await buildAnthropicRequest(
+        'claude-sonnet-4-20250514',
+        {
+          messages: [userMsg('hello')],
+          systemPrompt: segments,
+          tools: [],
+        } as unknown as Parameters<typeof buildAnthropicRequest>[1],
+        undefined,
+        defaultCache,
+      )
+    ).body
+    const arraySystemText = JSON.stringify(arrayBody.system)
+    const firstUserContent = arrayBody.messages[0]?.content as Array<
+      Record<string, unknown>
+    >
+
+    expect(arraySystemText).not.toContain('MOVE THIS')
+    expect(firstUserContent[0]).toMatchObject({
+      type: 'text',
+      text: segments[2],
+      cache_control: { type: 'ephemeral' },
+    })
+    expect(arrayBody.system?.slice(2).map((block) => block.text)).toEqual([
+      'KEEP ONE: you are an assistant.\n\nKEEP TWO: available tools.',
+    ])
+    expect(arrayBody.system).toEqual(stringBody.system)
+    expect(arrayBody.messages).toEqual(stringBody.messages)
   })
 })
 

--- a/packages/pi/src/tests/convert.test.ts
+++ b/packages/pi/src/tests/convert.test.ts
@@ -343,6 +343,63 @@ describe('convertMessages — empty base64 image guard', () => {
     expect(content[1]?.type).toBe('image')
   })
 })
+describe('buildAnthropicRequest — system prompt arrays', () => {
+  test('adds each non-empty prompt string as a separate text block', async () => {
+    const { body } = await buildAnthropicRequest(
+      'claude-sonnet-4-20250514',
+      {
+        messages: [userMsg('hello')],
+        systemPrompt: [' first prompt ', 'second prompt'],
+        tools: [],
+      } as unknown as Parameters<typeof buildAnthropicRequest>[1],
+      undefined,
+      defaultCache,
+    )
+
+    expect(body.system).toHaveLength(4)
+    expect(body.system?.map((block) => block.type)).toEqual([
+      'text',
+      'text',
+      'text',
+      'text',
+    ])
+    expect(body.system?.slice(2).map((block) => block.text)).toEqual([
+      'first prompt',
+      'second prompt',
+    ])
+  })
+
+  test('skips empty and whitespace-only prompt strings', async () => {
+    const { body } = await buildAnthropicRequest(
+      'claude-sonnet-4-20250514',
+      {
+        messages: [userMsg('hello')],
+        systemPrompt: ['', '  ', 'valid'],
+        tools: [],
+      } as unknown as Parameters<typeof buildAnthropicRequest>[1],
+      undefined,
+      defaultCache,
+    )
+
+    expect(body.system).toHaveLength(3)
+    expect(body.system?.[2]?.text).toBe('valid')
+  })
+
+  test('does not add prompt blocks for an empty prompt array', async () => {
+    const { body } = await buildAnthropicRequest(
+      'claude-sonnet-4-20250514',
+      {
+        messages: [userMsg('hello')],
+        systemPrompt: [],
+        tools: [],
+      } as unknown as Parameters<typeof buildAnthropicRequest>[1],
+      undefined,
+      defaultCache,
+    )
+
+    expect(body.system).toHaveLength(2)
+  })
+})
 
 describe('buildAnthropicRequest — Claude Code system[] shape', () => {
   // Anthropic rejects Pi's documentation paragraph inside the top-level


### PR DESCRIPTION
## Summary

Pi-compatible hosts (oh-my-pi) pass `context.systemPrompt` as an array of segments; `buildAnthropicRequest` only handled a string, so the prompt was dropped. This accepts the array form.

The array is joined with `\n\n` and routed through the **same** path the string branch uses (`splitPiSystemPrompt` → `prependCachedPromptBlock`), so Pi's documentation paragraph still moves out of top-level `system[]` into the first user message's cached block. An earlier shape of this change pushed each segment straight into `system[]`, which would have reintroduced the OAuth billing rejection that relocation exists to avoid — the new test pins byte-equivalence between the array and string paths, and it fails if the array takes a separate branch.

Credit: original patch by **randomvariable** (CortexKit Discord, 2026-09-03), who could not open the PR themselves. Reviewed, reworked to share the relocation path, and re-authored here with `Co-authored-by`.

## Changes

- `packages/pi/src/convert.ts` — `context.systemPrompt: string | readonly string[]`; array segments are trimmed, empties dropped (`isNonEmptyText`, shared with the string branch), joined, and handed to the existing relocation path. The SDK type declares `string`; the array form is a host divergence, noted at the branch.
- `packages/pi/src/tests/convert.test.ts` — array happy paths, empty/whitespace segments, empty array, and the relocation contract: `arrayBody.system` and `arrayBody.messages` equal the string path's output; the docs paragraph is not in `system[]`.

## Verification

- `packages/pi`: 98 pass / 0 fail · root typecheck 0 · format/biome clean.
- Red-first: the relocation test failed on the per-segment shape (docs paragraph at `system[4]`); reverting to that shape reddens it again.

Base: `upstream/main` `360b68e` (v1.22.0).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791695930&installation_model_id=22398&pr_number=213&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F213&signature=574d1fc0e22455aabf782301c25c935b132bfa3ea8676647fcea0f3dd1849cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `buildAnthropicRequest` dropping Pi-compatible hosts' array `systemPrompt` values, which previously only handled strings. Array segments are now joined and routed through the same docs-paragraph relocation path as string prompts, keeping Pi's documentation paragraph out of top-level `system[]` to avoid OAuth billing rejection.

- Normalizes array segments by trimming and dropping empty/whitespace-only entries before joining with `\n\n`.
- Adds tests covering array happy paths, empty/whitespace segments, empty arrays, and byte-equivalence between array and string paths.

<sup>Written for commit 7da8919efad3de283eb1c8d1e6bc69ff6b115508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

