### PR TITLE
fix(opencode): run one RPC server per project directory in a shared process

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -45,9 +45,10 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/cli.ts src/sidebar-state.ts src/tui-preferences.ts src/rpc/rpc-client.ts src/rpc/port-file.ts src/rpc/protocol.ts src/rpc/rpc-dir.ts --outdir dist --target node --format esm --splitting --external @opencode-ai/plugin --minify && tsc -p tsconfig.build.json --emitDeclarationOnly && bun run build:tui",
+    "build": "rm -rf dist && bun build src/index.ts src/cli.ts src/sidebar-state.ts src/tui-preferences.ts src/rpc/rpc-client.ts src/rpc/port-file.ts src/rpc/protocol.ts src/rpc/rpc-dir.ts --outdir dist --target node --format esm --splitting --external @opencode-ai/plugin --minify && tsc -p tsconfig.build.json --emitDeclarationOnly && bun run build:tui && bun run check:bundle",
     "build:tui": "bun scripts/build-tui.ts",
     "smoke:tui": "bun scripts/smoke-tui-pack-install.ts",
+    "check:bundle": "bun scripts/check-bundle-globals.ts",
     "build:dev": "rm -rf dist && tsc -p tsconfig.build.json",
     "dev": "bun ../../scripts/dev.ts",
     "dev:clean": "bun ../../scripts/dev-clean.ts",

--- a/packages/opencode/scripts/check-bundle-globals.ts
+++ b/packages/opencode/scripts/check-bundle-globals.ts
@@ -1,0 +1,35 @@
+import { readFile, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const bundlePath = join(import.meta.dir, '..', 'dist', 'index.js')
+const minBundleBytes = 1024
+
+let size: number
+try {
+  size = (await stat(bundlePath)).size
+} catch {
+  throw new Error(`Bundle artifact check failed: ${bundlePath} is missing`)
+}
+
+if (size <= minBundleBytes) {
+  throw new Error(
+    `Bundle artifact check failed: ${bundlePath} is not substantial (${size} bytes)`,
+  )
+}
+
+const bundle = await readFile(bundlePath, 'utf8')
+const registryMatches = bundle.match(/__anthropicAuthRpcServers/g)?.length ?? 0
+if (registryMatches === 0) {
+  throw new Error(
+    'Bundle positive-control check failed: __anthropicAuthRpcServers is absent',
+  )
+}
+
+// This catches one identifier; the positive control makes its zero assertion meaningful, not proof that no other stale global exists.
+const singularMatches =
+  bundle.match(/__anthropicAuthRpcServer(?!s)/g)?.length ?? 0
+if (singularMatches !== 0) {
+  throw new Error(
+    `Bundle stale-global check failed: __anthropicAuthRpcServer appears ${singularMatches} time(s)`,
+  )
+}

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -2809,7 +2809,6 @@ const anthropicAuthPlugin = async (
   let rpcDir: string | null = null
   if (ctx.directory) {
     const rpcGlobal = globalThis as {
-      __anthropicAuthRpcServer?: RpcServerHandle
       __anthropicAuthRpcServers?: Map<string, RpcServerHandle>
     }
     rpcDir = getRpcDir(ctx.directory)
@@ -2820,9 +2819,6 @@ const anthropicAuthPlugin = async (
     if (previousRpcServer) {
       await previousRpcServer.stop().catch(() => {})
       rpcServers.delete(rpcDir)
-      if (rpcGlobal.__anthropicAuthRpcServer === previousRpcServer) {
-        rpcGlobal.__anthropicAuthRpcServer = undefined
-      }
     }
     try {
       rpcServer = await startRpcServer({
@@ -2831,7 +2827,6 @@ const anthropicAuthPlugin = async (
         apply: applyCommand,
       })
       rpcServers.set(rpcDir, rpcServer)
-      rpcGlobal.__anthropicAuthRpcServer = rpcServer
     } catch (error) {
       logger.warn('rpc', 'failed to start', {
         error: error instanceof Error ? error.message : String(error),

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -181,7 +181,7 @@ import {
   stickyRouteFamilyForModel,
   tokenFingerprint,
 } from '@cortexkit/anthropic-auth-core'
-import type { Plugin } from '@opencode-ai/plugin'
+import type { Hooks, Plugin } from '@opencode-ai/plugin'
 
 import {
   applyCacheDiagnosticsOptIn,
@@ -2806,23 +2806,64 @@ const anthropicAuthPlugin = async (
   }
 
   let rpcServer: RpcServerHandle | null = null
+  let rpcDir: string | null = null
   if (ctx.directory) {
     const rpcGlobal = globalThis as {
       __anthropicAuthRpcServer?: RpcServerHandle
+      __anthropicAuthRpcServers?: Map<string, RpcServerHandle>
     }
-    if (rpcGlobal.__anthropicAuthRpcServer) {
-      await rpcGlobal.__anthropicAuthRpcServer.stop().catch(() => {})
-      rpcGlobal.__anthropicAuthRpcServer = undefined
+    rpcDir = getRpcDir(ctx.directory)
+    const rpcServers =
+      rpcGlobal.__anthropicAuthRpcServers ?? new Map<string, RpcServerHandle>()
+    rpcGlobal.__anthropicAuthRpcServers = rpcServers
+    const previousRpcServer = rpcServers.get(rpcDir)
+    if (previousRpcServer) {
+      await previousRpcServer.stop().catch(() => {})
+      rpcServers.delete(rpcDir)
+      if (rpcGlobal.__anthropicAuthRpcServer === previousRpcServer) {
+        rpcGlobal.__anthropicAuthRpcServer = undefined
+      }
     }
     try {
       rpcServer = await startRpcServer({
-        dir: getRpcDir(ctx.directory),
+        dir: rpcDir,
         drain: drainNotifications,
         apply: applyCommand,
       })
+      rpcServers.set(rpcDir, rpcServer)
       rpcGlobal.__anthropicAuthRpcServer = rpcServer
     } catch (error) {
       logger.warn('rpc', 'failed to start', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+  const dispose: NonNullable<Hooks['dispose']> = async () => {
+    try {
+      await quotaHeaderFeedRegistry?.dispose()
+    } catch (error) {
+      logger.warn('quota-header-feed', 'failed to dispose', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+    try {
+      claustrumCredentialCache?.close()
+    } catch (error) {
+      logger.warn('claustrum', 'failed to close credential cache', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+    const rpcServers = (
+      globalThis as {
+        __anthropicAuthRpcServers?: Map<string, RpcServerHandle>
+      }
+    ).__anthropicAuthRpcServers
+    if (!rpcServer || !rpcDir || rpcServers?.get(rpcDir) !== rpcServer) return
+    try {
+      await rpcServer.stop()
+      if (rpcServers.get(rpcDir) === rpcServer) rpcServers.delete(rpcDir)
+    } catch (error) {
+      logger.warn('rpc', 'failed to stop', {
         error: error instanceof Error ? error.message : String(error),
       })
     }
@@ -7600,10 +7641,6 @@ const anthropicAuthPlugin = async (
 
         return {}
       },
-      dispose: async () => {
-        await quotaHeaderFeedRegistry?.dispose()
-        claustrumCredentialCache?.close()
-      },
       methods: [
         {
           label: 'Claude Pro/Max',
@@ -7664,6 +7701,7 @@ const anthropicAuthPlugin = async (
         },
       ],
     },
+    dispose,
     __primeManager: primeManager,
     __quotaManager: quotaManager,
     __persistFallbackQuotaErrorForTest: persistFallbackQuotaError,

--- a/packages/opencode/src/rpc/notifications.ts
+++ b/packages/opencode/src/rpc/notifications.ts
@@ -1,16 +1,25 @@
+import { logger } from '@cortexkit/anthropic-auth-core'
+
 import type { OpenDialogPayload, RpcNotification } from './protocol'
 
 const QUEUE_CAP = 100
 const TUI_CONNECTED_WINDOW_MS = 3_000
 
+// One queue serves every RPC server in the process, and a process can hold one server per
+// project directory. Session ids are globally unique, so a notice that carries one reaches
+// only the TUI polling for that session. A notice WITHOUT one broadcasts instead: every
+// draining TUI receives it and one session's ack does not prune it for the others — which,
+// once a process serves more than one project, would carry it across project boundaries.
+// The producer boundary therefore requires a session id; the wire field stays optional so
+// an older TUI still parses what it is sent.
 let queue: RpcNotification[] = []
 let nextId = 1
-let lastDrainAtAny = 0
 const lastDrainAtBySession = new Map<string, number>()
+let warnedAboutUnscopedDrain = false
 
 export function pushNotification(
   payload: OpenDialogPayload,
-  sessionId?: string,
+  sessionId: string,
 ): void {
   queue.push({ id: nextId++, type: 'open-dialog', payload, sessionId })
   if (queue.length > QUEUE_CAP) queue = queue.slice(queue.length - QUEUE_CAP)
@@ -21,34 +30,35 @@ export function drainNotifications(
   sessionId?: string,
 ): RpcNotification[] {
   const now = Date.now()
-  lastDrainAtAny = now
   if (sessionId !== undefined) lastDrainAtBySession.set(sessionId, now)
   const matches = (n: RpcNotification) =>
-    sessionId === undefined ||
-    n.sessionId === undefined ||
-    n.sessionId === sessionId
+    sessionId === undefined || n.sessionId === sessionId
+  if (sessionId === undefined && !warnedAboutUnscopedDrain) {
+    warnedAboutUnscopedDrain = true
+    logger.warn(
+      'rpc.notifications',
+      'drain arrived without a session id; delivery is unscoped and the queue is left intact',
+    )
+  }
   if (lastReceivedId > 0) {
     queue = queue.filter((n) => {
       if (n.id > lastReceivedId) return true
-      if (sessionId === undefined) return false
+      if (sessionId === undefined) return true
       return n.sessionId !== sessionId
     })
   }
   return queue.filter((n) => n.id > lastReceivedId && matches(n))
 }
 
-export function isTuiConnected(sessionId?: string): boolean {
+export function isTuiConnected(sessionId: string): boolean {
   const now = Date.now()
-  if (sessionId !== undefined) {
-    const at = lastDrainAtBySession.get(sessionId) ?? 0
-    return at > 0 && now - at < TUI_CONNECTED_WINDOW_MS
-  }
-  return lastDrainAtAny > 0 && now - lastDrainAtAny < TUI_CONNECTED_WINDOW_MS
+  const at = lastDrainAtBySession.get(sessionId) ?? 0
+  return at > 0 && now - at < TUI_CONNECTED_WINDOW_MS
 }
 
 export function resetNotificationsForTest(): void {
   queue = []
   nextId = 1
-  lastDrainAtAny = 0
   lastDrainAtBySession.clear()
+  warnedAboutUnscopedDrain = false
 }

--- a/packages/opencode/src/rpc/rpc-server.ts
+++ b/packages/opencode/src/rpc/rpc-server.ts
@@ -1,5 +1,5 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
-import { unlink } from 'node:fs/promises'
+import { readFile, unlink } from 'node:fs/promises'
 import {
   createServer,
   type IncomingMessage,
@@ -115,9 +115,16 @@ export async function startRpcServer(
     token,
     async stop() {
       await new Promise<void>((resolve) => server.close(() => resolve()))
-      await unlink(join(options.dir, `port-${process.pid}.json`)).catch(
-        () => {},
-      )
+      try {
+        const portFile = join(options.dir, `port-${process.pid}.json`)
+        const current = JSON.parse(await readFile(portFile, 'utf8')) as {
+          port?: unknown
+          pid?: unknown
+        }
+        if (current.port === port && current.pid === process.pid) {
+          await unlink(portFile)
+        }
+      } catch {}
     },
   }
 }

--- a/packages/opencode/src/tests/rpc-multi-project.test.ts
+++ b/packages/opencode/src/tests/rpc-multi-project.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createEmptyStorage,
+  QuotaHeaderFeedRegistry,
+  saveAccounts,
+} from '@cortexkit/anthropic-auth-core'
+import type { Hooks } from '@opencode-ai/plugin'
+import { AnthropicAuthPlugin } from '../index'
+import { resetNotificationsForTest } from '../rpc/notifications'
+import { discoverPortFile } from '../rpc/port-file'
+import { getRpcDir } from '../rpc/rpc-dir'
+import type { RpcServerHandle } from '../rpc/rpc-server'
+
+type RpcGlobal = typeof globalThis & {
+  __anthropicAuthRpcServer?: RpcServerHandle
+  __anthropicAuthRpcServers?: Map<string, RpcServerHandle>
+}
+
+let testRoot: string
+let previousRpcDir: string | undefined
+let previousAccountFile: string | undefined
+let previousSidebarStateFile: string | undefined
+let previousCacheKeepRegistryDir: string | undefined
+let previousQuotaFeedDir: string | undefined
+
+const disabledPluginRuntimeOverrides = {
+  setInterval: mock(
+    () => ({ unref() {} }) as unknown as ReturnType<typeof setInterval>,
+  ) as unknown as typeof setInterval,
+  clearInterval: mock(() => {}) as unknown as typeof clearInterval,
+}
+
+function createMockClient(applyMarker?: string) {
+  return {
+    auth: { set: mock(() => Promise.resolve()) },
+    session: {
+      promptAsync: mock(() =>
+        applyMarker
+          ? Promise.reject(new Error(applyMarker))
+          : Promise.resolve(),
+      ),
+    },
+  }
+}
+
+async function getPlugin(
+  directory: string,
+  applyMarker?: string,
+): Promise<Hooks> {
+  const plugin = AnthropicAuthPlugin as unknown as (
+    ctx: Parameters<typeof AnthropicAuthPlugin>[0],
+    runtimeOverrides: typeof disabledPluginRuntimeOverrides,
+  ) => ReturnType<typeof AnthropicAuthPlugin>
+  return plugin(
+    {
+      // @ts-expect-error: minimal mock for testing
+      client: createMockClient(applyMarker),
+      directory,
+    },
+    disabledPluginRuntimeOverrides,
+  )
+}
+
+async function applyViaRpc(
+  entry: { port: number; token: string },
+  sessionId: string,
+) {
+  const response = await fetch(`http://127.0.0.1:${entry.port}/rpc/apply`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${entry.token}`,
+    },
+    body: JSON.stringify({
+      command: 'claude-start',
+      arguments: '',
+      sessionId,
+    }),
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as { text: string }
+}
+
+async function stopRpcServers() {
+  const rpcGlobal = globalThis as RpcGlobal
+  const servers = rpcGlobal.__anthropicAuthRpcServers
+  const handles = new Set<RpcServerHandle>([
+    ...(servers?.values() ?? []),
+    ...(rpcGlobal.__anthropicAuthRpcServer
+      ? [rpcGlobal.__anthropicAuthRpcServer]
+      : []),
+  ])
+  await Promise.all([...handles].map((server) => server.stop()))
+  if (servers) {
+    servers.clear()
+    rpcGlobal.__anthropicAuthRpcServers = undefined
+  }
+  rpcGlobal.__anthropicAuthRpcServer = undefined
+}
+
+beforeEach(async () => {
+  testRoot = await mkdtemp(join(tmpdir(), 'aa-rpc-multi-project-'))
+  previousRpcDir = process.env.OPENCODE_ANTHROPIC_AUTH_RPC_DIR
+  previousAccountFile = process.env.OPENCODE_ANTHROPIC_AUTH_FILE
+  previousSidebarStateFile =
+    process.env.OPENCODE_ANTHROPIC_AUTH_SIDEBAR_STATE_FILE
+  previousCacheKeepRegistryDir =
+    process.env.OPENCODE_ANTHROPIC_AUTH_CACHEKEEP_REGISTRY_DIR
+  previousQuotaFeedDir = process.env.OPENCODE_ANTHROPIC_AUTH_QUOTA_FEED_DIR
+  process.env.OPENCODE_ANTHROPIC_AUTH_RPC_DIR = '.rpc'
+  process.env.OPENCODE_ANTHROPIC_AUTH_FILE = join(
+    testRoot,
+    'anthropic-auth.json',
+  )
+  process.env.OPENCODE_ANTHROPIC_AUTH_SIDEBAR_STATE_FILE = join(
+    testRoot,
+    'sidebar-state.json',
+  )
+  process.env.OPENCODE_ANTHROPIC_AUTH_CACHEKEEP_REGISTRY_DIR = join(
+    testRoot,
+    'cachekeep-registry',
+  )
+  process.env.OPENCODE_ANTHROPIC_AUTH_QUOTA_FEED_DIR = join(
+    testRoot,
+    'quota-header-feed',
+  )
+  await stopRpcServers()
+})
+
+afterEach(async () => {
+  await stopRpcServers()
+  if (previousRpcDir === undefined) {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_RPC_DIR
+  } else {
+    process.env.OPENCODE_ANTHROPIC_AUTH_RPC_DIR = previousRpcDir
+  }
+  if (previousAccountFile === undefined) {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_FILE
+  } else {
+    process.env.OPENCODE_ANTHROPIC_AUTH_FILE = previousAccountFile
+  }
+  if (previousSidebarStateFile === undefined) {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_SIDEBAR_STATE_FILE
+  } else {
+    process.env.OPENCODE_ANTHROPIC_AUTH_SIDEBAR_STATE_FILE =
+      previousSidebarStateFile
+  }
+  if (previousCacheKeepRegistryDir === undefined) {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_CACHEKEEP_REGISTRY_DIR
+  } else {
+    process.env.OPENCODE_ANTHROPIC_AUTH_CACHEKEEP_REGISTRY_DIR =
+      previousCacheKeepRegistryDir
+  }
+  if (previousQuotaFeedDir === undefined) {
+    delete process.env.OPENCODE_ANTHROPIC_AUTH_QUOTA_FEED_DIR
+  } else {
+    process.env.OPENCODE_ANTHROPIC_AUTH_QUOTA_FEED_DIR = previousQuotaFeedDir
+  }
+  await rm(testRoot, { recursive: true, force: true })
+  resetNotificationsForTest()
+})
+
+describe('RPC server lifecycle', () => {
+  test('dispose stops and removes its server when feed cleanup rejects', async () => {
+    await saveAccounts({
+      ...createEmptyStorage(),
+      quotaHeaderFeed: { enabled: true },
+    })
+    const originalDispose = QuotaHeaderFeedRegistry.prototype.dispose
+    QuotaHeaderFeedRegistry.prototype.dispose = async () => {
+      throw new Error('feed disposal failed')
+    }
+    try {
+      const directory = join(testRoot, 'project')
+      const plugin = await getPlugin(directory)
+      const rpcDir = getRpcDir(directory)
+      const entry = await discoverPortFile(rpcDir)
+
+      expect(entry).not.toBeNull()
+      await plugin.dispose?.()
+
+      expect(await discoverPortFile(rpcDir)).toBeNull()
+      expect(
+        (globalThis as RpcGlobal).__anthropicAuthRpcServers?.get(rpcDir),
+      ).toBeUndefined()
+      await expect(
+        fetch(`http://127.0.0.1:${entry?.port}/health`),
+      ).rejects.toThrow()
+    } finally {
+      QuotaHeaderFeedRegistry.prototype.dispose = originalDispose
+    }
+  })
+
+  test('keeps RPC servers live for distinct project directories', async () => {
+    const directoryA = join(testRoot, 'project-a')
+    const directoryB = join(testRoot, 'project-b')
+
+    await getPlugin(directoryA)
+    await getPlugin(directoryB)
+
+    const entryA = await discoverPortFile(getRpcDir(directoryA))
+    const entryB = await discoverPortFile(getRpcDir(directoryB))
+
+    expect(entryA).not.toBeNull()
+    expect(entryB).not.toBeNull()
+    expect(entryA?.port).not.toBe(entryB?.port)
+  })
+
+  test('each project RPC server applies through its own plugin instance', async () => {
+    const directoryA = join(testRoot, 'project-a')
+    const directoryB = join(testRoot, 'project-b')
+    await getPlugin(directoryA, 'applied by project-a')
+    await getPlugin(directoryB, 'applied by project-b')
+
+    const entryA = await discoverPortFile(getRpcDir(directoryA))
+    const entryB = await discoverPortFile(getRpcDir(directoryB))
+
+    expect(entryA).not.toBeNull()
+    expect(entryB).not.toBeNull()
+    if (!entryA || !entryB) return
+    expect(
+      JSON.parse(
+        await readFile(
+          join(getRpcDir(directoryA), `port-${process.pid}.json`),
+          'utf8',
+        ),
+      ),
+    ).toMatchObject({ port: entryA.port, token: entryA.token })
+    expect(
+      JSON.parse(
+        await readFile(
+          join(getRpcDir(directoryB), `port-${process.pid}.json`),
+          'utf8',
+        ),
+      ),
+    ).toMatchObject({ port: entryB.port, token: entryB.token })
+
+    expect((await applyViaRpc(entryA, 'session-a')).text).toContain(
+      'applied by project-a',
+    )
+    expect((await applyViaRpc(entryB, 'session-b')).text).toContain(
+      'applied by project-b',
+    )
+  })
+
+  test('dispose stops its directory while another project remains live', async () => {
+    const directoryA = join(testRoot, 'project-a')
+    const directoryB = join(testRoot, 'project-b')
+    const pluginA = await getPlugin(directoryA)
+    const pluginB = await getPlugin(directoryB)
+    const entryB = await discoverPortFile(getRpcDir(directoryB))
+
+    expect(entryB).not.toBeNull()
+    expect(pluginA.dispose).toBeFunction()
+    await pluginA.dispose?.()
+
+    expect(await discoverPortFile(getRpcDir(directoryA))).toBeNull()
+    expect((await discoverPortFile(getRpcDir(directoryB)))?.port).toBe(
+      entryB?.port,
+    )
+    expect(
+      (await fetch(`http://127.0.0.1:${entryB?.port}/health`)).status,
+    ).toBe(200)
+    await pluginB.dispose?.()
+  })
+
+  test('late disposal cannot remove a same-directory successor port file', async () => {
+    const directory = join(testRoot, 'project')
+    const first = await getPlugin(directory)
+    const second = await getPlugin(directory)
+    const successor = await discoverPortFile(getRpcDir(directory))
+    const successorHandle = (
+      globalThis as RpcGlobal
+    ).__anthropicAuthRpcServers?.get(getRpcDir(directory))
+
+    expect(successor).not.toBeNull()
+    expect(successorHandle).toBeDefined()
+    await first.dispose?.()
+
+    expect(
+      (globalThis as RpcGlobal).__anthropicAuthRpcServers?.get(
+        getRpcDir(directory),
+      ),
+    ).toBe(successorHandle)
+    expect((await discoverPortFile(getRpcDir(directory)))?.port).toBe(
+      successor?.port,
+    )
+    await second.dispose?.()
+  })
+
+  test('a dispose whose entry was replaced does not stop the successor server', async () => {
+    const directory = join(testRoot, 'project')
+    const first = await getPlugin(directory)
+    const rpcGlobal = globalThis as RpcGlobal
+    const rpcDir = getRpcDir(directory)
+    const firstHandle = rpcGlobal.__anthropicAuthRpcServers?.get(rpcDir)
+    const successorHandle: RpcServerHandle = {
+      port: firstHandle?.port ?? 0,
+      token: firstHandle?.token ?? '',
+      stop: mock(async () => {}),
+    }
+
+    expect(firstHandle).toBeDefined()
+    if (!firstHandle) return
+    const stopSpy = mock(firstHandle.stop)
+    firstHandle.stop = stopSpy
+    rpcGlobal.__anthropicAuthRpcServers?.set(rpcDir, successorHandle)
+
+    await first.dispose?.()
+
+    // D2's port-file check would otherwise mask loss of D1.
+    expect(stopSpy).not.toHaveBeenCalled()
+    expect(rpcGlobal.__anthropicAuthRpcServers?.get(rpcDir)).toBe(
+      successorHandle,
+    )
+  })
+
+  test('a disposed project can start a discoverable RPC server again', async () => {
+    const directory = join(testRoot, 'project')
+    const first = await getPlugin(directory)
+
+    await first.dispose?.()
+
+    const replacement = await getPlugin(directory)
+    const entry = await discoverPortFile(getRpcDir(directory))
+    expect(entry).not.toBeNull()
+    expect((await fetch(`http://127.0.0.1:${entry?.port}/health`)).status).toBe(
+      200,
+    )
+    await replacement.dispose?.()
+  })
+})

--- a/packages/opencode/src/tests/rpc-multi-project.test.ts
+++ b/packages/opencode/src/tests/rpc-multi-project.test.ts
@@ -15,7 +15,6 @@ import { getRpcDir } from '../rpc/rpc-dir'
 import type { RpcServerHandle } from '../rpc/rpc-server'
 
 type RpcGlobal = typeof globalThis & {
-  __anthropicAuthRpcServer?: RpcServerHandle
   __anthropicAuthRpcServers?: Map<string, RpcServerHandle>
 }
 
@@ -25,6 +24,7 @@ let previousAccountFile: string | undefined
 let previousSidebarStateFile: string | undefined
 let previousCacheKeepRegistryDir: string | undefined
 let previousQuotaFeedDir: string | undefined
+let startedRpcDirs: Set<string>
 
 const disabledPluginRuntimeOverrides = {
   setInterval: mock(
@@ -54,6 +54,7 @@ async function getPlugin(
     ctx: Parameters<typeof AnthropicAuthPlugin>[0],
     runtimeOverrides: typeof disabledPluginRuntimeOverrides,
   ) => ReturnType<typeof AnthropicAuthPlugin>
+  startedRpcDirs.add(getRpcDir(directory))
   return plugin(
     {
       // @ts-expect-error: minimal mock for testing
@@ -87,22 +88,17 @@ async function applyViaRpc(
 async function stopRpcServers() {
   const rpcGlobal = globalThis as RpcGlobal
   const servers = rpcGlobal.__anthropicAuthRpcServers
-  const handles = new Set<RpcServerHandle>([
-    ...(servers?.values() ?? []),
-    ...(rpcGlobal.__anthropicAuthRpcServer
-      ? [rpcGlobal.__anthropicAuthRpcServer]
-      : []),
-  ])
+  const handles = new Set<RpcServerHandle>(servers?.values() ?? [])
   await Promise.all([...handles].map((server) => server.stop()))
   if (servers) {
     servers.clear()
     rpcGlobal.__anthropicAuthRpcServers = undefined
   }
-  rpcGlobal.__anthropicAuthRpcServer = undefined
 }
 
 beforeEach(async () => {
   testRoot = await mkdtemp(join(tmpdir(), 'aa-rpc-multi-project-'))
+  startedRpcDirs = new Set()
   previousRpcDir = process.env.OPENCODE_ANTHROPIC_AUTH_RPC_DIR
   previousAccountFile = process.env.OPENCODE_ANTHROPIC_AUTH_FILE
   previousSidebarStateFile =
@@ -132,6 +128,12 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await stopRpcServers()
+  for (const rpcDir of startedRpcDirs) {
+    expect(
+      (globalThis as RpcGlobal).__anthropicAuthRpcServers?.get(rpcDir),
+    ).toBeUndefined()
+    expect(await discoverPortFile(rpcDir)).toBeNull()
+  }
   if (previousRpcDir === undefined) {
     delete process.env.OPENCODE_ANTHROPIC_AUTH_RPC_DIR
   } else {
@@ -316,6 +318,9 @@ describe('RPC server lifecycle', () => {
     expect(rpcGlobal.__anthropicAuthRpcServers?.get(rpcDir)).toBe(
       successorHandle,
     )
+    // Dispose refused to stop D1 by design; the spy wraps the real stop, so
+    // invoking it clears the dangling server and its port file before afterEach.
+    await stopSpy()
   })
 
   test('a disposed project can start a discoverable RPC server again', async () => {

--- a/packages/opencode/src/tests/rpc-notifications.test.ts
+++ b/packages/opencode/src/tests/rpc-notifications.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 import {
+  __setLogTestSink,
+  type LogTestRecord,
+} from '@cortexkit/anthropic-auth-core'
+import {
   drainNotifications,
   isTuiConnected,
   pushNotification,
@@ -16,6 +20,78 @@ const payload = (command: OpenDialogPayload['command']): OpenDialogPayload => ({
 describe('notifications', () => {
   beforeEach(() => resetNotificationsForTest())
 
+  test('warns once when an unscoped drain leaves the queue intact', () => {
+    const records: LogTestRecord[] = []
+    __setLogTestSink((record) => records.push(record))
+    try {
+      drainNotifications(0)
+      drainNotifications(0)
+      expect(
+        records.filter(
+          (record) =>
+            record.level === 'warn' &&
+            record.message.includes('drain arrived without a session id'),
+        ),
+      ).toHaveLength(1)
+    } finally {
+      __setLogTestSink(null)
+    }
+  })
+
+  test('an unscoped drain delivers every pending notice', () => {
+    pushNotification(payload('claude-quota'), 's1')
+    pushNotification(payload('claude-dump'), 's2')
+
+    expect(
+      drainNotifications(0, undefined).map((n) => n.payload.command),
+    ).toEqual(['claude-quota', 'claude-dump'])
+  })
+
+  test('an unscoped drain acknowledges without pruning other sessions', () => {
+    pushNotification(payload('claude-quota'), 's1')
+    pushNotification(payload('claude-dump'), 's2')
+
+    // Acknowledged notices are not re-delivered to the client that acked them,
+    // and an unscoped ack must not speak for the sessions it does not name.
+    expect(drainNotifications(2, undefined)).toEqual([])
+    expect(drainNotifications(0, 's2').map((n) => n.payload.command)).toEqual([
+      'claude-dump',
+    ])
+    expect(drainNotifications(0, 's1').map((n) => n.payload.command)).toEqual([
+      'claude-quota',
+    ])
+  })
+
+  test('reset re-arms the unscoped-drain warning after an earlier drain', () => {
+    const records: LogTestRecord[] = []
+    __setLogTestSink((record) => records.push(record))
+    try {
+      drainNotifications(0)
+      resetNotificationsForTest()
+      drainNotifications(0)
+      expect(
+        records.filter(
+          (record) =>
+            record.level === 'warn' &&
+            record.message.includes('drain arrived without a session id'),
+        ),
+      ).toHaveLength(2)
+    } finally {
+      __setLogTestSink(null)
+    }
+  })
+
+  test('a session-scoped drain prunes its own acknowledged notices', () => {
+    pushNotification(payload('claude-quota'), 's1')
+    pushNotification(payload('claude-dump'), 's2')
+
+    const s1 = drainNotifications(0, 's1')
+    expect(drainNotifications(s1[0]?.id, 's1')).toEqual([])
+    expect(drainNotifications(0, 's2').map((n) => n.payload.command)).toEqual([
+      'claude-dump',
+    ])
+  })
+
   test('push then drain returns the item once, ordered', () => {
     pushNotification(payload('claude-quota'), 's1')
     pushNotification(payload('claude-fast'), 's1')
@@ -29,12 +105,14 @@ describe('notifications', () => {
     expect(second).toEqual([])
   })
 
-  test('session scoping: a session only drains its own + global', () => {
+  test('every queued notice carries its session id and stays scoped to it', () => {
     pushNotification(payload('claude-quota'), 's1')
     pushNotification(payload('claude-dump'), 's2')
-    expect(drainNotifications(0, 's1').map((n) => n.payload.command)).toEqual([
-      'claude-quota',
-    ])
+    const s1 = drainNotifications(0, 's1')
+
+    expect(s1).toHaveLength(1)
+    expect(s1[0]?.sessionId).toBe('s1')
+    expect(s1.map((n) => n.payload.command)).toEqual(['claude-quota'])
     expect(drainNotifications(0, 's2').map((n) => n.payload.command)).toEqual([
       'claude-dump',
     ])
@@ -46,6 +124,14 @@ describe('notifications', () => {
     expect(isTuiConnected('s1')).toBe(true)
   })
 
+  test('a drain only marks its own session as connected', () => {
+    drainNotifications(0, 's2')
+    expect(isTuiConnected('s1')).toBe(false)
+    expect(isTuiConnected('s2')).toBe(true)
+    // @ts-expect-error isTuiConnected requires a session id
+    expect(isTuiConnected()).toBe(false)
+  })
+
   test('queue cap evicts oldest beyond 100', () => {
     for (let i = 0; i < 130; i++)
       pushNotification(payload('claude-quota'), 's1')
@@ -53,15 +139,8 @@ describe('notifications', () => {
     expect(all.length).toBe(100)
   })
 
-  test('a global notification reaches every session and is not pruned by one ack', () => {
-    // push a global (no sessionId) notification
+  test('pushNotification requires a session id at compile time', () => {
+    // @ts-expect-error pushNotification requires a session id
     pushNotification(payload('claude-quota'))
-    const a = drainNotifications(0, 's1')
-    expect(a.length).toBe(1)
-    // s1 acks it
-    drainNotifications(a[0]?.id as number, 's1')
-    // s2 must STILL receive it
-    const b = drainNotifications(0, 's2')
-    expect(b.length).toBe(1)
   })
 })

--- a/packages/opencode/src/tests/rpc-server.test.ts
+++ b/packages/opencode/src/tests/rpc-server.test.ts
@@ -7,6 +7,7 @@ import {
   pushNotification,
   resetNotificationsForTest,
 } from '../rpc/notifications'
+import { discoverPortFile } from '../rpc/port-file'
 import { startRpcServer } from '../rpc/rpc-server'
 
 let stop: (() => Promise<void>) | null = null
@@ -173,5 +174,27 @@ describe('rpc-server', () => {
     await new Promise((r) => setTimeout(r, 50))
     process.removeListener('uncaughtException', onUnhandled)
     expect(unhandledError).toBeNull()
+  })
+
+  test('stopping a stale server preserves its successor port file', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'aa-rpcsrv-'))
+    const first = await startRpcServer({
+      dir,
+      drain: drainNotifications,
+      apply: async () => ({ text: 'ok', knobs: {} }),
+    })
+    const second = await startRpcServer({
+      dir,
+      drain: drainNotifications,
+      apply: async () => ({ text: 'ok', knobs: {} }),
+    })
+    stop = second.stop
+
+    await first.stop()
+
+    expect((await discoverPortFile(dir))?.port).toBe(second.port)
+    expect((await fetch(`http://127.0.0.1:${second.port}/health`)).status).toBe(
+      200,
+    )
   })
 })


### PR DESCRIPTION
## Symptom

In some sessions the `/claude-*` commands stop opening their modal. No error, no log line — the command is accepted and nothing appears. A restart fixes that session until it happens again.

## Mechanism

The plugin kept one RPC server handle per **process** on `globalThis.__anthropicAuthRpcServer`. Each instantiation stopped the existing handle before starting its own, and `stop()` unlinks `port-<pid>.json` from the directory that handle was started with (`rpc/rpc-server.ts`). The directory is `sha256(ctx.directory)` — the project the instance belongs to (`rpc/rpc-dir.ts`).

So as soon as one opencode process instantiated the plugin for a second project directory, the first project's port file was deleted and its server stopped. That project's TUI resolves its own `getRpcDir(...)`, finds no port file, and has nothing to poll — the modal never opens again for the life of the process.

Observed on a machine running eight sessions: seven had `port-<pid>.json` under `sha256(cwd)` and worked; the eighth, with cwd `~/projects/brandon`, had no port file under its own hash and its `port-<pid>.json` sat under `sha256(~/projects/homelab)`, written 21 hours after that session started.

One process legitimately holds several project directories: request routing accepts `?directory=` / `x-opencode-directory` (`workspace-routing.ts:86-88`), the SDK sends that header (`sdk/js/src/client.ts:46-50`), and the plugin factory is scoped per directory (`plugin/index.ts:134-179`) — opencode `339536bc`, 1.18.25.

## Changes

**One RPC server per project directory.** `globalThis.__anthropicAuthRpcServers: Map<rpcDir, RpcServerHandle>`. Re-instantiating the same directory stops and replaces as before; a different directory starts an additional server and leaves the others alone. Each server keeps its creating instance's `applyCommand` closure, so a modal request arriving on project B's server is applied by project B's plugin.

**Teardown, so the map cannot grow without bound.** `Hooks.dispose` — declared in the package this repo builds against (`@opencode-ai/plugin` 1.18.21, `dist/index.d.ts:173-178`) and invoked by opencode's instance finalizer (`plugin/index.ts:265-278`; disposers also run on ordinary dispose and per-project reload, `project/instance-store.ts:94-105`, `:126-145`). Teardown acts **only when the registry entry is still its own handle**. That condition is correctness, not hygiene: `port-<pid>.json` is the same filename for every server a process starts in one directory, so a dispose arriving after a same-directory replace would otherwise unlink the live successor's port file and put that project back in the dark.

**`stop()` unlinks only its own file**, matching the recorded port and pid — a stale handle cannot remove a successor's port file even if a future path forgets the guard.

**Session-scoped notification state.** The notification module is shared by every server in the process, so anything in it that is not keyed by session is keyed by nothing:

- `pushNotification` now **requires** a session id. A notice without one broadcasts to every draining TUI and survives one session's ack, which across several servers means crossing project boundaries. (The wire field stays optional so an older TUI still parses what it is sent.)
- `isTuiConnected` now **requires** a session id, and the process-wide `lastDrainAtAny` timestamp it fell back on is deleted. That timestamp was written by every project's drain, so an unscoped call could report a TUI connected for project A because project B's TUI polled — and the caller (`index.ts:3334`) skips the desktop fallback when it believes a TUI is present, so the notice would go nowhere. Both call sites already passed an id; this removes the possibility rather than relying on it.
- **An unscoped drain no longer deletes other sessions' notices.** `drainNotifications(id, undefined)` pruned every acknowledged notice regardless of owner, so one client both swallowed and destroyed other sessions' pending dialogs. This predates the registry — with a single server it was cross-session inside one project; the registry widens it to cross-project. Fixed as deliver-but-never-prune. On reachability, stated precisely: the TUI has sent the session id since polling was introduced (`e2e0f4c`, and `git log -S".pending("` returns only that commit), so no released TUI build produces an unscoped drain; what can is a malformed or third-party client on the loopback RPC (`rpc-server.ts:77-79` coerces a non-string `sessionId` to `undefined`) plus any future caller. The fix costs one line and cannot break a working client; rejecting unscoped drains costs the same and fails by silently not delivering, which is the symptom this PR exists to fix.

**The old single-handle global is deleted, not merely superseded.** `__anthropicAuthRpcServer` was still declared, assigned on every start, and conditionally cleared alongside the new registry. Production never *read* it — the `===` was a clear-if-mine, not a lookup — so nothing routed off it, but every instance overwrote it, `dispose` never cleared it, and after teardown it held a dangling reference to a stopped server for the life of the process. Its only remaining readers were in a test helper, so a test's behaviour depended on state production writes and never reads. Removing it is this PR's own claim carried through: a registry that *replaces* the single global should not ship a vestigial twin of it.

**A post-build gate for that class** (`scripts/check-bundle-globals.ts`, last step of `bun run build`, also `bun run check:bundle`). A source grep cannot see a call site in a file nobody opened; the bundle contains everything that ships. Three ordered assertions, each with its own message: the artifact exists and is non-trivial → the positive control `__anthropicAuthRpcServers` matches at least once → only then the old identifier's count is 0. The order matters, and the positive control is what makes the zero assertion mean anything: without it the gate passes on a missing or wrongly-built bundle by matching nothing.

## Verification

- `rpc-multi-project.test.ts`: two directories in one process both discover live port files on different ports (red before the registry — `entryA` null); dispose stops its own directory's server while a second stays discoverable; the late-dispose ordering case — start A, replace with B for the same directory, dispose A, B's port file must survive and B must still answer (the naive teardown returned `undefined`); and a test pinning the dispose identity guard on its own behaviour.
- The two defences were mutated **independently**, because they protect the same observable and would otherwise mask each other: removing the identity guard alone reddens only the dispose-behaviour test (`stop` called once) while the port-file test stays green; removing the port/pid match alone reddens only `rpc-server.test.ts`'s stale-server test. A test that fails only when both are reverted proves the pair, not the layer.
- `rpc-notifications.test.ts`: an unscoped drain delivers everything above the ack cursor, returns nothing at or below it, and prunes nothing; a drain by one session does not make another report connected (red on the old code). `@ts-expect-error` pins fail to compile if either session id becomes optional again — each proven non-vacuous by restoring the optional parameter and watching typecheck fail on the unused directive.
- A unit test cannot prove opencode calls `dispose`; what is pinned is that the hooks object exposes it, type-checked against the SDK's `Hooks`. The invocation is cited above.
- **Cleanup is now asserted per directory**: for each directory the file started a server in, the registry entry is gone and its `port-<pid>.json` is absent. Previously nothing verified teardown at all — neutering the cleanup helper left the file green. It now reddens 3 of 7 (`expect(received).toBeUndefined()` against a live handle). Not an aggregate `size === 0`: that depends on every other test in the process and on which dispose ran first.
- That assertion found a pre-existing leak on its first run. `a dispose whose entry was replaced does not stop the successor server` swaps the registry entry for a no-op mock, correctly asserts the dispose is a no-op, and then exited without stopping the real server — leaving its port file on disk. Fixed in place.
- **The bundle gate was proven to fail** before being trusted: absent bundle, 1-byte bundle, a bundle without the positive control, and a bundle containing the stale identifier each trip their own assertion with a distinct message; the real bundle exits 0 silently. A check that has never failed is unproven.
- opencode 1567 pass / 0 fail · core 169 / 0 · typecheck 0 · format and biome clean.

## Not included

**Stale RPC directories are never collected.** The base accumulates one hash directory per project ever seen, some holding port files from months back. A sweep at server start (unlink dead-pid port files, remove the directories they leave empty, skip any directory a live registry entry owns, and leave alone one whose server is mid-start) is a separate change.

**Config mirrored into module-global state.** A sweep of every module-scope binding in both packages found the rest correctly scoped — write chains serialise access to machine-global files, the notification queue is keyed by session — with one class of exception worth recording as a precondition rather than a defect: `dumpEnabled`, `fastModeEnabled`, `cache1hEnabled`/`cache1hMode`, the logger level and the dump counters are process-global mirrors of sidecar config written by each plugin instance at boot. Two projects in one process share one set of these. That is correct only because the sidecar path is process-wide (`$HOME` / `OPENCODE_CONFIG_DIR` / `OPENCODE_ANTHROPIC_AUTH_FILE` are all process-scope env), so every instance reads the same file. If the plugin ever gains a per-project config path, all of them become cross-project bugs simultaneously and silently.

The sibling `openai-auth` plugin carries the same single-handle pattern (`src/index.ts:1907-1940` at v0.7.1) and the same live symptom on the same session; its maintainer confirmed the diagnosis from their own source and filesystem and has a matching fix in `cortexkit/openai-auth#145`, including two further instances of the class that this codebase does not have.

Base: `main` `360b68e` (v1.22.0).
