### PR TITLE
fix(pi): build the effort-history context without the SDK-only buildContextEntries

### DIFF
--- a/packages/pi/src/effort-history.ts
+++ b/packages/pi/src/effort-history.ts
@@ -88,3 +88,54 @@ export function collectPiEffortHistory(
 
   return transitions
 }
+
+type SessionEntryWithParent = SessionEntryLike & {
+  id: string
+  parentId?: string | null
+  firstKeptEntryId?: unknown
+}
+
+/**
+ * Compaction-aware active entry list, mirroring the host SDK's
+ * buildContextEntries: latest compaction plus kept entries replace the
+ * summarized prefix. Implemented locally because some Pi-compatible hosts
+ * (oh-my-pi) lack the SDK method while sharing the entry model.
+ */
+export function buildContextEntries(
+  entries: readonly SessionEntryWithParent[],
+  leafId?: string | null,
+): SessionEntryWithParent[] {
+  const byId = new Map(entries.map((entry) => [entry.id, entry]))
+  let leaf: SessionEntryWithParent | undefined
+  if (leafId !== null) {
+    if (leafId) leaf = byId.get(leafId)
+    leaf ??= entries.at(-1)
+  }
+  if (!leaf) return []
+  const path: SessionEntryWithParent[] = []
+  let current: SessionEntryWithParent | undefined = leaf
+  while (current) {
+    path.push(current)
+    current = current.parentId ? byId.get(current.parentId) : undefined
+  }
+  path.reverse()
+
+  let compaction: SessionEntryWithParent | undefined
+  for (const entry of path) {
+    if (entry.type === 'compaction') compaction = entry
+  }
+  if (!compaction) return path
+
+  const compactionIndex = path.findIndex((entry) => entry.id === compaction.id)
+  if (compactionIndex < 0) return path
+  const contextEntries: SessionEntryWithParent[] = [compaction]
+  let foundFirstKept = false
+  for (let index = 0; index < compactionIndex; index++) {
+    const entry = path[index]
+    if (!entry) continue
+    if (entry.id === compaction.firstKeptEntryId) foundFirstKept = true
+    if (foundFirstKept) contextEntries.push(entry)
+  }
+  contextEntries.push(...path.slice(compactionIndex + 1))
+  return contextEntries
+}

--- a/packages/pi/src/effort-history.ts
+++ b/packages/pi/src/effort-history.ts
@@ -95,11 +95,27 @@ type SessionEntryWithParent = SessionEntryLike & {
   firstKeptEntryId?: unknown
 }
 
+type SessionManagerLeaf = {
+  getLeafId?: () => string | null
+  [key: string]: unknown
+}
+
+export function resolveSessionLeafId(
+  sessionManager: SessionManagerLeaf,
+): string | null | undefined {
+  return sessionManager.getLeafId?.()
+}
+
 /**
  * Compaction-aware active entry list, mirroring the host SDK's
  * buildContextEntries: latest compaction plus kept entries replace the
  * summarized prefix. Implemented locally because some Pi-compatible hosts
  * (oh-my-pi) lack the SDK method while sharing the entry model.
+ *
+ * `undefined` means the leaf is unknown and selects the latest entry; `null`
+ * means an explicit no-leaf state and returns an empty list; a string selects
+ * that leaf. Callers must preserve the distinction and not coalesce an absent
+ * leaf method into `null`.
  */
 export function buildContextEntries(
   entries: readonly SessionEntryWithParent[],
@@ -107,10 +123,9 @@ export function buildContextEntries(
 ): SessionEntryWithParent[] {
   const byId = new Map(entries.map((entry) => [entry.id, entry]))
   let leaf: SessionEntryWithParent | undefined
-  if (leafId !== null) {
-    if (leafId) leaf = byId.get(leafId)
-    leaf ??= entries.at(-1)
-  }
+  if (leafId === null) return []
+  if (leafId) leaf = byId.get(leafId)
+  leaf ??= entries.at(-1)
   if (!leaf) return []
   const path: SessionEntryWithParent[] = []
   let current: SessionEntryWithParent | undefined = leaf

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -20,6 +20,7 @@ import { registerCommands } from './commands.ts'
 import {
   buildContextEntries,
   collectPiEffortHistory,
+  resolveSessionLeafId,
 } from './effort-history.ts'
 import { streamCortexKitAnthropic } from './stream.ts'
 
@@ -77,7 +78,7 @@ export default function cortexKitPiAnthropicAuth(pi: ExtensionAPI) {
     const transitions = collectPiEffortHistory(
       buildContextEntries(
         ctx.sessionManager.getEntries(),
-        ctx.sessionManager.getLeafId?.() ?? null,
+        resolveSessionLeafId(ctx.sessionManager),
       ),
       ctx.sessionManager.getBranch(),
     )

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -17,7 +17,10 @@ import type {
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
 import { registerCommands } from './commands.ts'
-import { collectPiEffortHistory } from './effort-history.ts'
+import {
+  buildContextEntries,
+  collectPiEffortHistory,
+} from './effort-history.ts'
 import { streamCortexKitAnthropic } from './stream.ts'
 
 async function loginAnthropic(
@@ -72,7 +75,10 @@ export default function cortexKitPiAnthropicAuth(pi: ExtensionAPI) {
     const sessionId = ctx.sessionManager.getSessionId()
     if (!sessionId) return
     const transitions = collectPiEffortHistory(
-      ctx.sessionManager.buildContextEntries(),
+      buildContextEntries(
+        ctx.sessionManager.getEntries(),
+        ctx.sessionManager.getLeafId?.() ?? null,
+      ),
       ctx.sessionManager.getBranch(),
     )
     effortHistoryBySession.delete(sessionId)

--- a/packages/pi/src/tests/effort-history.test.ts
+++ b/packages/pi/src/tests/effort-history.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { collectPiEffortHistory } from '../effort-history.ts'
+import {
+  buildContextEntries,
+  collectPiEffortHistory,
+  resolveSessionLeafId,
+} from '../effort-history.ts'
 
 const entry = (
   id: string,
@@ -50,5 +54,105 @@ describe('Pi Fable 5.1 effort history', () => {
       { afterAssistantMessages: 0, effort: 'high' },
       { afterAssistantMessages: 1, effort: 'xhigh' },
     ])
+  })
+})
+
+describe('buildContextEntries', () => {
+  const contextEntry = (
+    id: string,
+    parentId: string | null,
+    type = 'message',
+    extra: Record<string, unknown> = {},
+  ) => ({ id, parentId, type, ...extra })
+
+  test('uses the latest entry when the host has no leaf method', () => {
+    const entries = [contextEntry('a', null), contextEntry('b', 'a')]
+    expect(
+      buildContextEntries(entries, undefined).map((entry) => entry.id),
+    ).toEqual(['a', 'b'])
+  })
+
+  test('preserves an absent host leaf method as undefined', () => {
+    const host = { getEntries: () => [] }
+    expect(resolveSessionLeafId(host)).toBeUndefined()
+    expect(
+      buildContextEntries(
+        [contextEntry('a', null), contextEntry('b', 'a')],
+        resolveSessionLeafId(host),
+      ).map((entry) => entry.id),
+    ).toEqual(['a', 'b'])
+  })
+
+  test('preserves an explicit null host leaf', () => {
+    const host = { getLeafId: () => null }
+    expect(resolveSessionLeafId(host)).toBeNull()
+  })
+
+  test('returns no entries for an explicit null leaf', () => {
+    const entries = [contextEntry('a', null)]
+    expect(buildContextEntries(entries, null)).toEqual([])
+  })
+
+  test('follows a leaf path from the root', () => {
+    const entries = [
+      contextEntry('a', null),
+      contextEntry('b', 'a'),
+      contextEntry('c', 'b'),
+      contextEntry('other', 'a'),
+    ]
+    expect(buildContextEntries(entries, 'c').map((entry) => entry.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+  })
+
+  test('keeps a compaction and entries starting at firstKeptEntryId', () => {
+    const entries = [
+      contextEntry('a', null),
+      contextEntry('kept', 'a'),
+      contextEntry('drop', 'kept'),
+      contextEntry('compact', 'drop', 'compaction', {
+        firstKeptEntryId: 'kept',
+      }),
+      contextEntry('after', 'compact'),
+    ]
+    expect(
+      buildContextEntries(entries, 'after').map((entry) => entry.id),
+    ).toEqual(['compact', 'kept', 'drop', 'after'])
+  })
+
+  test('returns the full path when there is no compaction', () => {
+    const entries = [contextEntry('a', null), contextEntry('b', 'a')]
+    expect(buildContextEntries(entries, 'b').map((entry) => entry.id)).toEqual([
+      'a',
+      'b',
+    ])
+  })
+
+  test('uses only the latest compaction on the path', () => {
+    const entries = [
+      contextEntry('a', null),
+      contextEntry('kept1', 'a'),
+      contextEntry('compact1', 'kept1', 'compaction', {
+        firstKeptEntryId: 'kept1',
+      }),
+      contextEntry('kept2', 'compact1'),
+      contextEntry('compact2', 'kept2', 'compaction', {
+        firstKeptEntryId: 'kept2',
+      }),
+      contextEntry('after', 'compact2'),
+    ]
+    expect(
+      buildContextEntries(entries, 'after').map((entry) => entry.id),
+    ).toEqual(['compact2', 'kept2', 'after'])
+  })
+
+  test('passes branch summaries through unchanged', () => {
+    const summary = contextEntry('summary', 'a', 'branch_summary', {
+      summary: 'branch',
+    })
+    const entries = [contextEntry('a', null), summary]
+    expect(buildContextEntries(entries, 'summary')).toEqual(entries)
   })
 })


### PR DESCRIPTION
## Summary

oh-my-pi bundles a `pi-coding-agent` whose `SessionManager` has no `buildContextEntries()`, so the `turn_start` effort-history handler threw and the extension failed to load on that host. The compaction-aware context builder is now ported locally and fed from `getEntries()` / `getLeafId()`, which both hosts provide.

The port was checked against the SDK's implementation across eight entry shapes (leaf resolution, compaction with `firstKeptEntryId`, multiple compactions, `branch_summary` entries) and matches it, so it replaces the SDK call unconditionally rather than branching per host.

One defect in the first shape of this change was caught in review and fixed here: the call site coalesced an *absent* `getLeafId` method into `null`, and `null` is the SDK's explicit "no leaf → empty context" — so the hosts this fix targets would have received an empty effort history. `resolveSessionLeafId()` now keeps the three states distinct: absent method → `undefined` (fall back to the latest entry), explicit `null` → empty, string → that leaf.

Credit: original patch by **randomvariable** (CortexKit Discord, 2026-09-03), who could not open the PR themselves. Reviewed, fixed, tested, and re-authored here with `Co-authored-by`.

## Changes

- `packages/pi/src/effort-history.ts` — `buildContextEntries(entries, leafId?)` (local port, three-state contract documented) and `resolveSessionLeafId(sessionManager)`.
- `packages/pi/src/index.ts` — the `turn_start` handler uses the port with the resolved leaf.
- `packages/pi/src/tests/effort-history.test.ts` — nine new cases: helper passthrough, `null` leaf, `undefined` leaf, root path, compaction mid-path, no compaction, multi-compaction (latest wins), `branch_summary` passthrough.

## Verification

- `packages/pi`: 103 pass / 0 fail (+9) · root typecheck 0 · format/biome clean.
- Red-first: the absent-method test failed while the helper still coalesced to `null`; restoring `?? null` reddens it again.

Base: `upstream/main` `360b68e` (v1.22.0).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/anthropic-auth/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791696027&installation_model_id=22398&pr_number=214&repository=cortexkit%2Fanthropic-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fanthropic-auth%2Fpull%2F214&signature=f0c6e983b1d44d1c0656f44e5f6c3892da9f7c5b8cde5194fd460a13f46dc51b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the effort-history context builder in `packages/pi` so the `turn_start` handler no longer crashes extension load on hosts like `oh-my-pi` that bundle their own `pi-coding-agent` without the SDK-only `buildContextEntries()` method.

- Ports the compaction-aware builder locally and feeds it from `getEntries()` / `getLeafId()`, which both hosts provide; the SDK call is replaced unconditionally.
- Keeps an absent `getLeafId` distinct from an explicit `null` leaf: absent falls back to the latest entry, `null` returns an empty context, and a string selects that leaf — coalescing them previously discarded the entire effort history.
- Adds nine tests covering leaf resolution, `firstKeptEntryId` compaction, multiple compactions, and `branch_summary` passthrough.

<sup>Written for commit 0317d7686ef1ffdcd8b8ec781b14933177234de5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/anthropic-auth/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

